### PR TITLE
fix(network): resolve Cilium 1.18 policy validation failures

### DIFF
--- a/kubernetes/platform/config/network-policy/baselines/kube-api-access.yaml
+++ b/kubernetes/platform/config/network-policy/baselines/kube-api-access.yaml
@@ -5,10 +5,12 @@ kind: CiliumClusterwideNetworkPolicy
 metadata:
   name: baseline-kube-api-access
 spec:
-  description: "Allow pods with kube-api access label to reach the Kubernetes API server"
+  description: >-
+    Allow pods with kube-api access label to reach the Kubernetes API server.
+    Usage: Add label access.network-policy.homelab/kube-api=true to namespace.
   endpointSelector:
     matchExpressions:
-      - key: io.cilium.k8s.namespace.labels.access\.network-policy\.homelab/kube-api
+      - key: io.cilium.k8s.namespace.labels.access.network-policy.homelab/kube-api
         operator: In
         values: ["true"]
   egress:

--- a/kubernetes/platform/config/network-policy/platform/database.yaml
+++ b/kubernetes/platform/config/network-policy/platform/database.yaml
@@ -12,7 +12,7 @@ spec:
     # Allow PostgreSQL connections from namespaces with postgres access label
     - fromEndpoints:
         - matchExpressions:
-            - key: io.cilium.k8s.namespace.labels.access\.network-policy\.homelab/postgres
+            - key: io.cilium.k8s.namespace.labels.access.network-policy.homelab/postgres
               operator: In
               values: ["true"]
       toPorts:

--- a/kubernetes/platform/config/network-policy/platform/garage.yaml
+++ b/kubernetes/platform/config/network-policy/platform/garage.yaml
@@ -12,7 +12,7 @@ spec:
     # Allow S3 API from namespaces with garage-s3 access label
     - fromEndpoints:
         - matchExpressions:
-            - key: io.cilium.k8s.namespace.labels.access\.network-policy\.homelab/garage-s3
+            - key: io.cilium.k8s.namespace.labels.access.network-policy.homelab/garage-s3
               operator: In
               values: ["true"]
       toPorts:

--- a/kubernetes/platform/config/network-policy/platform/kube-system.yaml
+++ b/kubernetes/platform/config/network-policy/platform/kube-system.yaml
@@ -10,8 +10,9 @@ spec:
   endpointSelector: { }
   ingress:
     # Allow DNS queries from all cluster pods
+    # Note: empty matchLabels {} means "any endpoint in the cluster"
     - fromEndpoints:
-        - { }
+        - matchLabels: { }
       toPorts:
         - ports:
             - port: "53"
@@ -40,7 +41,7 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: kube-system
   egress:
-    # Allow DNS resolution
+    # Allow DNS resolution (internal)
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: kube-system
@@ -49,6 +50,15 @@ spec:
         - ports:
             - port: "53"
               protocol: UDP
+    # Allow CoreDNS to reach node-local upstream DNS (Talos host DNS forwarder)
+    - toEntities:
+        - host
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
     # Allow NTP for time sync (world egress on UDP 123)
     - toEntities:
         - world
@@ -70,3 +80,10 @@ spec:
     # Allow health checks to all cluster pods (Cilium)
     - toEntities:
         - cluster
+    # Allow Hubble relay to reach Cilium agents on nodes (host network)
+    - toEntities:
+        - host
+      toPorts:
+        - ports:
+            - port: "4244"
+              protocol: TCP

--- a/kubernetes/platform/config/network-policy/profiles/default-deny.yaml
+++ b/kubernetes/platform/config/network-policy/profiles/default-deny.yaml
@@ -29,12 +29,14 @@ spec:
           - spegel
           - kromgo
       # Escape hatch: exclude namespaces with enforcement disabled
-      - key: io.cilium.k8s.namespace.labels.network-policy\.homelab/enforcement
+      - key: io.cilium.k8s.namespace.labels.network-policy.homelab/enforcement
         operator: NotIn
         values: ["disabled"]
