### PR TITLE
feat(docs): add /deploy-app skill for end-to-end application deployment

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,7 @@
       "Bash(task inv:status-*:*)",
       "Bash(task wt:*:*)",
       "Bash(task renovate:validate:*)",
+      "Bash(task k8s:validate:*)",
 
       "Bash(git status:*)",
       "Bash(git diff:*)",
@@ -38,6 +39,8 @@
       "Bash(kubectl config:*)",
       "Bash(kubectl explain:*)",
       "Bash(kubectl top:*)",
+      "Bash(kubectl wait:*)",
+      "Bash(kubectl port-forward:*)",
 
       "Bash(flux get:*)",
       "Bash(flux logs:*)",
@@ -47,10 +50,14 @@
       "Bash(helm repo:*)",
       "Bash(helm search:*)",
       "Bash(helm show:*)",
+      "Bash(helm install:*)",
+      "Bash(helm uninstall:*)",
+      "Bash(helm template:*)",
 
       "Bash(kustomize build:*)",
       "Bash(yq:*)",
       "Bash(jq:*)",
+      "Bash(curl:*)",
 
       "Bash(gh issue:*)",
       "Bash(gh pr:*)",
@@ -70,6 +77,7 @@
       "WebFetch(domain:gateway-api.sigs.k8s.io)",
       "WebFetch(domain:kubernetes.io)",
       "WebFetch(domain:fluxcd.io)",
+      "WebFetch(domain:grafana.com)",
 
       "Skill(kubesearch)",
       "Skill(terragrunt)",
@@ -79,7 +87,8 @@
       "Skill(taskfiles)",
       "Skill(opentofu-modules)",
       "Skill(gha-pipelines)",
-      "Skill(k8s-manifest-generator)"
+      "Skill(k8s-manifest-generator)",
+      "Skill(deploy-app)"
     ]
   },
   "outputStyle": "Explanatory",

