### PR TITLE
feat(ci): add kubernetes YAML schema validation workflow

### DIFF
--- a/.github/workflows/kubernetes-validate.yaml
+++ b/.github/workflows/kubernetes-validate.yaml
@@ -26,6 +26,12 @@ jobs:
           curl -sSL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz | tar xz
           sudo mv kubeconform /usr/local/bin/
 
+      - name: Install yq
+        run: |
+          curl -sSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o yq
+          chmod +x yq
+          sudo mv yq /usr/local/bin/
+
       - name: Build kustomizations
         run: |
           mkdir -p /tmp/manifests


### PR DESCRIPTION
## Summary
- Validates Kubernetes YAML schemas on PRs to prevent invalid CRD fields from causing Flux reconciliation failures in production
- Builds all kustomizations in `kubernetes/platform/config/` and validates against schemas from kubernetes-schemas.pages.dev

## Test plan
- [ ] Verify workflow runs on this PR
- [ ] Introduce invalid field (e.g., `responseTime` instead of `thresholdMillis`) and verify workflow fails
- [ ] Fix invalid field and verify workflow passes

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)