### PR TITLE
fix(tasks): auto-install terragrunt version if missing

### DIFF
--- a/.taskfiles/terragrunt/taskfile.yaml
+++ b/.taskfiles/terragrunt/taskfile.yaml
@@ -11,8 +11,9 @@ env:
 
 tasks:
   use:
-    desc: Uses tgenv to set up the Terragrunt environment.
+    desc: Uses tgenv to set up the Terragrunt environment, installing if needed.
     cmds:
+      - tgenv install
       - tgenv use
     preconditions:
       - which tgenv


### PR DESCRIPTION
## Summary
- Adds `tgenv install` before `tgenv use` in the `tg:use` task
- `tgenv install` is idempotent - reads from `.terragrunt-version` and reports "already installed" if present
- Prevents task failures when required terragrunt version isn't locally installed

## Test plan
- [x] Verified with missing version - installs automatically
- [x] Verified with present version - reports "already installed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)