### PR TITLE
fix(infra): add missing config documents to talos unit mock outputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,20 @@ task tg:gen-dev                    # Generate dev stack
 task tg:clean-dev                  # Clean dev stack cache
 ```
 
+## AWS Credentials
+
+Infrastructure operations require AWS credentials for remote state and Parameter Store access:
+
+```bash
+export AWS_PROFILE=terragrunt
+export AWS_REGION=us-east-2
+```
+
+Verify credentials before running Terragrunt:
+```bash
+aws sts get-caller-identity
+```
+
 ## Pre-Flight Checks
 
 Before running infrastructure operations on dev, verify cluster readiness:

--- a/infrastructure/units/talos/terragrunt.hcl
+++ b/infrastructure/units/talos/terragrunt.hcl
@@ -23,20 +23,27 @@ dependency "config" {
       kubernetes_version = "1.34.0"
       talos_machines = [
         {
-          install = { selector = "disk.model = *" }
-          configs = [<<EOT
-cluster:
-  clusterName: talos.local
-  controlPlane:
-    endpoint: https://talos.local:6443
-machine:
-  type: controlplane
-  network:
-    hostname: mock-controlplane-1
-    interfaces:
-      - addresses:
-        - 10.10.10.10/24
-EOT
+          install = { selector = "disk.model = *", secureboot = false }
+          configs = [
+            <<-EOT
+            kind: HostnameConfig
+            hostname: mock-controlplane-1
+            EOT
+            ,
+            <<-EOT
+            kind: BondConfig
+            addresses:
+              - address: 10.10.10.10/24
+            EOT
+            ,
+            <<-EOT
+            cluster:
+              clusterName: talos.local
+              controlPlane:
+                endpoint: https://talos.local:6443
+            machine:
+              type: controlplane
+            EOT
           ]
         }
       ]


### PR DESCRIPTION
## Summary
- Fix talos unit mock outputs that caused `plan` to fail on fresh deployments
- The talos module parses configs by `kind` field (HostnameConfig, BondConfig) but mocks only had the main machine config
- Add AWS credentials documentation to CLAUDE.md for infrastructure operations

## Test plan
- [x] `task tg:validate-dev` passes (all 5 units succeed)
- [ ] CI validation passes