### PR TITLE
fix(k8s): resolve StorageClass type error and improve k8s-sre skill

### DIFF
--- a/infrastructure/modules/config/main.tf
+++ b/infrastructure/modules/config/main.tf
@@ -195,6 +195,8 @@ locals {
     { name = "cluster_service_subnet", value = var.networking.service_subnet },
     { name = "cluster_path", value = local.cluster_path },
     { name = "default_replica_count", value = tostring(min(3, length(local.machines))) },
+    # YAML-safe string version for StorageClass parameters (must be strings, not integers)
+    { name = "storage_replica_count", value = "\"${tostring(min(3, length(local.machines)))}\"" },
     { name = "cluster_id", value = tostring(var.networking.id) },
     { name = "cluster_ip_pool_start", value = var.networking.ip_pool_start },
     { name = "cluster_ip_pool_stop", value = var.networking.ip_pool_stop },

--- a/kubernetes/clusters/dev/.cluster-vars.env
+++ b/kubernetes/clusters/dev/.cluster-vars.env
@@ -10,6 +10,7 @@ cluster_pod_subnet=172.24.0.0/16
 cluster_service_subnet=172.25.0.0/16
 cluster_path=kubernetes/clusters/dev
 default_replica_count=3
+storage_replica_count="3"
 cluster_id=4
 cluster_ip_pool_start=192.168.10.51
 cluster_ip_pool_stop=192.168.10.59

--- a/kubernetes/platform/config/longhorn/storage-classes/fast-critical.yaml
+++ b/kubernetes/platform/config/longhorn/storage-classes/fast-critical.yaml
@@ -8,7 +8,7 @@ allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 parameters:
-  numberOfReplicas: "${default_replica_count}"
+  numberOfReplicas: ${storage_replica_count}
   fsType: xfs
   staleReplicaTimeout: "30"
   dataLocality: best-effort

--- a/kubernetes/platform/config/longhorn/storage-classes/fast.yaml
+++ b/kubernetes/platform/config/longhorn/storage-classes/fast.yaml
@@ -8,7 +8,7 @@ allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 parameters:
-  numberOfReplicas: "${default_replica_count}"
+  numberOfReplicas: ${storage_replica_count}
   fsType: xfs
   staleReplicaTimeout: "30"
   dataLocality: best-effort

--- a/kubernetes/platform/config/longhorn/storage-classes/slow-critical.yaml
+++ b/kubernetes/platform/config/longhorn/storage-classes/slow-critical.yaml
@@ -8,7 +8,7 @@ allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 parameters:
-  numberOfReplicas: "${default_replica_count}"
+  numberOfReplicas: ${storage_replica_count}
   fsType: xfs
   staleReplicaTimeout: "30"
   dataLocality: best-effort

--- a/kubernetes/platform/config/longhorn/storage-classes/slow.yaml
+++ b/kubernetes/platform/config/longhorn/storage-classes/slow.yaml
@@ -8,7 +8,7 @@ allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 parameters:
-  numberOfReplicas: "${default_replica_count}"
+  numberOfReplicas: ${storage_replica_count}
   fsType: xfs
   staleReplicaTimeout: "30"
   dataLocality: best-effort

--- a/kubernetes/platform/helm-charts.yaml
+++ b/kubernetes/platform/helm-charts.yaml
@@ -206,6 +206,7 @@ spec:
         createNamespace: false
         remediation:
           retries: 3
+        timeout: 10m
       interval: 10m
       maxHistory: 3
       releaseName: << inputs.name >>
@@ -216,6 +217,7 @@ spec:
         crds: CreateReplace
         remediation:
           retries: 3
+        timeout: 10m
       valuesFrom:
         - kind: ConfigMap
           name: platform-values


### PR DESCRIPTION
## Summary

- Fix StorageClass `numberOfReplicas` type error that was blocking all PVC provisioning on the `fast` StorageClass
- Add default 10m timeout for all Helm releases as a safety measure
- Refactor k8s-sre skill to prioritize 5 Whys root cause analysis (reduced from 598 to 202 lines)

## Root Cause

Kustomize YAML normalization strips quotes from values like `"${default_replica_count}"`. After Flux substitution, the result was `numberOfReplicas: 3` (integer) instead of `numberOfReplicas: "3"` (string). Kubernetes StorageClass parameters must be strings.

The fix introduces `storage_replica_count` with embedded quotes in the value itself (`"3"`), ensuring valid YAML after substitution.

## Test plan

- [ ] Verify `longhorn-storage` Kustomization becomes Ready
- [ ] Verify StorageClasses `fast`, `slow`, etc. are created
- [ ] Verify garage and loki PVCs bind successfully
- [ ] Verify HelmReleases become Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)