### PR TITLE
feat(platform): add CloudNative-PG S3 backup and automatic recovery

### DIFF
--- a/infrastructure/modules/longhorn-storage/main.tf
+++ b/infrastructure/modules/longhorn-storage/main.tf
@@ -1,11 +1,14 @@
-# Longhorn backup storage infrastructure for all clusters
-# This module provisions S3 buckets, IAM users, and SSM parameters for each cluster.
+# Backup storage infrastructure for all clusters
+# This module provisions S3 buckets, IAM users, and SSM parameters for:
+# - Longhorn: Volume-level backups for stateful workloads
+# - CloudNative-PG (CNPG): PostgreSQL database backups via Barman
+#
 # Separated from cluster lifecycle so backups persist through cluster rebuilds.
-
+#
 # Note: No lifecycle expiration - Longhorn backups are incremental and share block
-# objects across backups. Age-based S3 expiration would delete blocks still
-# referenced by newer backups, corrupting them. Retention is managed by Longhorn's
-# RecurringJob `retain` field instead.
+# objects across backups. CNPG uses retentionPolicy for automatic pruning.
+# Age-based S3 expiration would delete blocks still referenced by newer backups,
+# corrupting them. Retention is managed by the applications themselves.
 
 # S3 buckets - one per cluster
 resource "aws_s3_bucket" "longhorn_backup" {
@@ -119,6 +122,128 @@ resource "aws_ssm_parameter" "secret_access_key" {
   tags = {
     managed-by = "opentofu"
     purpose    = "longhorn-backup"
+    cluster    = each.key
+  }
+}
+
+# =============================================================================
+# CloudNative-PG (CNPG) Backup Infrastructure
+# =============================================================================
+# PostgreSQL backups using Barman to S3. Enables automatic recovery on cluster
+# rebuild - CNPG's bootstrap.recovery will restore from latest backup if exists.
+
+# S3 buckets - one per cluster for CNPG
+resource "aws_s3_bucket" "cnpg_backup" {
+  for_each = var.clusters
+  bucket   = "homelab-cnpg-backup-${each.key}"
+
+  tags = {
+    managed-by = "opentofu"
+    purpose    = "cnpg-backup"
+    cluster    = each.key
+  }
+}
+
+resource "aws_s3_bucket_versioning" "cnpg_backup" {
+  for_each = var.clusters
+  bucket   = aws_s3_bucket.cnpg_backup[each.key].id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "cnpg_backup" {
+  for_each = var.clusters
+  bucket   = aws_s3_bucket.cnpg_backup[each.key].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "cnpg_backup" {
+  for_each = var.clusters
+  bucket   = aws_s3_bucket.cnpg_backup[each.key].id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# IAM users - one per cluster for isolated CNPG access
+resource "aws_iam_user" "cnpg_backup" {
+  for_each = var.clusters
+  name     = "cnpg-backup-${each.key}"
+
+  tags = {
+    managed-by = "opentofu"
+    purpose    = "cnpg-backup"
+    cluster    = each.key
+  }
+}
+
+resource "aws_iam_access_key" "cnpg_backup" {
+  for_each = var.clusters
+  user     = aws_iam_user.cnpg_backup[each.key].name
+}
+
+resource "aws_iam_user_policy" "cnpg_backup" {
+  for_each = var.clusters
+  name     = "cnpg-backup-${each.key}"
+  user     = aws_iam_user.cnpg_backup[each.key].name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "CNPGBackupAccess"
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:DeleteObject"
+        ]
+        Resource = [
+          aws_s3_bucket.cnpg_backup[each.key].arn,
+          "${aws_s3_bucket.cnpg_backup[each.key].arn}/*"
+        ]
+      }
+    ]
+  })
+}
+
+# SSM Parameters - store CNPG credentials at paths expected by Kubernetes ExternalSecrets
+resource "aws_ssm_parameter" "cnpg_access_key_id" {
+  for_each = var.clusters
+
+  name        = "/homelab/kubernetes/${each.key}/cnpg-s3-backup/access-key-id"
+  description = "AWS access key ID for CloudNative-PG S3 backup in cluster '${each.key}'."
+  type        = "SecureString"
+  value       = aws_iam_access_key.cnpg_backup[each.key].id
+
+  tags = {
+    managed-by = "opentofu"
+    purpose    = "cnpg-backup"
+    cluster    = each.key
+  }
+}
+
+resource "aws_ssm_parameter" "cnpg_secret_access_key" {
+  for_each = var.clusters
+
+  name        = "/homelab/kubernetes/${each.key}/cnpg-s3-backup/secret-access-key"
+  description = "AWS secret access key for CloudNative-PG S3 backup in cluster '${each.key}'."
+  type        = "SecureString"
+  value       = aws_iam_access_key.cnpg_backup[each.key].secret
+
+  tags = {
+    managed-by = "opentofu"
+    purpose    = "cnpg-backup"
     cluster    = each.key
   }
 }