-  # Empty ingress list = no ingress allowed by this policy
-  # Other CCNPs (baselines, profiles) add allow rules for these endpoints
-  ingress: []
-  # Empty egress list = no egress allowed by this policy
-  # Baseline DNS CCNP adds DNS egress for all pods
-  egress: []
+  # Explicit deny rules required in Cilium 1.18+ (empty arrays are invalid)
+  # Other CCNPs (baselines, profiles) add allow rules for matching endpoints
+  ingressDeny:
+    - fromEntities:
+        - all
+  egressDeny:
+    - toEntities:
+        - all

--- a/kubernetes/platform/config/network-policy/profiles/profile-isolated.yaml
+++ b/kubernetes/platform/config/network-policy/profiles/profile-isolated.yaml
@@ -8,11 +8,28 @@ spec:
   description: >-
     Isolated profile: No external ingress, no internet egress.
     For batch jobs and internal processors with no network needs beyond DNS and metrics.
-    DNS egress and Prometheus scrape ingress handled by baseline CCNPs.
+    This policy explicitly allows only baseline capabilities (DNS egress, Prometheus ingress).
+    Combined with default-deny CCNP, this restricts isolated workloads to internal-only communication.
   endpointSelector:
     matchLabels:
       io.cilium.k8s.namespace.labels.network-policy.homelab/profile: isolated
-  # No additional ingress allowed (baselines handle Prometheus scrape)
-  ingress: []
-  # No additional egress allowed (baselines handle DNS)
-  egress: []
+  # Explicit allow for baseline capabilities (Cilium 1.18+ requires non-empty rules)
+  # These match what baseline CCNPs already allow, making behavior explicit
+  ingress:
+    # Allow Prometheus scraping (matches baseline-prometheus-scrape)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus
+  egress:
+    # Allow DNS resolution (matches baseline-dns-egress)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/kubernetes/platform/config/network-policy/shared-resources/access-garage-s3.yaml
+++ b/kubernetes/platform/config/network-policy/shared-resources/access-garage-s3.yaml
@@ -11,7 +11,7 @@ spec:
     Usage: Add label access.network-policy.homelab/garage-s3=true to namespace.
   endpointSelector:
     matchExpressions:
-      - key: io.cilium.k8s.namespace.labels.access\.network-policy\.homelab/garage-s3
+      - key: io.cilium.k8s.namespace.labels.access.network-policy.homelab/garage-s3
         operator: In
         values: ["true"]
   egress:

--- a/kubernetes/platform/config/network-policy/shared-resources/access-postgres.yaml
+++ b/kubernetes/platform/config/network-policy/shared-resources/access-postgres.yaml
@@ -11,7 +11,7 @@ spec:
     Usage: Add label access.network-policy.homelab/postgres=true to namespace.
   endpointSelector:
     matchExpressions:
-      - key: io.cilium.k8s.namespace.labels.access\.network-policy\.homelab/postgres
+      - key: io.cilium.k8s.namespace.labels.access.network-policy.homelab/postgres
         operator: In
         values: ["true"]
   egress:


### PR DESCRIPTION
## Summary

- Fixes cluster-wide DNS resolution failures caused by invalid Cilium network policies from PR #114
- Cilium 1.18+ rejects empty ingress/egress arrays (now requires explicit deny rules)
- Backslash-escaped dots in label keys fail RFC 1123 validation when Cilium prepends its namespace label prefix
- CoreDNS couldn't reach upstream DNS on Talos nodes; Hubble relay couldn't reach Cilium agents

## Test plan

- [ ] Deploy to dev cluster and verify all CCNPs/CNPs show `VALID: True`
- [ ] Confirm DNS resolution works (Flux kustomizations reconcile successfully)
- [ ] Verify Hubble relay becomes healthy
- [ ] Check no `PacketDrop (policy_denied)` events in kube-system

🤖 Generated with [Claude Code](https://claude.com/claude-code)