### PR TITLE
fix(k8s): update ExternalSecret API version from v1beta1 to v1

### DIFF
--- a/kubernetes/platform/CLAUDE.md
+++ b/kubernetes/platform/CLAUDE.md
@@ -341,7 +341,7 @@ Use ExternalSecret only when secrets MUST come from outside the cluster:
 - Secrets needed for disaster recovery bootstrapping
 
 ```yaml
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: external-api-credentials

--- a/kubernetes/platform/config/issuers/cloudflare-issuer/external-secret.yaml
+++ b/kubernetes/platform/config/issuers/cloudflare-issuer/external-secret.yaml
@@ -1,6 +1,6 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: cloudflare-api-token

--- a/kubernetes/platform/config/issuers/istio-mesh-ca/external-secret.yaml
+++ b/kubernetes/platform/config/issuers/istio-mesh-ca/external-secret.yaml
@@ -1,8 +1,8 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
 # Pulls the shared Istio mesh root CA from AWS SSM Parameter Store.
 # This CA is shared across all clusters, enabling cross-cluster mTLS trust.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: istio-mesh-root-ca

--- a/kubernetes/platform/config/longhorn/backup/external-secret.yaml
+++ b/kubernetes/platform/config/longhorn/backup/external-secret.yaml
@@ -1,6 +1,6 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: longhorn-s3-backup-credentials

--- a/kubernetes/platform/config/monitoring/discord-secret.yaml
+++ b/kubernetes/platform/config/monitoring/discord-secret.yaml
@@ -1,6 +1,6 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: alertmanager-discord-webhook

--- a/kubernetes/platform/config/secrets/cluster-secret-store.yaml
+++ b/kubernetes/platform/config/secrets/cluster-secret-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: aws-ssm

--- a/kubernetes/platform/config/secrets/external-secret-test.yaml
+++ b/kubernetes/platform/config/secrets/external-secret-test.yaml
@@ -1,6 +1,6 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: example


### PR DESCRIPTION
## Summary
- External-secrets operator upgrade deprecated v1beta1 API version, causing dev cluster bootstrap failures
- Update all ExternalSecret and ClusterSecretStore manifests to use stable v1 API

## Test plan
- [x] `task k8s:validate` passes locally
- [x] Dev cluster bootstrap succeeds with updated manifests