### PR TITLE
fix(k8s): correct spegel Helm chart version format

### DIFF
--- a/kubernetes/platform/helm-charts.yaml
+++ b/kubernetes/platform/helm-charts.yaml
@@ -165,7 +165,7 @@ spec:
       namespace: spegel
       chart:
         name: spegel
-        version: v0.6.0
+        version: 0.6.0
         url: oci://ghcr.io/spegel-org/helm-charts
       dependsOn: [cilium, kube-prometheus-stack-crds]
   resourcesTemplate: |


### PR DESCRIPTION
## Summary
- Fix spegel Helm chart version format by removing leading `v` prefix
- OCI-based Helm charts require standard semver format (`0.6.0`) without prefix

## Test plan
- [x] Verify Flux successfully reconciles the spegel HelmRelease
- [x] Confirm spegel pods are running after reconciliation

🤖 Generated with [Claude Code](https://claude.com/claude-code)