### PR TITLE
fix(ci): disable hashicorp/terraform lookups in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -88,5 +88,14 @@
   "ignorePaths": [
     "kubernetes/clusters/*/flux-system/**",
     "kubernetes/clusters/generated-cluster-vars.env"
+  ],
+  "packageRules": [
+    {
+      // Disable hashicorp/terraform lookups - we use OpenTofu
+      // The actual OpenTofu version is tracked via .opentofu-version custom manager
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["hashicorp/terraform"],
+      "enabled": false
+    }
   ]
 }

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -23,7 +23,7 @@ on:
       version:
         description: Renovate version to use
         type: string
-        default: latest
+        default: "41"
         required: false
 
 jobs:

--- a/.github/workflows/validate-renovate.yaml
+++ b/.github/workflows/validate-renovate.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Validate Renovate Config
+
+on:
+  pull_request:
+    paths:
+      - '.github/renovate.json5'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Validate Renovate Config
+        run: npx --yes --package renovate@41 -- renovate-config-validator --strict

--- a/.taskfiles/renovate/taskfile.yaml
+++ b/.taskfiles/renovate/taskfile.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+tasks:
+  validate:
+    desc: Validates the Renovate configuration.
+    cmds:
+      - npx --yes --package renovate@41 -- renovate-config-validator --strict
+    preconditions:
+      - which npx

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -6,6 +6,7 @@ includes:
   tg: .taskfiles/terragrunt
   k8s: .taskfiles/kubernetes
   wt: .taskfiles/worktree
+  renovate: .taskfiles/renovate
 
 tasks:
   default:


### PR DESCRIPTION
## Summary
- Disable `hashicorp/terraform` GitHub releases lookups in Renovate (we use OpenTofu, tracked via `.opentofu-version`)
- Pin Renovate workflow version to `41` to eliminate "No Docker version specified" warning
- Add CI validation workflow for Renovate config changes to catch issues before main

## Test plan
- [x] `task renovate:validate` passes locally
- [ ] Verify next Renovate run has no `hashicorp/terraform` lookup warnings
- [ ] Verify validate-renovate workflow triggers on this PR

🤖 Generated with [Claude Code](https://claude.ai/code)