### PR TITLE
fix(k8s): use correct namespaceSelector field in canary-checker

### DIFF
--- a/kubernetes/platform/config/canary-checker/platform-health.yaml
+++ b/kubernetes/platform/config/canary-checker/platform-health.yaml
@@ -28,8 +28,7 @@ spec:
     - name: flux-pods-healthy
       kind: Pod
       namespaceSelector:
-        matchNames:
-          - flux-system
+        name: flux-system
       resource:
         labelSelector: app.kubernetes.io/part-of=flux
       test:


### PR DESCRIPTION
## Summary
- Fixes canary-checker-config Kustomization failure on integration cluster
- Changes `namespaceSelector.matchNames` to `namespaceSelector.name`
- Canary-checker uses custom Resource Selector format, not Kubernetes-style label selectors

## Test plan
- [ ] Verify canary-checker-config Kustomization reconciles successfully
- [ ] Verify platform-validation Canary becomes healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)