--- a/kubernetes/platform/config/database/backup-secret.yaml
+++ b/kubernetes/platform/config/database/backup-secret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cnpg-s3-backup-credentials
+  namespace: database
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: cnpg-s3-backup-credentials
+  data:
+    - secretKey: ACCESS_KEY_ID
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/cnpg-s3-backup/access-key-id
+    - secretKey: ACCESS_SECRET_KEY
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/cnpg-s3-backup/secret-access-key

--- a/kubernetes/platform/config/database/cluster.yaml
+++ b/kubernetes/platform/config/database/cluster.yaml
@@ -27,6 +27,44 @@ spec:
     storageClass: fast
     size: ${database_volume_size}
 
+  # S3 backup via Barman - enables continuous WAL archiving and scheduled base backups
+  backup:
+    barmanObjectStore:
+      destinationPath: "s3://homelab-cnpg-backup-${cluster_name}@us-east-2/"
+      s3Credentials:
+        accessKeyId:
+          name: cnpg-s3-backup-credentials
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: cnpg-s3-backup-credentials
+          key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip
+        maxParallel: 4
+      retentionPolicy: "30d"
+
+  # Recovery source for disaster recovery - CNPG uses this on cluster creation
+  # to restore from the latest backup if one exists in S3
+  externalClusters:
+    - name: backup-source
+      barmanObjectStore:
+        destinationPath: "s3://homelab-cnpg-backup-${cluster_name}@us-east-2/"
+        s3Credentials:
+          accessKeyId:
+            name: cnpg-s3-backup-credentials
+            key: ACCESS_KEY_ID
+          secretAccessKey:
+            name: cnpg-s3-backup-credentials
+            key: ACCESS_SECRET_KEY
+        wal:
+          maxParallel: 4
+
+  # Bootstrap from recovery - restores from latest backup on cluster creation.
+  # If no backup exists, CNPG initializes a fresh database instead.
+  bootstrap:
+    recovery:
+      source: backup-source
+
   resources:
     requests:
       cpu: 100m

--- a/kubernetes/platform/config/database/kustomization.yaml
+++ b/kubernetes/platform/config/database/kustomization.yaml
@@ -4,6 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - superuser-secret.yaml
+  - backup-secret.yaml
   - cluster.yaml
+  - scheduled-backup.yaml
   - pooler.yaml
   - prometheus-rules.yaml

--- a/kubernetes/platform/config/database/scheduled-backup.yaml
+++ b/kubernetes/platform/config/database/scheduled-backup.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: platform-daily
+  namespace: database
+spec:
+  cluster:
+    name: platform
+  schedule: "0 2 * * *"
+  backupOwnerReference: self
+  immediate: true


### PR DESCRIPTION
## Summary

- Enables PostgreSQL disaster recovery by configuring CNPG's native Barman backup to S3
- Clusters automatically restore from latest backup on rebuild (bootstrap.recovery)
- Infrastructure provisions per-cluster S3 buckets with isolated IAM credentials

## Test plan

- [ ] Apply storage stack to create CNPG S3 buckets
- [ ] Deploy to dev cluster and verify backup starts
- [ ] Insert test data with UUID marker
- [ ] Destroy and rebuild dev cluster
- [ ] Verify data recovery via UUID query

🤖 Generated with [Claude Code](https://claude.com/claude-code)