--- a/.claude/skills/deploy-app/SKILL.md
+++ b/.claude/skills/deploy-app/SKILL.md
@@ -1,0 +1,540 @@
+---
+name: deploy-app
+description: |
+  End-to-end application deployment orchestration for the Kubernetes homelab.
+
+  Use when: (1) Deploying a new application to the cluster, (2) Adding a new Helm release to the platform,
+  (3) Setting up monitoring, alerting, and health checks for a new service, (4) Research before deploying,
+  (5) Testing deployment on dev cluster before GitOps promotion.
+
+  Triggers: "deploy app", "add new application", "deploy to kubernetes", "install helm chart",
+  "/deploy-app", "set up new service", "add monitoring for", "deploy with monitoring"
+user_invocable: true
+---
+
+# Deploy App Workflow
+
+End-to-end orchestration for deploying applications to the Kubernetes homelab with full monitoring integration.
+
+## Workflow Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                      /deploy-app Workflow                           │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  1. RESEARCH                                                        │
+│     ├─ Invoke kubesearch skill for real-world patterns              │
+│     ├─ Check if native Helm chart exists (helm search hub)          │
+│     ├─ Determine: native chart vs app-template                      │
+│     └─ AskUserQuestion: Present findings, confirm approach          │
+│                                                                      │
+│  2. SETUP                                                           │
+│     └─ task wt:new -- deploy-<app-name>                             │
+│        (Creates isolated worktree + branch)                         │
+│                                                                      │
+│  3. CONFIGURE (in worktree)                                         │
+│     ├─ kubernetes/platform/versions.env (add version)               │
+│     ├─ kubernetes/platform/namespaces.yaml (add namespace)          │
+│     ├─ kubernetes/platform/helm-charts.yaml (add input)             │
+│     ├─ kubernetes/platform/charts/<app>.yaml (create values)        │
+│     ├─ kubernetes/platform/kustomization.yaml (register)            │
+│     ├─ .github/renovate.json5 (add manager)                         │
+│     └─ kubernetes/platform/config/<app>/ (optional extras)          │
+│        ├─ route.yaml (HTTPRoute if exposed)                         │
+│        ├─ canary.yaml (health checks)                               │
+│        ├─ prometheus-rules.yaml (custom alerts)                     │
+│        └─ dashboard.yaml (Grafana ConfigMap)                        │
+│                                                                      │
+│  4. VALIDATE                                                        │
+│     ├─ task k8s:validate                                            │
+│     └─ task renovate:validate                                       │
+│                                                                      │
+│  5. TEST ON DEV (bypass Flux)                                       │
+│     ├─ helm install directly to dev cluster                         │
+│     ├─ Wait for pods ready (kubectl wait)                           │
+│     ├─ Verify ServiceMonitor discovered (Prometheus API)            │
+│     ├─ Verify no new alerts firing                                  │
+│     ├─ Verify canary passing (if created)                           │
+│     └─ AskUserQuestion: Report status, confirm proceed              │
+│                                                                      │
+│  6. CLEANUP & PR                                                    │
+│     ├─ helm uninstall from dev                                      │
+│     ├─ git commit (conventional commit format)                      │
+│     ├─ git push + gh pr create                                      │
+│     └─ Report PR URL to user                                        │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Phase 1: Research
+
+### 1.1 Search Kubesearch for Real-World Examples
+
+Invoke the kubesearch skill to find how other homelabs configure this chart:
+
+```
+/kubesearch <chart-name>
+```
+
+This provides:
+- Common configuration patterns
+- Values.yaml examples from production homelabs
+- Gotchas and best practices
+
+### 1.2 Check for Native Helm Chart
+
+```bash
+helm search hub <app-name> --max-col-width=100
+```
+
+Decision matrix:
+
+| Scenario | Approach |
+|----------|----------|
+| Official/community chart exists | Use native Helm chart |
+| Only container image available | Use app-template |
+| Chart is unmaintained (>1 year) | Consider app-template |
+| User preference for app-template | Use app-template |
+
+### 1.3 User Confirmation
+
+Use AskUserQuestion to present findings and confirm:
+
+- Chart selection (native vs app-template)
+- Exposure type: internal, external, or none
+- Namespace selection (new or existing)
+- Persistence requirements
+
+---
+
+## Phase 2: Setup
+
+### 2.1 Create Worktree
+
+All deployment work happens in an isolated worktree:
+
+```bash
+task wt:new -- deploy-<app-name>
+```
+
+This creates:
+- Branch: `deploy-<app-name>`
+- Worktree: `../homelab-deploy-<app-name>/`
+
+### 2.2 Change to Worktree
+
+```bash
+cd ../homelab-deploy-<app-name>
+```
+
+All subsequent file operations happen in the worktree.
+
+---
+
+## Phase 3: Configure
+
+### 3.1 Add Version to versions.env
+
+```bash
+# kubernetes/platform/versions.env
+<APP>_VERSION="x.y.z"
+```
+
+### 3.2 Add Namespace to namespaces.yaml
+
+Add to `kubernetes/platform/namespaces.yaml` inputs array:
+
+```yaml
+- name: <namespace>
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+```
+
+### 3.3 Add to helm-charts.yaml
+
+Add to `kubernetes/platform/helm-charts.yaml` inputs array:
+
+```yaml
+- name: "<app-name>"
+  namespace: "<namespace>"
+  chart:
+    name: "<chart-name>"
+    version: "${<APP>_VERSION}"
+    url: "https://charts.example.com"  # or oci://registry.io/path
+  dependsOn: [cilium]  # Adjust based on dependencies
+```
+
+For OCI registries:
+```yaml
+    url: "oci://ghcr.io/org/helm"
+```
+
+### 3.4 Create Values File
+
+Create `kubernetes/platform/charts/<app-name>.yaml`:
+
+```yaml
+# yaml-language-server: $schema=<schema-url-if-available>
+---
+# Helm values for <app-name>
+# Based on kubesearch research and best practices
+
+# Enable monitoring
+serviceMonitor:
+  enabled: true
+
+# Use internal domain for ingress
+ingress:
+  enabled: true
+  hosts:
+    - host: <app-name>.${internal_domain}
+```
+
+See [references/file-templates.md](references/file-templates.md) for complete templates.
+
+### 3.5 Register in kustomization.yaml
+
+Add to `kubernetes/platform/kustomization.yaml` configMapGenerator:
+
+```yaml
+configMapGenerator:
+  - name: platform-values
+    files:
+      # ... existing
+      - charts/<app-name>.yaml
+```
+
+### 3.6 Add Renovate Manager
+
+Add to `.github/renovate.json5` customManagers:
+
+```json5
+{
+  customType: "regex",
+  fileMatch: ["kubernetes/platform/versions\\.env$"],
+  matchStrings: ["<APP>_VERSION=\"(?<currentValue>[^\"]+)\""],
+  depNameTemplate: "<chart-name>",
+  packageNameTemplate: "<registry-path>",
+  datasourceTemplate: "helm"  // or "docker" for OCI
+}
+```
+
+### 3.7 Optional: Additional Configuration
+
+For apps that need extra resources, create `kubernetes/platform/config/<app-name>/`:
+
+#### HTTPRoute (for exposed apps)
+
+```yaml
+# config/<app-name>/route.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: <app-name>
+spec:
+  parentRefs:
+    - name: internal-gateway
+      namespace: gateway
+  hostnames:
+    - <app-name>.${internal_domain}
+  rules:
+    - backendRefs:
+        - name: <app-name>
+          port: 80
+```
+
+#### Canary Health Check
+
+```yaml
+# config/<app-name>/canary.yaml
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: http-check-<app-name>
+spec:
+  schedule: "@every 1m"
+  http:
+    - name: <app-name>-health
+      url: https://<app-name>.${internal_domain}/health
+      responseCodes: [200]
+      maxSSLExpiry: 7
+```
+
+#### PrometheusRule (custom alerts)
+
+Only create if the chart doesn't include its own alerts:
+
+```yaml
+# config/<app-name>/prometheus-rules.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: <app-name>-alerts
+spec:
+  groups:
+    - name: <app-name>.rules
+      rules:
+        - alert: <AppName>Down
+          expr: up{job="<app-name>"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "<app-name> is down"
+```
+
+#### Grafana Dashboard
+
+1. Search grafana.com for community dashboards
+2. Add via gnetId in grafana values, OR
+3. Create ConfigMap:
+
+```yaml
+# config/<app-name>/dashboard.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-<app-name>
+  labels:
+    grafana_dashboard: "true"
+  annotations:
+    grafana_folder: "Applications"
+data:
+  <app-name>.json: |
+    { ... dashboard JSON ... }
+```
+
+See [references/monitoring-patterns.md](references/monitoring-patterns.md) for detailed examples.
+
+---
+
+## Phase 4: Validate
+
+### 4.1 Kubernetes Validation
+
+```bash
+task k8s:validate
+```
+
+This runs:
+- kustomize build
+- kubeconform schema validation
+- yamllint checks
+
+### 4.2 Renovate Validation
+
+```bash
+task renovate:validate
+```
+
+Fix any errors before proceeding.
+
+---
+
+## Phase 5: Test on Dev
+
+### 5.1 Direct Helm Install
+
+Bypass Flux to test immediately on dev cluster:
+
+```bash
+# Get values from rendered kustomization
+KUBECONFIG=~/.kube/dev.yaml helm install <app-name> <repo>/<chart> \
+  -n <namespace> --create-namespace \
+  -f kubernetes/platform/charts/<app-name>.yaml \
+  --version <version>
+```
+
+For OCI charts:
+```bash
+KUBECONFIG=~/.kube/dev.yaml helm install <app-name> oci://registry/<path>/<chart> \
+  -n <namespace> --create-namespace \
+  -f kubernetes/platform/charts/<app-name>.yaml \
+  --version <version>
+```
+
+### 5.2 Wait for Pods
+
+```bash
+KUBECONFIG=~/.kube/dev.yaml kubectl -n <namespace> \
+  wait --for=condition=Ready pod -l app.kubernetes.io/name=<app-name> --timeout=300s
+```
+
+### 5.3 Verify Monitoring
+
+Use the helper scripts:
+
+```bash
+# Check deployment health
+.claude/skills/deploy-app/scripts/check-deployment-health.sh <namespace> <app-name>
+
+# Check ServiceMonitor discovery (requires port-forward)
+.claude/skills/deploy-app/scripts/check-servicemonitor.sh <app-name>
+
+# Check no new alerts
+.claude/skills/deploy-app/scripts/check-alerts.sh
+
+# Check canary status (if created)
+.claude/skills/deploy-app/scripts/check-canary.sh <app-name>
+```
+
+### 5.4 User Confirmation
+
+Use AskUserQuestion to report:
+- Pod status (Ready/NotReady)
+- ServiceMonitor discovery status
+- Alert status
+- Canary status (if applicable)
+
+Ask whether to proceed with PR creation.
+
+---
+
+## Phase 6: Cleanup & PR
+
+### 6.1 Uninstall from Dev
+
+```bash
+KUBECONFIG=~/.kube/dev.yaml helm uninstall <app-name> -n <namespace>
+```
+
+### 6.2 Commit Changes
+
+```bash
+git add -A
+git commit -m "feat(k8s): deploy <app-name> to platform
+
+- Add <app-name> HelmRelease via ResourceSet
+- Configure monitoring (ServiceMonitor, alerts)
+- Add Renovate manager for version updates
+$([ -f kubernetes/platform/config/<app-name>/canary.yaml ] && echo "- Add canary health checks")
+$([ -f kubernetes/platform/config/<app-name>/route.yaml ] && echo "- Configure HTTPRoute for ingress")"
+```
+
+### 6.3 Push and Create PR
+
+```bash
+git push -u origin deploy-<app-name>
+
+gh pr create --title "feat(k8s): deploy <app-name>" --body "$(cat <<'EOF'
+## Summary
+- Deploy <app-name> to the Kubernetes platform
+- Full monitoring integration (ServiceMonitor + alerts)
+- Automated version updates via Renovate
+
+## Test plan
+- [ ] Validated with `task k8s:validate`
+- [ ] Tested on dev cluster with direct helm install
+- [ ] ServiceMonitor targets discovered by Prometheus
+- [ ] No new alerts firing
+- [ ] Canary health checks passing (if applicable)
+
+Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### 6.4 Report PR URL
+
+Output the PR URL for the user.
+
+**Note**: The worktree is intentionally kept until PR is merged. User cleans up with:
+```bash
+task wt:remove -- deploy-<app-name>
+```
+
+---
+
+## Secrets Handling
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                      Secrets Decision Tree                          │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  App needs a secret?                                                │
+│      │                                                              │
+│      ├─ Random/generated (password, API key, encryption key)        │
+│      │   └─ Use secret-generator annotation:                        │
+│      │      secret-generator.v1.mittwald.de/autogenerate: "key"     │
+│      │                                                              │
+│      ├─ External service (OAuth, third-party API)                   │
+│      │   └─ Create ExternalSecret → AWS SSM                         │
+│      │      Instruct user to add secret to Parameter Store          │
+│      │                                                              │
+│      └─ Unclear which type?                                         │
+│          └─ AskUserQuestion: "Can this be randomly generated?"      │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Auto-Generated Secrets
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <app-name>-secret
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: "password,api-key"
+type: Opaque
+```
+
+### External Secrets
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: <app-name>-secret
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-parameter-store
+  target:
+    name: <app-name>-secret
+  data:
+    - secretKey: api-token
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/<app-name>/api-token
+```
+
+---
+
+## Error Handling
+
+| Error | Response |
+|-------|----------|
+| No chart found | Suggest app-template, ask user |
+| Validation fails | Show error, fix, retry |
+| CrashLoopBackOff | Show logs, propose fix, ask user |
+| Alerts firing | Show alerts, determine if related, ask user |
+| Namespace exists | Ask user: reuse or new name |
+| Secret needed | Apply decision tree above |
+| Port-forward fails | Check if Prometheus is running in dev |
+
+---
+
+## User Interaction Points
+
+| Phase | Interaction | Purpose |
+|-------|-------------|---------|
+| Research | AskUserQuestion | Present kubesearch findings, confirm chart choice |
+| Research | AskUserQuestion | Native helm vs app-template decision |
+| Research | AskUserQuestion | Exposure type (internal/external/none) |
+| Dev Test | AskUserQuestion | Report test results, confirm PR creation |
+| Failure | AskUserQuestion | Report error, propose fix, ask to retry |
+
+---
+
+## References
+
+- [File Templates](references/file-templates.md) - Copy-paste templates for all config files
+- [Monitoring Patterns](references/monitoring-patterns.md) - ServiceMonitor, PrometheusRule, Canary examples
+- [flux-gitops skill](../flux-gitops/SKILL.md) - ResourceSet patterns
+- [app-template skill](../app-template/SKILL.md) - For apps without native charts
+- [kubesearch skill](../kubesearch/SKILL.md) - Research workflow

--- a/.claude/skills/deploy-app/references/file-templates.md
+++ b/.claude/skills/deploy-app/references/file-templates.md
@@ -1,0 +1,299 @@
+# File Templates for Application Deployment
+
+Copy-paste templates for all configuration files needed when deploying a new application.
+
+## versions.env Entry
+
+```bash
+# kubernetes/platform/versions.env
+# Add version variable (use SCREAMING_SNAKE_CASE)
+<APP_NAME>_VERSION="x.y.z"
+```
+
+## namespaces.yaml Entry
+
+```yaml
+# kubernetes/platform/namespaces.yaml - add to inputs array
+- name: <namespace>
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+```
+
+For apps requiring elevated privileges:
+```yaml
+- name: <namespace>
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+```
+
+## helm-charts.yaml Entry
+
+### Standard Helm Repository
+
+```yaml
+# kubernetes/platform/helm-charts.yaml - add to inputs array
+- name: "<app-name>"
+  namespace: "<namespace>"
+  chart:
+    name: "<chart-name>"
+    version: "${<APP_NAME>_VERSION}"
+    url: "https://charts.example.com"
+  dependsOn: [cilium]
+```
+
+### OCI Registry (GHCR, etc.)
+
+```yaml
+- name: "<app-name>"
+  namespace: "<namespace>"
+  chart:
+    name: "<chart-name>"
+    version: "${<APP_NAME>_VERSION}"
+    url: "oci://ghcr.io/<org>/helm"
+  dependsOn: [cilium]
+```
+
+### With Multiple Dependencies
+
+```yaml
+- name: "<app-name>"
+  namespace: "<namespace>"
+  chart:
+    name: "<chart-name>"
+    version: "${<APP_NAME>_VERSION}"
+    url: "https://charts.example.com"
+  dependsOn:
+    - cilium
+    - kube-prometheus-stack   # For apps needing monitoring CRDs
+    - external-secrets        # For apps using ExternalSecret
+```
+
+## Values File (charts/<app-name>.yaml)
+
+### Minimal Template
+
+```yaml
+# yaml-language-server: $schema=<schema-url>
+# kubernetes/platform/charts/<app-name>.yaml
+---
+# See kubesearch.dev for real-world examples
+```
+
+### With ServiceMonitor
+
+```yaml
+# yaml-language-server: $schema=<schema-url>
+---
+# Enable Prometheus scraping
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 10s
+
+# Alternative naming conventions (check chart docs)
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+```
+
+### With Ingress (HTTPRoute preferred)
+
+```yaml
+# yaml-language-server: $schema=<schema-url>
+---
+# Disable chart-native ingress (use HTTPRoute instead)
+ingress:
+  enabled: false
+
+# If chart requires ingress config for URL generation
+ingress:
+  enabled: false
+  hosts:
+    - host: <app-name>.${internal_domain}
+```
+
+### With Persistence
+
+```yaml
+# yaml-language-server: $schema=<schema-url>
+---
+persistence:
+  enabled: true
+  storageClass: longhorn
+  size: 1Gi
+  accessMode: ReadWriteOnce
+```
+
+### With Resource Limits
+
+```yaml
+# yaml-language-server: $schema=<schema-url>
+---
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    memory: 512Mi
+    # Note: CPU limits often cause throttling, avoid unless necessary
+```
+
+## kustomization.yaml Entry
+
+```yaml
+# kubernetes/platform/kustomization.yaml - add to configMapGenerator files
+configMapGenerator:
+  - name: platform-values
+    files:
+      # ... existing entries
+      - charts/<app-name>.yaml
+```
+
+## Renovate Manager (.github/renovate.json5)
+
+### Helm Chart Version
+
+```json5
+// .github/renovate.json5 - add to customManagers array
+{
+  customType: "regex",
+  fileMatch: ["kubernetes/platform/versions\\.env$"],
+  matchStrings: ["<APP_NAME>_VERSION=\"(?<currentValue>[^\"]+)\""],
+  depNameTemplate: "<chart-name>",
+  packageNameTemplate: "<registry-url>/<chart-path>",
+  datasourceTemplate: "helm"
+}
+```
+
+### OCI/Docker Image Version
+
+```json5
+{
+  customType: "regex",
+  fileMatch: ["kubernetes/platform/versions\\.env$"],
+  matchStrings: ["<APP_NAME>_VERSION=\"(?<currentValue>[^\"]+)\""],
+  depNameTemplate: "<image-name>",
+  packageNameTemplate: "<registry>/<org>/<image>",
+  datasourceTemplate: "docker"
+}
+```
+
+---
+
+## Optional: Config Directory Resources
+
+### HTTPRoute (config/<app-name>/route.yaml)
+
+```yaml
+# kubernetes/platform/config/<app-name>/route.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: <app-name>
+spec:
+  parentRefs:
+    - name: internal-gateway
+      namespace: gateway
+  hostnames:
+    - <app-name>.${internal_domain}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: <app-name>
+          port: 80
+```
+
+### External HTTPRoute
+
+```yaml
+# kubernetes/platform/config/<app-name>/route.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: <app-name>
+spec:
+  parentRefs:
+    - name: external-gateway
+      namespace: gateway
+  hostnames:
+    - <app-name>.${external_domain}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: <app-name>
+          port: 80
+```
+
+### Auto-Generated Secret
+
+```yaml
+# kubernetes/platform/config/<app-name>/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <app-name>-secret
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: "password,api-key,encryption-key"
+type: Opaque
+```
+
+### ExternalSecret
+
+```yaml
+# kubernetes/platform/config/<app-name>/external-secret.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: <app-name>-secret
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-parameter-store
+  target:
+    name: <app-name>-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: api-token
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/<app-name>/api-token
+```
+
+### Kustomization for Config Directory
+
+```yaml
+# kubernetes/platform/config/<app-name>/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: <namespace>
+resources:
+  - route.yaml
+  # - secret.yaml
+  # - external-secret.yaml
+  # - canary.yaml
+  # - prometheus-rules.yaml
+```
+
+---
+
+## Quick Reference: Common Chart Value Patterns
+
+| Feature | Common Keys |
+|---------|-------------|
+| ServiceMonitor | `serviceMonitor.enabled`, `metrics.serviceMonitor.enabled`, `prometheus.serviceMonitor.enabled` |
+| Persistence | `persistence.enabled`, `storage.enabled`, `data.persistence.enabled` |
+| Ingress | `ingress.enabled`, `server.ingress.enabled` |
+| Resources | `resources`, `server.resources`, `controller.resources` |
+| Replicas | `replicaCount`, `replicas`, `server.replicas` |
+| Image | `image.repository`, `image.tag`, `controller.image.repository` |
+| Secrets | `secretName`, `existingSecret`, `auth.existingSecret` |
+
+Always check the specific chart's values.yaml or use `helm show values <chart>` for exact keys.

--- a/.claude/skills/deploy-app/references/monitoring-patterns.md
+++ b/.claude/skills/deploy-app/references/monitoring-patterns.md
@@ -1,0 +1,352 @@
+# Monitoring Patterns for Application Deployment
+
+Templates and best practices for ServiceMonitor, PrometheusRule, Canary, and Grafana dashboards.
+
+---
+
+## ServiceMonitor
+
+Most Helm charts support ServiceMonitor creation via values. Enable it in the chart values:
+
+### Via Helm Values (Preferred)
+
+```yaml
+# kubernetes/platform/charts/<app-name>.yaml
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 10s
+  # Optional: additional labels for Prometheus selector
+  labels: {}
+```
+
+Alternative patterns (check chart docs):
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+
+# or
+prometheus:
+  serviceMonitor:
+    enabled: true
+```
+
+### Manual ServiceMonitor (if chart doesn't support)
+
+```yaml
+# kubernetes/platform/config/<app-name>/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: <app-name>
+  labels:
+    release: kube-prometheus-stack  # Must match Prometheus selector
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: <app-name>
+  namespaceSelector:
+    matchNames:
+      - <namespace>
+  endpoints:
+    - port: metrics  # Must match service port name
+      interval: 30s
+      scrapeTimeout: 10s
+      path: /metrics
+```
+
+### Verify ServiceMonitor Discovery
+
+```bash
+# After deployment, verify Prometheus is scraping
+kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090 &
+
+# Check targets
+curl -s "http://localhost:9090/api/v1/targets" | \
+  jq '.data.activeTargets[] | select(.labels.job | contains("<app-name>"))'
+```
+
+---
+
+## PrometheusRule (Custom Alerts)
+
+Only create custom alerts if the chart doesn't include its own. Most kube-prometheus-stack compatible charts include sensible defaults.
+
+### Basic Application Alert
+
+```yaml
+# kubernetes/platform/config/<app-name>/prometheus-rules.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: <app-name>-alerts
+  labels:
+    release: kube-prometheus-stack  # Must match Prometheus selector
+spec:
+  groups:
+    - name: <app-name>.rules
+      rules:
+        # Application Down Alert
+        - alert: <AppName>Down
+          expr: up{job="<app-name>"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "<app-name> is down"
+            description: "{{ $labels.instance }} has been down for more than 5 minutes."
+            runbook_url: "https://docs.example.com/runbooks/<app-name>"
+```
+
+### Request Latency Alert
+
+```yaml
+        # High Latency Alert
+        - alert: <AppName>HighLatency
+          expr: |
+            histogram_quantile(0.99,
+              sum(rate(http_request_duration_seconds_bucket{job="<app-name>"}[5m])) by (le)
+            ) > 1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "<app-name> experiencing high latency"
+            description: "P99 latency is {{ $value | humanizeDuration }} (threshold: 1s)"
+```
+
+### Error Rate Alert
+
+```yaml
+        # High Error Rate Alert
+        - alert: <AppName>HighErrorRate
+          expr: |
+            sum(rate(http_requests_total{job="<app-name>",status=~"5.."}[5m]))
+            /
+            sum(rate(http_requests_total{job="<app-name>"}[5m]))
+            > 0.05
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "<app-name> high error rate"
+            description: "Error rate is {{ $value | humanizePercentage }}"
+```
+
+### PVC Space Alert
+
+```yaml
+        # Persistent Volume Running Low
+        - alert: <AppName>PVCLow
+          expr: |
+            kubelet_volume_stats_available_bytes{persistentvolumeclaim=~".*<app-name>.*"}
+            /
+            kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~".*<app-name>.*"}
+            < 0.15
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "<app-name> PVC running low on space"
+            description: "PVC {{ $labels.persistentvolumeclaim }} has {{ $value | humanizePercentage }} free"
+```
+
+---
+
+## Canary Health Checks
+
+Canary resources provide synthetic monitoring via Flanksource canary-checker.
+
+### HTTP Health Check
+
+```yaml
+# kubernetes/platform/config/<app-name>/canary.yaml
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: http-check-<app-name>
+spec:
+  schedule: "@every 1m"
+  http:
+    - name: <app-name>-health
+      url: https://<app-name>.${internal_domain}/health
+      responseCodes: [200]
+      maxSSLExpiry: 7
+      # Optional: response body check
+      responseContent:
+        content: '"status":"healthy"'
+```
+
+### HTTP with Authentication
+
+```yaml
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: http-check-<app-name>
+spec:
+  schedule: "@every 1m"
+  http:
+    - name: <app-name>-health
+      url: https://<app-name>.${internal_domain}/api/health
+      responseCodes: [200]
+      headers:
+        - name: Authorization
+          valueFrom:
+            secretKeyRef:
+              name: <app-name>-canary-token
+              key: token
+```
+
+### TCP Port Check
+
+```yaml
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: tcp-check-<app-name>
+spec:
+  schedule: "@every 1m"
+  tcp:
+    - name: <app-name>-port
+      host: <app-name>.<namespace>.svc.cluster.local
+      port: 8080
+      timeout: 5000
+```
+
+### Multiple Endpoints
+
+```yaml
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: http-check-<app-name>
+spec:
+  schedule: "@every 1m"
+  http:
+    - name: <app-name>-health
+      url: https://<app-name>.${internal_domain}/health
+      responseCodes: [200]
+    - name: <app-name>-ready
+      url: https://<app-name>.${internal_domain}/ready
+      responseCodes: [200]
+    - name: <app-name>-metrics
+      url: http://<app-name>.<namespace>.svc.cluster.local:9090/metrics
+      responseCodes: [200]
+```
+
+---
+
+## Grafana Dashboards
+
+### Strategy 1: Search grafana.com (Recommended)
+
+1. Search for community dashboards: https://grafana.com/grafana/dashboards/?search=<app>
+2. Note the dashboard ID (gnetId)
+3. Add to Grafana values:
+
+```yaml
+# kubernetes/platform/charts/grafana.yaml (or kube-prometheus-stack.yaml)
+grafana:
+  dashboards:
+    default:
+      <app-name>:
+        gnetId: 12345
+        revision: 1
+        datasource: Prometheus
+```
+
+### Strategy 2: ConfigMap Dashboard
+
+If no community dashboard exists or customization needed:
+
+```yaml
+# kubernetes/platform/config/<app-name>/dashboard.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-<app-name>
+  labels:
+    grafana_dashboard: "true"
+  annotations:
+    grafana_folder: "Applications"
+data:
+  <app-name>.json: |
+    {
+      "annotations": { "list": [] },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": { "unit": "short" }
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+          "id": 1,
+          "options": {},
+          "targets": [
+            {
+              "expr": "up{job=\"<app-name>\"}",
+              "legendFormat": "{{ instance }}"
+            }
+          ],
+          "title": "<app-name> Up Status",
+          "type": "stat"
+        }
+      ],
+      "schemaVersion": 38,
+      "style": "dark",
+      "tags": ["<app-name>"],
+      "templating": { "list": [] },
+      "time": { "from": "now-1h", "to": "now" },
+      "title": "<App Name>",
+      "uid": "<app-name>-dashboard"
+    }
+```
+
+### Strategy 3: Chart-Included Dashboard
+
+Many charts include dashboards that can be enabled:
+
+```yaml
+# kubernetes/platform/charts/<app-name>.yaml
+grafana:
+  enabled: true
+  # or
+dashboards:
+  enabled: true
+  # or
+metrics:
+  dashboards:
+    enabled: true
+```
+
+---
+
+## Quick Reference: Common Metrics
+
+| App Type | Common Metrics |
+|----------|---------------|
+| HTTP Service | `http_requests_total`, `http_request_duration_seconds`, `http_request_size_bytes` |
+| Database | `<db>_up`, `<db>_connections`, `<db>_queries_total`, `<db>_query_duration_seconds` |
+| Queue | `<queue>_messages_total`, `<queue>_consumers`, `<queue>_lag` |
+| Cache | `<cache>_hits_total`, `<cache>_misses_total`, `<cache>_memory_bytes` |
+
+---
+
+## Monitoring Checklist
+
+Before marking deployment complete, verify:
+
+- [ ] ServiceMonitor created and targets discovered in Prometheus
+- [ ] No new alerts firing (check baseline comparison)
+- [ ] Grafana dashboard accessible (if added)
+- [ ] Canary health checks passing (if created)
+- [ ] Custom PrometheusRules validated against real metrics

