### PR TITLE
feat(infra): add cluster-driven storage provisioning mode

### DIFF
--- a/infrastructure/modules/config/variables.tf
+++ b/infrastructure/modules/config/variables.tf
@@ -14,6 +14,17 @@ variable "features" {
   }
 }
 
+variable "storage_provisioning" {
+  description = "Storage provisioning mode: 'normal' for production sizes, 'minimal' for dev/test sizes."
+  type        = string
+  default     = "normal"
+
+  validation {
+    condition     = contains(["normal", "minimal"], var.storage_provisioning)
+    error_message = "storage_provisioning must be 'normal' or 'minimal'."
+  }
+}
+
 variable "networking" {
   description = "Networking configuration for the cluster."
   type = object({

--- a/infrastructure/stacks/dev/terragrunt.stack.hcl
+++ b/infrastructure/stacks/dev/terragrunt.stack.hcl
@@ -1,6 +1,7 @@
 locals {
-  name     = "${basename(get_terragrunt_dir())}"
-  features = ["gateway-api", "longhorn", "prometheus", "spegel"]
+  name                 = "${basename(get_terragrunt_dir())}"
+  features             = ["gateway-api", "longhorn", "prometheus", "spegel"]
+  storage_provisioning = "minimal"
 }
 
 unit "config" {
@@ -8,8 +9,9 @@ unit "config" {
   path   = "config"
 
   values = {
-    name     = local.name
-    features = local.features
+    name                 = local.name
+    features             = local.features
+    storage_provisioning = local.storage_provisioning
   }
 }
 

--- a/infrastructure/stacks/integration/terragrunt.stack.hcl
+++ b/infrastructure/stacks/integration/terragrunt.stack.hcl
@@ -1,6 +1,7 @@
 locals {
-  name     = "${basename(get_terragrunt_dir())}"
-  features = ["gateway-api", "longhorn", "prometheus", "spegel"]
+  name                 = "${basename(get_terragrunt_dir())}"
+  features             = ["gateway-api", "longhorn", "prometheus", "spegel"]
+  storage_provisioning = "normal"
 }
 
 unit "config" {
@@ -8,8 +9,9 @@ unit "config" {
   path   = "config"
 
   values = {
-    name     = local.name
-    features = local.features
+    name                 = local.name
+    features             = local.features
+    storage_provisioning = local.storage_provisioning
   }
 }
 

--- a/infrastructure/stacks/live/terragrunt.stack.hcl
+++ b/infrastructure/stacks/live/terragrunt.stack.hcl
@@ -1,6 +1,7 @@
 locals {
-  name     = "${basename(get_terragrunt_dir())}"
-  features = ["gateway-api", "longhorn", "prometheus", "spegel"]
+  name                 = "${basename(get_terragrunt_dir())}"
+  features             = ["gateway-api", "longhorn", "prometheus", "spegel"]
+  storage_provisioning = "normal"
 }
 
 unit "config" {
@@ -8,8 +9,9 @@ unit "config" {
   path   = "config"
 
   values = {
-    name     = local.name
-    features = local.features
+    name                 = local.name
+    features             = local.features
+    storage_provisioning = local.storage_provisioning
   }
 }
 

--- a/infrastructure/units/config/terragrunt.hcl
+++ b/infrastructure/units/config/terragrunt.hcl
@@ -19,11 +19,12 @@ terraform {
 }
 
 inputs = {
-  name        = values.name
-  features    = values.features
-  networking  = local.networking_vars.locals.clusters[values.name]
-  machines    = local.inventory_vars.locals.hosts
-  versions    = local.versions_vars.locals.versions
-  local_paths = local.local_paths
-  accounts    = local.accounts_vars.locals.accounts
+  name                 = values.name
+  features             = values.features
+  storage_provisioning = values.storage_provisioning
+  networking           = local.networking_vars.locals.clusters[values.name]
+  machines             = local.inventory_vars.locals.hosts
+  versions             = local.versions_vars.locals.versions
+  local_paths          = local.local_paths
+  accounts             = local.accounts_vars.locals.accounts
 }

--- a/kubernetes/platform/charts/garage.yaml
+++ b/kubernetes/platform/charts/garage.yaml
@@ -120,7 +120,7 @@ persistence:
     type: persistentVolumeClaim
     storageClass: fast
     accessMode: ReadWriteOnce
-    size: 10Gi
+    size: ${garage_meta_volume_size}
     globalMounts:
       - path: /var/lib/garage/meta
   data:
@@ -128,6 +128,6 @@ persistence:
     type: persistentVolumeClaim
     storageClass: fast
     accessMode: ReadWriteOnce
-    size: 100Gi
+    size: ${garage_data_volume_size}
     globalMounts:
       - path: /var/lib/garage/data

--- a/kubernetes/platform/charts/grafana-loki-single-binary.yaml
+++ b/kubernetes/platform/charts/grafana-loki-single-binary.yaml
@@ -34,7 +34,7 @@ singleBinary:
   persistence:
     enabled: true
     storageClass: fast
-    size: 50Gi
+    size: ${loki_volume_size}
 gateway:
   replicas: 0
 backend:

--- a/kubernetes/platform/config/database/cluster.yaml
+++ b/kubernetes/platform/config/database/cluster.yaml
@@ -25,7 +25,7 @@ spec:
 
   storage:
     storageClass: fast
-    size: 20Gi
+    size: ${database_volume_size}
 
   resources:
     requests:


### PR DESCRIPTION
## Summary
- Add `storage_provisioning` variable with "normal" and "minimal" modes to handle different cluster storage capacities
- Dev cluster uses "minimal" (10Gi garage-data, 2Gi garage-meta, 5Gi database, 10Gi loki) to fit within ~220GB/node constraints
- Integration and live use "normal" (100Gi garage-data, 10Gi garage-meta, 20Gi database, 50Gi loki)
- Size definitions centralized in config module, Kubernetes manifests use Flux variable substitution

## Test plan
- [x] `task tg:fmt` - formatting passed
- [x] `task tg:validate-dev` - all 5 units validated successfully
- [ ] After apply, verify `.cluster-vars.env` contains new variables
- [ ] Verify Flux substitutes volume sizes correctly in PVCs

🤖 Generated with [Claude Code](https://claude.com/claude-code)