### PR TITLE
docs(k8s): add KUBECONFIG instruction to k8s-sre skill

### DIFF
--- a/.claude/skills/k8s-sre/SKILL.md
+++ b/.claude/skills/k8s-sre/SKILL.md
@@ -14,6 +14,11 @@ description: |
   "deployment not working", "helm install failed", "flux not reconciling"
 ---
 
+# ACCESSING CLUSTERS
+
+ALWAYS USE `export KUBECONFIG=~/kube/<cluster>.yaml && kubectl ...` WHEN EXECUTING KUBE COMMANDS TO CONNECT TO THE CLUSTER.
+
+
 # Debugging Kubernetes Incidents
 
 ## Core Principles


### PR DESCRIPTION
## Summary
- Adds explicit KUBECONFIG export instruction to k8s-sre skill to prevent operators from accidentally running commands against the wrong cluster

## Test plan
- [x] Verify skill documentation renders correctly
- [x] Confirm instruction is visible when k8s-sre skill is invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)