### PR TITLE
fix(k8s): resolve silence-operator CrashLoopBackOff from CPU throttling

### DIFF
--- a/kubernetes/platform/charts/silence-operator.yaml
+++ b/kubernetes/platform/charts/silence-operator.yaml
@@ -17,9 +17,11 @@ podMonitor:
   enabled: true
 
 # Resource requests/limits
+# Chart defaults to cpu limit of 50m which causes throttling and liveness probe failures
 resources:
   requests:
     cpu: 10m
     memory: 32Mi
   limits:
+    cpu: 200m
     memory: 64Mi


### PR DESCRIPTION
## Summary
- The silence-operator Helm chart defaults to a 50m CPU limit which causes CPU throttling
- During controller reconciliation, throttling makes the liveness probe health endpoint respond slower than the 1s timeout
- This triggers repeated pod restarts (CrashLoopBackOff with Exit Code 0)
- Fix: Explicitly set CPU limit to 200m to prevent throttling

## Test plan
- [ ] Verify silence-operator pod stabilizes on dev cluster (no more restarts)
- [ ] Check liveness probes are passing consistently
- [ ] Confirm Silence CRs are being reconciled successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)