### PR TITLE
fix(k8s): remove unsupported s3Api.enabled field from GarageCluster

### DIFF
--- a/kubernetes/platform/config/garage/garage-cluster.yaml
+++ b/kubernetes/platform/config/garage/garage-cluster.yaml
@@ -32,7 +32,6 @@ spec:
       type: ClusterIP
 
   s3Api:
-    enabled: true
     bindPort: 3900
     region: garage
     rootDomain: .s3.${internal_domain}


### PR DESCRIPTION
## Summary
- Fixes `garage-config` Kustomization failure caused by schema incompatibility after Renovate auto-merged garage-operator v0.0.32
- The new CRD schema no longer supports `s3Api.enabled` - the S3 API is implicitly enabled when the section exists

## Test plan
- [ ] Verify `garage-config` Kustomization reconciles successfully on dev cluster
- [ ] Verify GarageCluster pods are running: `kubectl get pods -n garage`
- [ ] Verify S3 API responds: `kubectl run curl --rm -it --image=curlimages/curl --restart=Never -- curl -s http://garage.garage.svc:3900/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)