### PR TITLE
feat(k8s): complete Istio Ambient mesh adoption

### DIFF
--- a/kubernetes/platform/charts/cilium.yaml
+++ b/kubernetes/platform/charts/cilium.yaml
@@ -52,6 +52,8 @@ loadBalancer:
   acceleration: best-effort
   algorithm: maglev
   mode: dsr
+socketLB:
+  hostNamespaceOnly: true
 operator:
   rollOutPods: true
   replicas: 1

--- a/kubernetes/platform/charts/istio-cni.yaml
+++ b/kubernetes/platform/charts/istio-cni.yaml
@@ -2,7 +2,7 @@
 # https://github.com/istio/istio/blob/master/manifests/charts/istio-cni/values.yaml
 profile: ambient
 
-gobal:
+global:
   logAsJson: true
   defaultResources:
     resources:

--- a/kubernetes/platform/charts/istiod.yaml
+++ b/kubernetes/platform/charts/istiod.yaml
@@ -3,7 +3,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/helm-chart-lock.json
 profile: ambient
 
-gobal:
+global:
   logAsJson: true
   defaultResources:
     resources:

--- a/kubernetes/platform/namespaces.yaml
+++ b/kubernetes/platform/namespaces.yaml
@@ -16,7 +16,7 @@ spec:
       dataplane: ambient
       security: privileged
     - name: kube-system
-      dataplane: ambient
+      dataplane: standard
       security: privileged
     - name: longhorn-system
       dataplane: standard


### PR DESCRIPTION
## Summary
- Enable proper Cilium + Istio Ambient compatibility by adding `socketLB.hostNamespaceOnly: true`
- Fix typo in Istio values files (`gobal` -> `global`) so global settings are applied
- Exclude kube-system from ambient mesh to avoid CNI/DNS conflicts with ztunnel

## Manual Validation Steps

After Flux reconciles on integration cluster:

```bash
# 1. Verify Cilium config applied
kubectl get configmap -n kube-system cilium-config -o yaml | grep -A2 socketLB
# Expected: hostNamespaceOnly: "true"

# 2. Verify namespace labels
kubectl get ns -L istio.io/dataplane-mode
# kube-system and longhorn-system should show "standard"
# cert-manager, external-secrets, istio-system, monitoring, network, system should show "ambient"

# 3. Verify istiod picked up global settings
kubectl get configmap -n istio-system istio -o yaml | grep logAsJson
# Expected: logAsJson: true

# 4. Verify ztunnel is healthy and NOT capturing kube-system traffic
kubectl logs -n istio-system -l app=ztunnel --tail=100

# 5. Verify all HelmReleases reconciled successfully
flux get helmreleases -A | grep -E 'cilium|istio'
# All should show "True" for Ready
```

## References
- [Cilium + Istio Integration Docs](https://docs.cilium.io/en/stable/network/servicemesh/istio/)
- [Istio Ambient Workload Labeling](https://istio.io/latest/docs/ambient/usage/add-workloads/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)