--- a/.claude/skills/deploy-app/scripts/check-alerts.sh
+++ b/.claude/skills/deploy-app/scripts/check-alerts.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Check for firing alerts in Prometheus
+# Usage: ./check-alerts.sh [--baseline <file>]
+#
+# Without baseline: Shows all firing alerts
+# With baseline: Shows only NEW alerts since baseline was captured
+#
+# To capture a baseline before deployment:
+#   ./check-alerts.sh > /tmp/alerts-baseline.txt
+#
+# Then after deployment:
+#   ./check-alerts.sh --baseline /tmp/alerts-baseline.txt
+
+set -euo pipefail
+
+BASELINE_FILE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --baseline)
+            BASELINE_FILE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+PROMETHEUS_URL="${PROMETHEUS_URL:-http://localhost:9090}"
+
+# Check if Prometheus is accessible
+if ! curl -sf "$PROMETHEUS_URL/-/ready" >/dev/null 2>&1; then
+    echo "ERROR: Prometheus not accessible at $PROMETHEUS_URL"
+    echo ""
+    echo "Start a port-forward:"
+    echo "  kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090"
+    exit 1
+fi
+
+echo "=== Alert Status Check ==="
+echo "Using Prometheus at: $PROMETHEUS_URL"
+echo ""
+
+# Get all alerts
+ALERTS=$(curl -sf "$PROMETHEUS_URL/api/v1/alerts" 2>/dev/null || echo '{"data":{"alerts":[]}}')
+
+# Extract firing alerts
+FIRING=$(echo "$ALERTS" | jq -r '[.data.alerts[] | select(.state == "firing")]')
+FIRING_COUNT=$(echo "$FIRING" | jq 'length')
+
+# Extract pending alerts
+PENDING=$(echo "$ALERTS" | jq -r '[.data.alerts[] | select(.state == "pending")]')
+PENDING_COUNT=$(echo "$PENDING" | jq 'length')
+
+echo "Firing alerts: $FIRING_COUNT"
+echo "Pending alerts: $PENDING_COUNT"
+echo ""
+
+if [[ "$FIRING_COUNT" -gt 0 ]]; then
+    # Get alert names for comparison
+    CURRENT_ALERTS=$(echo "$FIRING" | jq -r '.[].labels.alertname' | sort)
+
+    if [[ -n "$BASELINE_FILE" && -f "$BASELINE_FILE" ]]; then
+        # Compare against baseline
+        NEW_ALERTS=$(comm -13 <(cat "$BASELINE_FILE") <(echo "$CURRENT_ALERTS"))
+
+        if [[ -n "$NEW_ALERTS" ]]; then
+            echo "=== NEW Firing Alerts (since baseline) ==="
+            echo "$NEW_ALERTS" | while read -r alert; do
+                echo "$FIRING" | jq -r --arg name "$alert" \
+                    '.[] | select(.labels.alertname == $name) | "[\(.labels.severity // "unknown")] \(.labels.alertname): \(.annotations.summary // .annotations.description // "No description")"'
+            done
+            echo ""
+            echo "WARNING: New alerts detected after deployment"
+            exit 1
+        else
+            echo "=== No NEW alerts since baseline ==="
+            echo "All $FIRING_COUNT firing alerts existed before deployment"
+            exit 0
+        fi
+    else
+        # No baseline, just show all firing alerts
+        echo "=== Firing Alerts ==="
+        echo "$FIRING" | jq -r '.[] | "[\(.labels.severity // "unknown")] \(.labels.alertname): \(.annotations.summary // .annotations.description // "No description")"'
+
+        # Output alert names for baseline capture
+        echo ""
+        echo "# Alert names (for baseline comparison):"
+        echo "$CURRENT_ALERTS"
+    fi
+fi
+
+if [[ "$PENDING_COUNT" -gt 0 ]]; then
+    echo ""
+    echo "=== Pending Alerts (may fire soon) ==="
+    echo "$PENDING" | jq -r '.[] | "[\(.labels.severity // "unknown")] \(.labels.alertname): \(.annotations.summary // .annotations.description // "No description")"'
+fi
+
+if [[ "$FIRING_COUNT" -eq 0 ]]; then
+    echo "=== No firing alerts ==="
+    exit 0
+fi

