### PR TITLE
feat(monitoring): add certificate expiration alerts

### DIFF
--- a/kubernetes/platform/config/monitoring/cert-manager-alerts.yaml
+++ b/kubernetes/platform/config/monitoring/cert-manager-alerts.yaml
@@ -1,0 +1,75 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cert-manager-alerts
+  labels:
+    app.kubernetes.io/name: cert-manager
+spec:
+  groups:
+    - name: cert-manager.rules
+      rules:
+        - alert: CertificateExpiringSoon14d
+          expr: |
+            certmanager_certificate_expiration_timestamp_seconds - time() < 86400 * 14
+          labels:
+            severity: warning
+          annotations:
+            summary: "Certificate {{ $labels.namespace }}/{{ $labels.name }} expires in less than 14 days"
+            description: >-
+              Certificate {{ $labels.name }} in namespace {{ $labels.namespace }}
+              will expire in less than 14 days. Verify cert-manager is renewing
+              certificates correctly.
+
+        - alert: CertificateExpiringSoon7d
+          expr: |
+            certmanager_certificate_expiration_timestamp_seconds - time() < 86400 * 7
+          labels:
+            severity: warning
+          annotations:
+            summary: "Certificate {{ $labels.namespace }}/{{ $labels.name }} expires in less than 7 days"
+            description: >-
+              Certificate {{ $labels.name }} in namespace {{ $labels.namespace }}
+              will expire in less than 7 days. Immediate attention required to
+              prevent service disruption.
+
+        - alert: CertificateExpiringSoon24h
+          expr: |
+            certmanager_certificate_expiration_timestamp_seconds - time() < 86400
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: "Certificate {{ $labels.namespace }}/{{ $labels.name }} expires in less than 24 hours"
+            description: >-
+              Certificate {{ $labels.name }} in namespace {{ $labels.namespace }}
+              will expire in less than 24 hours. This is a P1 incident - expired
+              certificates cause outages.
+
+        - alert: CertificateRenewalFailure
+          expr: |
+            certmanager_certificate_renewal_timestamp_seconds < time()
+              and on(namespace, name) certmanager_certificate_ready_status{condition="False"} == 1
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: "Certificate {{ $labels.namespace }}/{{ $labels.name }} renewal failed"
+            description: >-
+              Certificate {{ $labels.name }} in namespace {{ $labels.namespace }}
+              is past its renewal time and is not ready. The certificate renewal
+              process has failed and requires immediate investigation.
+
+        - alert: CertificateIssuanceFailure
+          expr: |
+            rate(certmanager_http_acme_client_request_count{status="error"}[5m]) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "ACME certificate issuance errors detected"
+            description: >-
+              cert-manager is experiencing ACME client errors when requesting
+              certificates. This may indicate DNS challenge failures, rate
+              limiting, or network issues with the ACME provider.

--- a/kubernetes/platform/config/monitoring/kustomization.yaml
+++ b/kubernetes/platform/config/monitoring/kustomization.yaml
@@ -12,4 +12,5 @@ resources:
   - grafana-canary.yaml
   - prometheus-route.yaml
   - prometheus-canary.yaml
+  - cert-manager-alerts.yaml
   - network-policy-alerts.yaml


### PR DESCRIPTION
## Summary
- Add tiered certificate expiration alerts (14d, 7d, 24h) to catch expiring certs before outages
- Alert on renewal failures when certificates are past renewal time but not ready
- Alert on ACME issuance failures to detect DNS challenge or rate limiting issues

## Test plan
- [x] `task k8s:validate` passes
- [x] Expiration calculations are correct (86400 seconds = 1 day)
- [x] Alert includes certificate name/namespace in labels via metric labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)