### PR TITLE
feat(infra): enable flux-operator ServiceMonitor for Prometheus scraping

### DIFF
--- a/infrastructure/modules/bootstrap/flux.tf
+++ b/infrastructure/modules/bootstrap/flux.tf
@@ -57,6 +57,15 @@ resource "helm_release" "flux_operator" {
   chart      = "flux-operator"
   wait       = true
   timeout    = 300
+
+  values = [yamlencode({
+    serviceMonitor = {
+      create = true
+      labels = {
+        release = "kube-prometheus-stack"
+      }
+    }
+  })]
 }
 
 resource "helm_release" "flux_instance" {


### PR DESCRIPTION
## Summary

- Enable the built-in `serviceMonitor` in flux-operator Helm chart
- Add `release: kube-prometheus-stack` label for automatic Prometheus discovery

## Context

The flux-operator chart has ServiceMonitor support disabled by default. This enables it to provide observability into the operator process that manages FluxInstance CRDs.

**Note:** This monitors the flux-operator itself, not the Flux controllers (source-controller, helm-controller, etc.). Controller metrics are scraped via the PodMonitor added in #215.

## Test plan

- [x] `task tg:fmt` passes
- [x] `task tg:test-bootstrap` passes (2 passed, 0 failed)
- [ ] After apply, verify ServiceMonitor appears: `kubectl -n flux-system get servicemonitor`
- [ ] Verify Prometheus scrapes flux-operator metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)