### PR TITLE
refactor(k8s): remove legacy ingress configs in favor of Gateway API

### DIFF
--- a/kubernetes/platform/charts/cilium.yaml
+++ b/kubernetes/platform/charts/cilium.yaml
@@ -37,15 +37,6 @@ hubble:
     enabled: true
   ui:
     enabled: true
-    ingress:
-      enabled: true
-      className: internal
-      hosts:
-        - hubble.${internal_domain}
-      tls:
-        - hosts:
-            - hubble.${internal_domain}
-          secretName: hubble-tls
 l2announcements:
   enabled: true
 loadBalancer:

--- a/kubernetes/platform/charts/grafana.yaml
+++ b/kubernetes/platform/charts/grafana.yaml
@@ -128,12 +128,6 @@ dashboards:
     miniflux:
       url: https://raw.githubusercontent.com/miniflux/v2/main/contrib/grafana/dashboard.json
       datasource: Prometheus
-    nginx:
-      url: https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/grafana/dashboards/nginx.json
-      datasource: Prometheus
-    nginx-request-handling-performance:
-      url: https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/grafana/dashboards/request-handling-performance.json
-      datasource: Prometheus
     node-exporter-full:
       # renovate: depName="Node Exporter Full"
       gnetId: 1860
@@ -200,10 +194,6 @@ plugins:
   - vonage-status-panel
 serviceMonitor:
   enabled: true
-ingress:
-  enabled: true
-  ingressClassName: internal
-  hosts: ["grafana.${internal_domain}"]
 persistence:
   enabled: false
 testFramework:

--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -5,12 +5,6 @@ crds:
 cleanPrometheusOperatorObjectNames: true
 alertmanager:
   enabled: true
-  additionalLabels:
-  ingress:
-    enabled: true
-    ingressClassName: internal
-    hosts: ["alertmanager.${internal_domain}"]
-    pathType: Prefix
   alertmanagerSpec:
     podMetadata:
       labels:

--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -13,11 +13,6 @@ csi:
   provisionerReplicaCount: ${default_replica_count}
   resizerReplicaCount: ${default_replica_count}
   snapshotterReplicaCount: ${default_replica_count}
-ingress:
-  enabled: true
-  ingressClassName: internal
-  tls: true
-  host: longhorn.${internal_domain}
 metrics:
   serviceMonitor:
     enabled: true


### PR DESCRIPTION
## Summary
- Remove vestigial `ingress:` sections from Helm values now that routing is handled by Gateway API + HTTPRoutes
- Remove nginx-ingress Grafana dashboards since no ingress-nginx controller is deployed

## Test plan
- [x] Verify Flux reconciles successfully on integration cluster
- [x] Confirm all services remain accessible via existing HTTPRoutes (Grafana, Prometheus, Alertmanager, Longhorn, Hubble)

🤖 Generated with [Claude Code](https://claude.com/claude-code)