### PR TITLE
fix(infra): adjust healthchecks.io schedule to prevent false panic state

### DIFF
--- a/infrastructure/modules/bootstrap/healthcheck.tf
+++ b/infrastructure/modules/bootstrap/healthcheck.tf
@@ -6,9 +6,9 @@ resource "healthchecksio_check" "this" {
   name = "${var.cluster_name}-heartbeat"
   desc = "Alertmanager heartbeat from cluster: ${var.cluster_name}."
 
-  timeout  = 0           # seconds
-  grace    = 300         # seconds
-  schedule = "* * * * *" # every minute
+  timeout  = 0             # seconds
+  grace    = 300           # seconds
+  schedule = "*/2 * * * *" # every 2 minutes
   timezone = "UTC"
 
   tags = [

--- a/kubernetes/platform/config/monitoring/alertmanager-config.yaml
+++ b/kubernetes/platform/config/monitoring/alertmanager-config.yaml
@@ -18,9 +18,9 @@ spec:
             value: InfoInhibitor
             matchType: =
       - receiver: heartbeat
-        groupInterval: 1m
+        groupInterval: 2m
         groupWait: 0s
-        repeatInterval: 1m
+        repeatInterval: 2m
         matchers:
           - name: alertname
             value: Watchdog


### PR DESCRIPTION
## Summary
- Align healthchecks.io cron schedule with Alertmanager heartbeat frequency to prevent timing drift
- Change from 1-minute to 2-minute intervals while maintaining 5-minute grace period for network delays

## Test plan
- [ ] Verify healthchecks.io check stays in "up" state for extended period
- [ ] Confirm Alertmanager sends heartbeats at 2-minute intervals
- [ ] Validate grace period handles occasional network delays appropriately

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)