--- a/.claude/skills/deploy-app/scripts/check-canary.sh
+++ b/.claude/skills/deploy-app/scripts/check-canary.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Check canary health check status for an application
+# Usage: ./check-canary.sh <app-name>
+#
+# Requires kubectl access to the cluster
+
+set -euo pipefail
+
+APP_NAME="${1:-}"
+
+if [[ -z "$APP_NAME" ]]; then
+    echo "Usage: $0 <app-name>" >&2
+    exit 1
+fi
+
+KUBECONFIG="${KUBECONFIG:-$HOME/.kube/dev.yaml}"
+export KUBECONFIG
+
+echo "=== Canary Health Check: $APP_NAME ==="
+echo ""
+
+# Look for canary resources
+CANARY_NAME="http-check-$APP_NAME"
+
+# Check if canary exists
+if ! kubectl get canary "$CANARY_NAME" -n default >/dev/null 2>&1; then
+    # Try finding in other namespaces
+    CANARY=$(kubectl get canary -A -o json 2>/dev/null | jq -r --arg name "$CANARY_NAME" \
+        '.items[] | select(.metadata.name == $name) | "\(.metadata.namespace)/\(.metadata.name)"' | head -1)
+
+    if [[ -z "$CANARY" ]]; then
+        # Try partial match
+        CANARY=$(kubectl get canary -A -o json 2>/dev/null | jq -r --arg app "$APP_NAME" \
+            '.items[] | select(.metadata.name | contains($app)) | "\(.metadata.namespace)/\(.metadata.name)"' | head -1)
+    fi
+
+    if [[ -z "$CANARY" ]]; then
+        echo "No canary found for $APP_NAME"
+        echo ""
+        echo "Expected canary name: $CANARY_NAME"
+        echo ""
+        echo "Available canaries:"
+        kubectl get canary -A 2>/dev/null || echo "(none found)"
+        exit 0  # Not an error if canary doesn't exist
+    fi
+
+    NAMESPACE="${CANARY%%/*}"
+    CANARY_NAME="${CANARY##*/}"
+else
+    NAMESPACE="default"
+fi
+
+echo "Found canary: $NAMESPACE/$CANARY_NAME"
+echo ""
+
+# Get canary status
+CANARY_JSON=$(kubectl get canary "$CANARY_NAME" -n "$NAMESPACE" -o json 2>/dev/null)
+
+# Extract status
+STATUS=$(echo "$CANARY_JSON" | jq -r '.status.status // "unknown"')
+MESSAGE=$(echo "$CANARY_JSON" | jq -r '.status.message // "No message"')
+LAST_RUN=$(echo "$CANARY_JSON" | jq -r '.status.lastRuntime // "Never"')
+UPTIME=$(echo "$CANARY_JSON" | jq -r '.status.uptime1h // "N/A"')
+
+echo "Status: $STATUS"
+echo "Message: $MESSAGE"
+echo "Last Run: $LAST_RUN"
+echo "Uptime (1h): $UPTIME"
+echo ""
+
+# Check individual checks
+echo "=== Check Results ==="
+echo "$CANARY_JSON" | jq -r '.status.checkStatuses // [] | .[] | "\(.name): \(.status) (duration: \(.duration)ms)"' 2>/dev/null || echo "(no check statuses)"
+
+# Determine exit code
+case "$STATUS" in
+    "Passed"|"Healthy")
+        echo ""
+        echo "=== Canary PASSED ==="
+        exit 0
+        ;;
+    "Failed"|"Unhealthy")
+        echo ""
+        echo "=== Canary FAILED ==="
+        echo ""
+        echo "Check the canary configuration and target endpoint"
+        exit 1
+        ;;
+    *)
+        echo ""
+        echo "=== Canary status: $STATUS ==="
+        echo "May need more time to run first check"
+        exit 0
+        ;;
+esac

