### PR TITLE
fix(monitoring): add Flux Discord notifications and fix alert false positives

### DIFF
--- a/kubernetes/platform/config.yaml
+++ b/kubernetes/platform/config.yaml
@@ -57,7 +57,7 @@ spec:
     - name: flux-notifications-config
       namespace: flux-system
       path: kubernetes/platform/config/flux-notifications
-      dependsOn: []
+      dependsOn: [external-secrets-stores]
     - name: tuppr-config
       namespace: system-upgrade
       path: kubernetes/platform/config/tuppr

--- a/kubernetes/platform/config/canary-checker/platform-health.yaml
+++ b/kubernetes/platform/config/canary-checker/platform-health.yaml
@@ -6,21 +6,12 @@ metadata:
   namespace: monitoring
 spec:
   interval: 60
-  # Prometheus check - verify Flux reconciliation health
-  prometheus:
-    - name: flux-reconciliation
-      url: http://kube-prometheus-stack-prometheus.monitoring:9090
-      query: |
-        (sum(gotk_reconcile_condition{status="True",type="Ready"}) /
-         sum(gotk_reconcile_condition{type="Ready"})) * 100
-      test:
-        expr: results[0] > 95
   # HTTP checks - verify critical services respond
   http:
     - name: kubernetes-api
       url: https://kubernetes.default.svc/healthz
       responseCodes: [200, 401]
-  # Kubernetes resource check - verify no failing pods
+  # Kubernetes resource check - verify Flux pods are healthy
   kubernetes:
     - name: flux-pods-healthy
       kind: Pod
@@ -28,5 +19,4 @@ spec:
         name: flux-system
       resource:
         labelSelector: app.kubernetes.io/part-of=flux
-      test:
-        expr: all(results, {.status.phase == "Running"})
+      healthy: true

--- a/kubernetes/platform/config/flux-notifications/discord-provider.yaml
+++ b/kubernetes/platform/config/flux-notifications/discord-provider.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/notification.toolkit.fluxcd.io/provider_v1beta3.json
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: discord
+  namespace: flux-system
+spec:
+  type: discord
+  secretRef:
+    name: flux-discord-webhook

--- a/kubernetes/platform/config/flux-notifications/discord-secret.yaml
+++ b/kubernetes/platform/config/flux-notifications/discord-secret.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: flux-discord-webhook
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: flux-discord-webhook
+  data:
+    - secretKey: address
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/discord-webhook-secret

--- a/kubernetes/platform/config/flux-notifications/kustomization.yaml
+++ b/kubernetes/platform/config/flux-notifications/kustomization.yaml
@@ -1,7 +1,11 @@
 ---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: flux-system
 resources:
   - github-provider.yaml
   - canary-alert.yaml
+  - discord-secret.yaml
+  - discord-provider.yaml
+  - reconciliation-failure-alert.yaml

--- a/kubernetes/platform/config/flux-notifications/reconciliation-failure-alert.yaml
+++ b/kubernetes/platform/config/flux-notifications/reconciliation-failure-alert.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/notification.toolkit.fluxcd.io/alert_v1beta3.json
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: reconciliation-failure
+  namespace: flux-system
+spec:
+  summary: "Flux reconciliation failure on ${cluster_name}"
+  providerRef:
+    name: discord
+  eventSeverity: error
+  eventSources:
+    # Watch all HelmReleases in all namespaces
+    - kind: HelmRelease
+      name: "*"
+      namespace: "*"
+    # Watch all Kustomizations in all namespaces
+    - kind: Kustomization
+      name: "*"
+      namespace: "*"
+    # Watch GitRepository/OCIRepository sources
+    - kind: GitRepository
+      name: "*"
+      namespace: "*"
+    - kind: OCIRepository
+      name: "*"
+      namespace: "*"
+    # Watch HelmRepositories and HelmCharts
+    - kind: HelmRepository
+      name: "*"
+      namespace: "*"
+    - kind: HelmChart
+      name: "*"
+      namespace: "*"

--- a/kubernetes/platform/config/monitoring/istio-alerts.yaml
+++ b/kubernetes/platform/config/monitoring/istio-alerts.yaml
@@ -177,14 +177,16 @@ spec:
               mesh workloads. Check cert-manager logs and istio-mesh-ca ClusterIssuer.
 
         # istio-csr certificate expiry approaching
+        # Note: istiod certs have 24h validity and renew at 50% lifetime (12h).
+        # Alert only if < 6h remaining (renewal should have happened by now).
         - alert: IstioCSRCertificateExpiringSoon
           expr: |
-            certmanager_certificate_expiration_timestamp_seconds{name=~"istiod.*"} - time() < 86400 * 2
-          for: 1h
+            certmanager_certificate_expiration_timestamp_seconds{name=~"istiod.*"} - time() < 21600
+          for: 30m
           labels:
             severity: warning
           annotations:
-            summary: "Istio component certificate expiring in < 2 days"
+            summary: "Istio component certificate expiring in < 6 hours"
             description: >-
               Certificate {{ $labels.name }} expires in {{ $value | humanizeDuration }}.
-              Check cert-manager renewal status.
+              Renewal should have occurred at 12h remaining. Check cert-manager and istio-csr health.


### PR DESCRIPTION
## Summary

- Add native Flux Discord notifications for reconciliation failures (HelmRelease, Kustomization, GitRepository, etc.)
- Fix IstioCSRCertificateExpiringSoon threshold: `< 2 days` → `< 6 hours` (24h certs renew at 12h)
- Fix canary-checker flux-pods-healthy: broken CEL syntax → `healthy: true`
- Remove broken flux-reconciliation Prometheus check (`gotk_reconcile_condition` removed in Flux 2.2+)

## New Files

| File | Purpose |
|------|---------|
| `discord-secret.yaml` | ExternalSecret to pull Discord webhook from SSM |
| `discord-provider.yaml` | Flux Provider for Discord notifications |
| `reconciliation-failure-alert.yaml` | Alert on error events from Flux resources |

## Test plan

- [x] `task k8s:validate` passes
- [ ] After merge, verify only Watchdog alert is firing
- [ ] Trigger a Flux failure and verify Discord notification arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)