### PR TITLE
fix(k8s): add networkPolicy key to ResourceSet inputs

### DIFF
--- a/.claude/skills/k8s-sre/SKILL.md
+++ b/.claude/skills/k8s-sre/SKILL.md
@@ -130,6 +130,8 @@ Apply 5 Whys analysis. Validate:
 
 ### Phase 5: Remediation
 
+Use **AskUserQuestion** tool to present fix options when multiple valid approaches exist.
+
 Provide recommendations only (read-only investigation):
 - **Immediate**: Rollback, scale, restart
 - **Permanent**: Code/config fixes
@@ -212,6 +214,9 @@ Task tool:
 
 ❌ Investigate without confirming cluster
 ✅ ALWAYS confirm cluster before any kubectl command
+
+❌ Use `helm list` to check Helm release status
+✅ Use `kubectl get helmrelease -A` - Flux manages releases via CRDs, not Helm CLI
 
 ## Keywords
 

--- a/kubernetes/platform/namespaces.yaml
+++ b/kubernetes/platform/namespaces.yaml
@@ -12,39 +12,51 @@ spec:
     - name: cert-manager
       dataplane: ambient
       security: privileged
+      networkPolicy: null
     - name: external-secrets
       dataplane: ambient
       security: privileged
+      networkPolicy: null
     - name: kube-system
       dataplane: standard
       security: privileged
+      networkPolicy: null
     - name: longhorn-system
       dataplane: standard
       security: privileged
+      networkPolicy: null
     - name: istio-system
       dataplane: ambient
       security: privileged
+      networkPolicy: null
     - name: istio-gateway
       dataplane: ambient
       security: privileged
+      networkPolicy: null
     - name: monitoring
       dataplane: ambient
       security: privileged
+      networkPolicy: null
     - name: system
       dataplane: ambient
       security: privileged
+      networkPolicy: null
     - name: garage
       dataplane: ambient
       security: privileged
+      networkPolicy: null
     - name: database
       dataplane: ambient
       security: privileged
+      networkPolicy: null
     - name: kromgo
       dataplane: ambient
       security: privileged
+      networkPolicy: null
     - name: spegel
       dataplane: standard
       security: privileged
+      networkPolicy: null
   resourcesTemplate: |
     ---
     apiVersion: v1


### PR DESCRIPTION
## Summary
- Fixes `platform-namespaces` ResourceSet template failure caused by accessing undefined `networkPolicy` key
- Adds explicit `networkPolicy: null` to all namespace inputs, satisfying the template engine while preserving conditional logic
- Updates k8s-sre skill with Flux-specific debugging guidance (use `kubectl get helmrelease` not `helm list`)

## Test plan
- [x] `task k8s:validate` passes
- [x] Deploy to dev cluster and verify namespaces are created
- [x] Verify HelmReleases progress past "namespace not found" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)