### PR TITLE
fix(k8s): use hardcoded paths in per-cluster resources

### DIFF
--- a/kubernetes/clusters/CLAUDE.md
+++ b/kubernetes/clusters/CLAUDE.md
@@ -55,11 +55,13 @@ metadata:
 spec:
   dependsOn:
     - name: platform  # Ensures CRDs exist
-  path: kubernetes/clusters/${cluster_name}/config
+  path: kubernetes/clusters/<cluster>/config  # Hardcoded per cluster
   sourceRef:
     kind: GitRepository  # or OCIRepository for integration/live
     name: flux-system
 ```
+
+**Note**: The `path` field must be hardcoded per cluster - Flux variable substitution only applies to resources *inside* the path, not to the Kustomization spec itself.
 
 **Adding cluster-specific config:**
 1. Create subdirectory in `config/` (e.g., `config/silences/`)

--- a/kubernetes/clusters/dev/config.yaml
+++ b/kubernetes/clusters/dev/config.yaml
@@ -8,7 +8,7 @@ spec:
   dependsOn:
     - name: platform
   interval: 10m
-  path: kubernetes/clusters/${cluster_name}/config
+  path: kubernetes/clusters/dev/config
   postBuild:
     substituteFrom:
       - kind: ConfigMap

--- a/kubernetes/clusters/dev/helm-charts.yaml
+++ b/kubernetes/clusters/dev/helm-charts.yaml
@@ -84,7 +84,7 @@ spec:
       <<- end >>
       <<- end >>
       interval: 10m
-      path: kubernetes/clusters/${cluster_name}/stubs/empty
+      path: kubernetes/clusters/dev/stubs/empty
       prune: false
       sourceRef:
         kind: GitRepository

--- a/kubernetes/clusters/integration/config.yaml
+++ b/kubernetes/clusters/integration/config.yaml
@@ -8,14 +8,14 @@ spec:
   dependsOn:
     - name: platform
   interval: 10m
-  path: kubernetes/clusters/${cluster_name}/config
+  path: kubernetes/clusters/integration/config
   postBuild:
     substituteFrom:
       - kind: ConfigMap
         name: cluster-vars
         optional: false
       - kind: ConfigMap
-        name: versions
+        name: platform-versions
         optional: true
   prune: true
   sourceRef:

--- a/kubernetes/clusters/integration/helm-charts.yaml
+++ b/kubernetes/clusters/integration/helm-charts.yaml
@@ -84,7 +84,7 @@ spec:
       <<- end >>
       <<- end >>
       interval: 10m
-      path: kubernetes/clusters/${cluster_name}/stubs/empty
+      path: kubernetes/clusters/integration/stubs/empty
       prune: false
       sourceRef:
         kind: OCIRepository

--- a/kubernetes/clusters/live/config.yaml
+++ b/kubernetes/clusters/live/config.yaml
@@ -8,14 +8,14 @@ spec:
   dependsOn:
     - name: platform
   interval: 10m
-  path: kubernetes/clusters/${cluster_name}/config
+  path: kubernetes/clusters/live/config
   postBuild:
     substituteFrom:
       - kind: ConfigMap
         name: cluster-vars
         optional: false
       - kind: ConfigMap
-        name: versions
+        name: platform-versions
         optional: true
   prune: true
   sourceRef:

--- a/kubernetes/clusters/live/helm-charts.yaml
+++ b/kubernetes/clusters/live/helm-charts.yaml
@@ -84,7 +84,7 @@ spec:
       <<- end >>
       <<- end >>
       interval: 10m
-      path: kubernetes/clusters/${cluster_name}/stubs/empty
+      path: kubernetes/clusters/live/stubs/empty
       prune: false
       sourceRef:
         kind: OCIRepository


### PR DESCRIPTION
## Summary

- Fixes cluster-config Kustomization failing with `path not found: kubernetes/clusters/${cluster_name}/config`
- Flux `postBuild.substituteFrom` only applies to resources *inside* the reconciled path, not to the Kustomization spec itself
- Hardcodes paths per cluster instead of using variable substitution
- Also fixes integration/live to use `platform-versions` ConfigMap consistently

## Test plan

- [x] `task k8s:validate` passes (verified locally)
- [ ] After merge, verify on dev cluster:
  - `flux get kustomization cluster-config` shows Ready
  - `kubectl get silence -n monitoring spegel-single-node` exists
- [ ] Verify on integration cluster that cluster-config reconciles

🤖 Generated with [Claude Code](https://claude.com/claude-code)