--- a/.claude/skills/deploy-app/scripts/check-deployment-health.sh
+++ b/.claude/skills/deploy-app/scripts/check-deployment-health.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Check deployment health for a newly deployed application
+# Usage: ./check-deployment-health.sh <namespace> <app-name>
+#
+# Returns exit 0 if healthy, exit 1 if issues detected
+
+set -euo pipefail
+
+NAMESPACE="${1:-}"
+APP_NAME="${2:-}"
+
+if [[ -z "$NAMESPACE" || -z "$APP_NAME" ]]; then
+    echo "Usage: $0 <namespace> <app-name>" >&2
+    exit 1
+fi
+
+KUBECONFIG="${KUBECONFIG:-$HOME/.kube/dev.yaml}"
+export KUBECONFIG
+
+echo "=== Deployment Health Check: $APP_NAME in $NAMESPACE ==="
+echo ""
+
+# Check pods
+echo "=== Pod Status ==="
+PODS=$(kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/name=$APP_NAME" -o json 2>/dev/null || echo '{"items":[]}')
+
+if [[ $(echo "$PODS" | jq '.items | length') -eq 0 ]]; then
+    # Try alternative label
+    PODS=$(kubectl get pods -n "$NAMESPACE" -l "app=$APP_NAME" -o json 2>/dev/null || echo '{"items":[]}')
+fi
+
+POD_COUNT=$(echo "$PODS" | jq '.items | length')
+
+if [[ "$POD_COUNT" -eq 0 ]]; then
+    echo "ERROR: No pods found for $APP_NAME in $NAMESPACE"
+    echo "Labels tried: app.kubernetes.io/name=$APP_NAME, app=$APP_NAME"
+    exit 1
+fi
+
+echo "Found $POD_COUNT pod(s)"
+echo ""
+
+# Check each pod
+HEALTHY=true
+echo "$PODS" | jq -r '.items[] | "\(.metadata.name) \(.status.phase) \(.status.containerStatuses // [] | map(.ready) | all)"' | while read -r name phase ready; do
+    if [[ "$phase" != "Running" ]]; then
+        echo "  $name: $phase (NOT HEALTHY)"
+        HEALTHY=false
+    elif [[ "$ready" != "true" ]]; then
+        echo "  $name: $phase but containers not ready (NOT HEALTHY)"
+        HEALTHY=false
+    else
+        echo "  $name: $phase (HEALTHY)"
+    fi
+done
+
+# Check for CrashLoopBackOff
+CRASH_LOOPS=$(echo "$PODS" | jq -r '.items[].status.containerStatuses[]? | select(.state.waiting.reason == "CrashLoopBackOff") | .name' 2>/dev/null || true)
+if [[ -n "$CRASH_LOOPS" ]]; then
+    echo ""
+    echo "ERROR: CrashLoopBackOff detected:"
+    echo "$CRASH_LOOPS"
+    echo ""
+    echo "=== Recent Logs ==="
+    FIRST_POD=$(echo "$PODS" | jq -r '.items[0].metadata.name')
+    kubectl logs -n "$NAMESPACE" "$FIRST_POD" --tail=50 2>/dev/null || echo "(logs unavailable)"
+    HEALTHY=false
+fi
+
+# Check for ImagePullBackOff
+IMAGE_PULLS=$(echo "$PODS" | jq -r '.items[].status.containerStatuses[]? | select(.state.waiting.reason == "ImagePullBackOff" or .state.waiting.reason == "ErrImagePull") | .name' 2>/dev/null || true)
+if [[ -n "$IMAGE_PULLS" ]]; then
+    echo ""
+    echo "ERROR: Image pull issues detected:"
+    echo "$IMAGE_PULLS"
+    HEALTHY=false
+fi
+
+# Check for OOMKilled
+OOM=$(echo "$PODS" | jq -r '.items[].status.containerStatuses[]? | select(.lastState.terminated.reason == "OOMKilled") | .name' 2>/dev/null || true)
+if [[ -n "$OOM" ]]; then
+    echo ""
+    echo "WARNING: OOMKilled detected (container may need more memory):"
+    echo "$OOM"
+fi
+
+# Check events
+echo ""
+echo "=== Recent Events ==="
+kubectl get events -n "$NAMESPACE" --field-selector "involvedObject.name=$APP_NAME" --sort-by='.lastTimestamp' 2>/dev/null | tail -10 || echo "(no events)"
+
+# Check services
+echo ""
+echo "=== Services ==="
+kubectl get svc -n "$NAMESPACE" -l "app.kubernetes.io/name=$APP_NAME" 2>/dev/null || \
+kubectl get svc -n "$NAMESPACE" -l "app=$APP_NAME" 2>/dev/null || \
+echo "(no services found with standard labels)"
+
+# Summary
+echo ""
+echo "=== Summary ==="
+if [[ "$HEALTHY" == "true" ]]; then
+    echo "Deployment appears healthy"
+    exit 0
+else
+    echo "Issues detected - review above output"
+    exit 1
+fi

--- a/.claude/skills/deploy-app/scripts/check-servicemonitor.sh
+++ b/.claude/skills/deploy-app/scripts/check-servicemonitor.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Check if ServiceMonitor is being scraped by Prometheus
+# Usage: ./check-servicemonitor.sh <job-name>
+#
+# Requires port-forward to Prometheus or PROMETHEUS_URL environment variable
+# Run: kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090
+
+set -euo pipefail
+
+JOB_NAME="${1:-}"
+
+if [[ -z "$JOB_NAME" ]]; then
+    echo "Usage: $0 <job-name>" >&2
+    exit 1
+fi
+
+PROMETHEUS_URL="${PROMETHEUS_URL:-http://localhost:9090}"
+
+echo "=== ServiceMonitor Check: $JOB_NAME ==="
+echo "Using Prometheus at: $PROMETHEUS_URL"
+echo ""
+
+# Check if Prometheus is accessible
+if ! curl -sf "$PROMETHEUS_URL/-/ready" >/dev/null 2>&1; then
+    echo "ERROR: Prometheus not accessible at $PROMETHEUS_URL"
+    echo ""
+    echo "Start a port-forward:"
+    echo "  kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090"
+    exit 1
+fi
+
+# Query active targets
+echo "=== Searching for job '$JOB_NAME' in active targets ==="
+TARGETS=$(curl -sf "$PROMETHEUS_URL/api/v1/targets" 2>/dev/null || echo '{"data":{"activeTargets":[]}}')
+
+# Search for matching targets (case-insensitive partial match)
+MATCHES=$(echo "$TARGETS" | jq -r --arg job "$JOB_NAME" \
+    '[.data.activeTargets[] | select(.labels.job | ascii_downcase | contains($job | ascii_downcase))]')
+
+MATCH_COUNT=$(echo "$MATCHES" | jq 'length')
+
+if [[ "$MATCH_COUNT" -eq 0 ]]; then
+    echo "No targets found matching job '$JOB_NAME'"
+    echo ""
+    echo "=== Available jobs ==="
+    echo "$TARGETS" | jq -r '.data.activeTargets[].labels.job' | sort -u | head -30
+    echo ""
+    echo "Possible reasons:"
+    echo "  1. ServiceMonitor not created (check helm values serviceMonitor.enabled)"
+    echo "  2. ServiceMonitor labels don't match Prometheus selector"
+    echo "  3. Target namespace not being scraped"
+    echo "  4. Prometheus hasn't reloaded yet (wait 30-60s)"
+    exit 1
+fi
+
+echo "Found $MATCH_COUNT target(s):"
+echo ""
+
+# Show target details
+echo "$MATCHES" | jq -r '.[] | "Job: \(.labels.job)\n  Instance: \(.labels.instance)\n  State: \(.health)\n  Last Scrape: \(.lastScrape)\n  Scrape Duration: \(.lastScrapeDuration)s\n"'
+
+# Check health
+UNHEALTHY=$(echo "$MATCHES" | jq '[.[] | select(.health != "up")] | length')
+if [[ "$UNHEALTHY" -gt 0 ]]; then
+    echo "WARNING: $UNHEALTHY target(s) not healthy"
+    echo ""
+    echo "Unhealthy targets:"
+    echo "$MATCHES" | jq -r '.[] | select(.health != "up") | "  \(.labels.instance): \(.lastError)"'
+    exit 1
+fi
+
+echo "=== All targets healthy ==="
+exit 0


### PR DESCRIPTION
## Summary
- Add `/deploy-app` skill that orchestrates complete application deployment workflow
- Provides 6-phase process: research, setup, configure, validate, dev test, PR creation
- Includes helper scripts for verifying deployment health, ServiceMonitor discovery, alerts, and canary checks
- Adds reference templates for all configuration files and monitoring patterns

## Test plan
- [x] Skill appears in available skills list
- [x] Permissions allow helm install/uninstall commands
- [x] Helper scripts are executable
- [x] Reference templates cover common deployment scenarios

Generated with [Claude Code](https://claude.com/claude-code)