### PR TITLE
ci(k8s): add Kubernetes manifest diff for PRs

### DIFF
--- a/.github/actions/kubernetes-diff/action.yaml
+++ b/.github/actions/kubernetes-diff/action.yaml
@@ -1,0 +1,197 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+name: Kubernetes Manifest Diff
+description: Compare rendered Kubernetes manifests between two Git refs
+inputs:
+  base_ref:
+    description: Base Git ref to compare against
+    required: false
+    default: main
+  head_ref:
+    description: Head Git ref to compare
+    required: false
+    default: HEAD
+outputs:
+  diff_text:
+    description: Full diff output from dyff
+    value: ${{ steps.diff.outputs.diff_text }}
+  summary_text:
+    description: Summary of changes
+    value: ${{ steps.diff.outputs.summary_text }}
+  has_changes:
+    description: Whether any changes were detected
+    value: ${{ steps.diff.outputs.has_changes }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install dependencies
+      shell: bash
+      run: |
+        set -euo pipefail
+        brew install go-task kustomize helm yq dyff
+        brew tap fluxcd/tap
+        brew install fluxcd/tap/flux
+
+    - name: Render base ref manifests
+      shell: bash
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+
+        # Extract base ref files to temp directory (worktree-safe)
+        TEMP_BASE=$(mktemp -d)
+        cleanup_base() { rm -rf "$TEMP_BASE" 2>/dev/null || true; }
+        trap cleanup_base EXIT
+        mkdir -p "$TEMP_BASE/kubernetes"
+        git archive ${{ inputs.base_ref }} kubernetes | tar -x -C "$TEMP_BASE"
+
+        mkdir -p .rendered/base
+        for cluster in "$TEMP_BASE"/kubernetes/clusters/*; do
+          if [ -d "$cluster" ]; then
+            cluster_name=$(basename "$cluster")
+            mkdir -p ".rendered/base/$cluster_name"
+            if [ -f "$cluster/kustomization.yaml" ]; then
+              if ! kustomize build "$cluster" > ".rendered/base/$cluster_name/kustomize.yaml" 2> ".rendered/base/$cluster_name/errors.log"; then
+                echo "ERROR: Failed to render $cluster_name in base ref" >&2
+                cat ".rendered/base/$cluster_name/errors.log" >&2
+                exit 1
+              fi
+            else
+              echo "Cluster $cluster_name has no kustomization.yaml in base ref" > ".rendered/base/$cluster_name/errors.log"
+            fi
+          fi
+        done
+
+    - name: Render head ref manifests
+      shell: bash
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+
+        # Extract head ref files to temp directory (worktree-safe)
+        TEMP_HEAD=$(mktemp -d)
+        cleanup_head() { rm -rf "$TEMP_HEAD" 2>/dev/null || true; }
+        trap cleanup_head EXIT
+        mkdir -p "$TEMP_HEAD/kubernetes"
+        git archive ${{ inputs.head_ref }} kubernetes | tar -x -C "$TEMP_HEAD"
+
+        mkdir -p .rendered/head
+        for cluster in "$TEMP_HEAD"/kubernetes/clusters/*; do
+          if [ -d "$cluster" ]; then
+            cluster_name=$(basename "$cluster")
+            mkdir -p ".rendered/head/$cluster_name"
+            if [ -f "$cluster/kustomization.yaml" ]; then
+              if ! kustomize build "$cluster" > ".rendered/head/$cluster_name/kustomize.yaml" 2> ".rendered/head/$cluster_name/errors.log"; then
+                echo "ERROR: Failed to render $cluster_name in head ref" >&2
+                cat ".rendered/head/$cluster_name/errors.log" >&2
+                exit 1
+              fi
+            else
+              echo "Cluster $cluster_name has no kustomization.yaml in head ref" > ".rendered/head/$cluster_name/errors.log"
+            fi
+          fi
+        done
+
+    - name: Run diff
+      id: diff
+      shell: bash
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+
+        diff_output=""
+        has_changes="false"
+        cluster_count=0
+        resources_added=0
+        resources_modified=0
+        resources_removed=0
+
+        # First pass: compare existing clusters in both base and head
+        for cluster_dir in .rendered/head/*; do
+          cluster_name=$(basename "$cluster_dir")
+          base_file=".rendered/base/$cluster_name/kustomize.yaml"
+          head_file=".rendered/head/$cluster_name/kustomize.yaml"
+
+          if [ -f "$base_file" ] && [ -f "$head_file" ]; then
+            # Compare base vs head to show changes FROM base TO head
+            cluster_diff=$(dyff between --color off --omit-header "$base_file" "$head_file" 2>&1 || true)
+            if [ -n "$cluster_diff" ]; then
+              diff_output+="### Cluster: $cluster_name"$'\n\n'
+              diff_output+="$cluster_diff"$'\n\n'
+              has_changes="true"
+              cluster_count=$((cluster_count + 1))
+
+              # Parse dyff output for resource-level changes
+              # dyff uses these patterns for resource-level changes:
+              # - "+ one document added:" = entire resource added (preceded by "(root level)" line)
+              # - "- one document removed:" = entire resource removed (preceded by "(root level)" line)
+              # - Field path with "(kind/name)" = modification to existing resource (e.g., "data.key  (v1/ConfigMap/test1)")
+              added=$(echo "$cluster_diff" | grep -c '^\+ one document added:' || true)
+              removed=$(echo "$cluster_diff" | grep -c '^- one document removed:' || true)
+              # Count unique resources with modifications (exclude "(root level)" which indicates add/remove)
+              modified=$(echo "$cluster_diff" | grep -E '\([^)]+/[^)]+/[^)]+\)' | grep -v '(root level)' | grep -oE '\([^)]+/[^)]+/[^)]+\)' | sort -u | wc -l | tr -d ' ')
+
+              resources_added=$((resources_added + added))
+              resources_removed=$((resources_removed + removed))
+              resources_modified=$((resources_modified + modified))
+            fi
+          elif [ -f "$head_file" ]; then
+            # New cluster added in head ref
+            diff_output+="### Cluster: $cluster_name"$'\n\n'
+            diff_output+="New cluster (not in base ref)"$'\n\n'
+            has_changes="true"
+            cluster_count=$((cluster_count + 1))
+
+            # Count all resources in new cluster as added
+            resource_count=$(grep -c '^kind: ' "$head_file" || true)
+            resources_added=$((resources_added + resource_count))
+          fi
+        done
+
+        # Second pass: check for removed clusters (iterate over base, check if missing in head)
+        for cluster_dir in .rendered/base/*; do
+          cluster_name=$(basename "$cluster_dir")
+          base_file=".rendered/base/$cluster_name/kustomize.yaml"
+          head_file=".rendered/head/$cluster_name/kustomize.yaml"
+
+          if [ -f "$base_file" ] && [ ! -f "$head_file" ]; then
+            diff_output+="### Cluster: $cluster_name"$'\n\n'
+            diff_output+="Cluster removed"$'\n\n'
+            has_changes="true"
+            cluster_count=$((cluster_count + 1))
+
+            # Count all resources in removed cluster as removed
+            resource_count=$(grep -c '^kind: ' "$base_file" || true)
+            resources_removed=$((resources_removed + resource_count))
+          fi
+        done
+
+        # Generate summary
+        if [ "$has_changes" = "true" ]; then
+          total_changes=$((resources_added + resources_modified + resources_removed))
+          summary="**$total_changes resource change"
+          if [ "$total_changes" -ne 1 ]; then
+            summary+="s"
+          fi
+          summary+="**: $resources_added added, $resources_modified modified, $resources_removed removed"
+        else
+          summary="No changes detected"
+        fi
+
+        # Output results
+        echo "has_changes=$has_changes" >> "$GITHUB_OUTPUT"
+        echo "summary_text=$summary" >> "$GITHUB_OUTPUT"
+
+        # Truncate diff if too large for GitHub comment (65536 char limit)
+        max_length=60000
+        if [ ${#diff_output} -gt "$max_length" ]; then
+          diff_output="${diff_output:0:$max_length}"$'\n\n'"... (diff truncated, see workflow logs for full output)"
+        fi
+
+        # Handle multiline diff output
+        {
+          echo 'diff_text<<EOF'
+          echo "$diff_output"
+          echo 'EOF'
+        } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/kubernetes-diff.yaml
+++ b/.github/workflows/kubernetes-diff.yaml
@@ -1,0 +1,63 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Kubernetes Manifest Diff
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - kubernetes/**
+      - .github/workflows/kubernetes-diff.yaml
+      - .github/actions/kubernetes-diff/**
+
+jobs:
+  render-and-diff:
+    runs-on: homelab-runner-staging-runner-app
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Kubernetes diff
+        id: k8s-diff
+        uses: ./.github/actions/kubernetes-diff
+        with:
+          base_ref: origin/main
+          head_ref: HEAD
+
+      - name: Post PR comment
+        if: steps.k8s-diff.outputs.has_changes == 'true'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Kubernetes Manifest Diff
+
+            ${{ steps.k8s-diff.outputs.summary_text }}
+
+            <details>
+            <summary>Click to expand full diff</summary>
+
+            ```diff
+            ${{ steps.k8s-diff.outputs.diff_text }}
+            ```
+
+            </details>
+          edit-mode: replace
+          comment-tag: k8s-manifest-diff
+
+      - name: Post no changes comment
+        if: steps.k8s-diff.outputs.has_changes == 'false'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Kubernetes Manifest Diff
+
+            No changes detected in rendered Kubernetes manifests.
+          edit-mode: replace
+          comment-tag: k8s-manifest-diff

--- a/.taskfiles/kubernetes/taskfile.yaml
+++ b/.taskfiles/kubernetes/taskfile.yaml
@@ -27,6 +27,114 @@ tasks:
         kubectl get pods --all-namespaces -o json | \
         jq -r '.items[] | select(.status.phase=="Succeeded" or .status.containerStatuses[]?.state.terminated?.reason=="Error") | "\(.metadata.namespace) \(.metadata.name)"' | \
         xargs -n2 sh -c 'kubectl delete pod -n "$0" "$1"'
+
+  diff:
+    desc: Show diff of rendered Kubernetes manifests between current branch and main
+    silent: false
+    vars:
+      CLUSTERS:
+        sh: "ls -1 {{.CLUSTER_DIR}}"
+      CURRENT_BRANCH:
+        sh: "git rev-parse --abbrev-ref HEAD"
+      CURRENT_RENDERED: "{{.ROOT_DIR}}/.rendered/current"
+      MAIN_RENDERED: "{{.ROOT_DIR}}/.rendered/main"
+    cmds:
+      - defer: rm -rf {{.CURRENT_RENDERED}} {{.MAIN_RENDERED}}
+      # Render current branch (HEAD)
+      - mkdir -p {{.CURRENT_RENDERED}}
+      - task: render-clusters-to-dir
+        vars:
+          OUTPUT_BASE: "{{.CURRENT_RENDERED}}"
+      # Render main branch using git show (worktree-safe)
+      - mkdir -p {{.MAIN_RENDERED}}
+      - task: render-clusters-from-ref
+        vars:
+          GIT_REF: main
+          OUTPUT_BASE: "{{.MAIN_RENDERED}}"
+      # Run dyff for each cluster (compare main vs current to show changes FROM main TO current)
+      - for: { var: CLUSTERS }
+        cmd: |
+          echo "=== Cluster: {{.ITEM}} ==="
+          if [ -f "{{.MAIN_RENDERED}}/{{.ITEM}}/kustomize.yaml" ] && [ -f "{{.CURRENT_RENDERED}}/{{.ITEM}}/kustomize.yaml" ]; then
+            dyff between --color on --omit-header "{{.MAIN_RENDERED}}/{{.ITEM}}/kustomize.yaml" "{{.CURRENT_RENDERED}}/{{.ITEM}}/kustomize.yaml" || true
+          elif [ -f "{{.CURRENT_RENDERED}}/{{.ITEM}}/kustomize.yaml" ]; then
+            echo "New cluster (not in main)"
+          elif [ -f "{{.MAIN_RENDERED}}/{{.ITEM}}/kustomize.yaml" ]; then
+            echo "Cluster removed"
+          fi
+          echo ""
+    preconditions:
+      - which dyff
+      - which kustomize
+      - which git
+
+  render-clusters-from-ref:
+    desc: Renders all clusters from a specific git ref (worktree-safe)
+    internal: true
+    silent: true
+    requires:
+      vars: [GIT_REF, OUTPUT_BASE]
+    vars:
+      CLUSTERS:
+        sh: "ls -1 {{.CLUSTER_DIR}}"
+      TEMP_DIR:
+        sh: "mktemp -d"
+    cmds:
+      - defer: rm -rf {{.TEMP_DIR}}
+      # Extract kubernetes/ directory from git ref to temp location
+      - mkdir -p {{.TEMP_DIR}}/kubernetes
+      - git archive {{.GIT_REF}} kubernetes | tar -x -C {{.TEMP_DIR}}
+      # Render each cluster from the extracted files
+      - for: { var: CLUSTERS }
+        cmd: |
+          cluster_name="{{.ITEM}}"
+          kustomization="{{.TEMP_DIR}}/kubernetes/clusters/$cluster_name"
+          output_dir="{{.OUTPUT_BASE}}/$cluster_name"
+          mkdir -p "$output_dir"
+          if [ -d "$kustomization" ] && [ -f "$kustomization/kustomization.yaml" ]; then
+            kustomize build "$kustomization" > "$output_dir/kustomize.yaml" 2> "$output_dir/kustomize_errors.log" || true
+          else
+            echo "Cluster $cluster_name has no kustomization.yaml in {{.GIT_REF}}" > "$output_dir/kustomize_errors.log"
+          fi
+
+  render-clusters-to-dir:
+    desc: Renders all clusters to a specific directory
+    internal: true
+    silent: true
+    requires:
+      vars: [OUTPUT_BASE]
+    vars:
+      CLUSTERS:
+        sh: "ls -1 {{.CLUSTER_DIR}}"
+    cmds:
+      - for: { var: CLUSTERS }
+        task: render-cluster-to-dir
+        vars:
+          CLUSTER: "{{.ITEM}}"
+          OUTPUT_BASE: "{{.OUTPUT_BASE}}"
+
+  render-cluster-to-dir:
+    desc: Renders a cluster to a specific directory
+    internal: true
+    silent: true
+    requires:
+      vars: [CLUSTER, OUTPUT_BASE]
+    vars:
+      OUTPUT_DIR: "{{.OUTPUT_BASE}}/{{.CLUSTER}}"
+      RENDERED: "{{.OUTPUT_DIR}}/kustomize.yaml"
+      ERRORS: "{{.OUTPUT_DIR}}/kustomize_errors.log"
+      KUSTOMIZATION: "{{.CLUSTER_DIR}}/{{.CLUSTER}}"
+    cmds:
+      - mkdir -p {{.OUTPUT_DIR}}
+      - cmd: |
+          if [ -d "{{.KUSTOMIZATION}}" ] && [ -f "{{.KUSTOMIZATION}}/kustomization.yaml" ]; then
+            kustomize build "{{.KUSTOMIZATION}}" > "{{.RENDERED}}" 2> "{{.ERRORS}}"
+          else
+            echo "Cluster {{.CLUSTER}} has no kustomization.yaml, skipping" > "{{.ERRORS}}"
+          fi
+        ignore_error: true
+    preconditions:
+      - which kustomize
   render:
     desc: Renders all manifests.
     silent: true

--- a/Brewfile
+++ b/Brewfile
@@ -16,6 +16,7 @@ brew "jq"
 brew "helm"
 brew "kustomize"
 brew "kubeconform"
+brew "dyff"
 
 # Flux
 tap "fluxcd/tap"


### PR DESCRIPTION
## Summary
- Enable PR reviewers to see rendered manifest changes without manually running kustomize builds
- Catch unintended side effects from Kustomize patches, Helm value changes, or variable substitution
- Add local `task k8s:diff` command for developers to preview changes before pushing

## Test plan
- [ ] Open a PR that modifies files under `kubernetes/`
- [ ] Verify workflow triggers and posts a diff comment on the PR
- [ ] Run `task k8s:diff` locally to confirm it shows changes vs main
- [ ] Verify `dyff` installs correctly via `brew bundle`