### PR TITLE
fix(monitoring): resolve false positive alerts and add missing observability

### DIFF
--- a/kubernetes/platform/config/canary-checker/platform-health.yaml
+++ b/kubernetes/platform/config/canary-checker/platform-health.yaml
@@ -19,10 +19,7 @@ spec:
   http:
     - name: kubernetes-api
       url: https://kubernetes.default.svc/healthz
-      responseCodes: [200]
-    - name: flux-source-controller
-      url: http://source-controller.flux-system:9090/healthz
-      responseCodes: [200]
+      responseCodes: [200, 401]
   # Kubernetes resource check - verify no failing pods
   kubernetes:
     - name: flux-pods-healthy

--- a/kubernetes/platform/config/kromgo/external-canary.yaml
+++ b/kubernetes/platform/config/kromgo/external-canary.yaml
@@ -8,7 +8,7 @@ spec:
   schedule: "@every 1m"
   http:
     - name: external-gateway-health
-      url: https://kromgo.${external_domain}
+      url: https://kromgo.${external_domain}/node_count
       responseCodes: [200]
       maxSSLExpiry: 7
       thresholdMillis: 5000

--- a/kubernetes/platform/config/monitoring/cert-manager-alerts.yaml
+++ b/kubernetes/platform/config/monitoring/cert-manager-alerts.yaml
@@ -12,7 +12,7 @@ spec:
       rules:
         - alert: CertificateExpiringSoon14d
           expr: |
-            certmanager_certificate_expiration_timestamp_seconds - time() < 86400 * 14
+            certmanager_certificate_expiration_timestamp_seconds{name!="istiod"} - time() < 86400 * 14
           labels:
             severity: warning
           annotations:
@@ -24,7 +24,7 @@ spec:
 
         - alert: CertificateExpiringSoon7d
           expr: |
-            certmanager_certificate_expiration_timestamp_seconds - time() < 86400 * 7
+            certmanager_certificate_expiration_timestamp_seconds{name!="istiod"} - time() < 86400 * 7
           labels:
             severity: warning
           annotations:
@@ -36,7 +36,7 @@ spec:
 
         - alert: CertificateExpiringSoon24h
           expr: |
-            certmanager_certificate_expiration_timestamp_seconds - time() < 86400
+            certmanager_certificate_expiration_timestamp_seconds{name!="istiod"} - time() < 86400
           for: 1h
           labels:
             severity: critical

--- a/kubernetes/platform/config/monitoring/flux-podmonitor.yaml
+++ b/kubernetes/platform/config/monitoring/flux-podmonitor.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: flux-controllers
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - flux-system
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - helm-controller
+          - source-controller
+          - kustomize-controller
+          - notification-controller
+          - image-automation-controller
+          - image-reflector-controller
+  podMetricsEndpoints:
+    - port: http-prom
+      path: /metrics
+      interval: 30s

--- a/kubernetes/platform/config/monitoring/istio-alerts.yaml
+++ b/kubernetes/platform/config/monitoring/istio-alerts.yaml
@@ -153,7 +153,7 @@ spec:
       rules:
         # istio-csr availability
         - alert: IstioCSRDown
-          expr: absent(up{job="cert-manager-istio-csr"} == 1)
+          expr: absent(up{job="cert-manager-istio-csr-metrics"} == 1)
           for: 5m
           labels:
             severity: critical

--- a/kubernetes/platform/config/monitoring/istio-servicemonitors.yaml
+++ b/kubernetes/platform/config/monitoring/istio-servicemonitors.yaml
@@ -38,3 +38,23 @@ spec:
     - port: "15020"
       path: /stats/prometheus
       interval: 30s
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: external-istio-gateway
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - istio-gateway
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: external
+  podMetricsEndpoints:
+    - port: http-envoy-prom
+      path: /stats/prometheus
+      interval: 30s

--- a/kubernetes/platform/config/monitoring/kustomization.yaml
+++ b/kubernetes/platform/config/monitoring/kustomization.yaml
@@ -21,3 +21,4 @@ resources:
   - grafana-alerts.yaml
   - loki-mixin-alerts.yaml
   - loki-mixin-recording-rules.yaml
+  - flux-podmonitor.yaml


### PR DESCRIPTION
## Summary

- Fix IstioCSRDown alert false positive (job label mismatch: `cert-manager-istio-csr` → `cert-manager-istio-csr-metrics`)
- Exclude istiod from generic cert expiration alerts (24h mesh certs auto-renew every 12h, shouldn't trigger 14d/7d/24h warnings)
- Fix kubernetes-api canary to accept 401 (no auth token for `/healthz`)
- Fix external-gateway-health canary to use `/node_count` endpoint (kromgo returns 404 on root)
- Remove redundant flux-source-controller canary check (wrong port, covered by other checks)
- Add PodMonitor for external-istio gateway (enables `istio_requests_total` for CorazaWAFDegraded alert)
- Add PodMonitor for Flux controllers (enables `gotk_reconcile_condition` for flux-reconciliation canary)

## Test plan

- [x] `task k8s:validate` passes
- [ ] After merge, verify alerts page shows only Watchdog firing
- [ ] Verify Spegel silence is active in Alertmanager

🤖 Generated with [Claude Code](https://claude.com/claude-code)