### PR TITLE
fix(infra): wipe disks on cluster destroy

### DIFF
--- a/infrastructure/modules/config/variables.tf
+++ b/infrastructure/modules/config/variables.tf
@@ -210,14 +210,18 @@ variable "ssm_output_path" {
 variable "on_destroy" {
   description = "Talos node destruction behavior."
   type = object({
-    graceful = bool
-    reboot   = bool
-    reset    = bool
+    graceful              = bool
+    reboot                = bool
+    reset                 = bool
+    system_labels_to_wipe = optional(list(string), ["STATE", "EPHEMERAL"])
+    user_disks_to_wipe    = optional(list(string), ["system_disk"])
   })
   default = {
-    graceful = false
-    reboot   = true
-    reset    = true
+    graceful              = false
+    reboot                = true
+    reset                 = true
+    system_labels_to_wipe = ["STATE", "EPHEMERAL"]
+    user_disks_to_wipe    = ["system_disk"]
   }
 }
 

--- a/infrastructure/modules/talos/apply.tf
+++ b/infrastructure/modules/talos/apply.tf
@@ -6,9 +6,11 @@ resource "talos_machine_configuration_apply" "machines" {
   node                        = local.addresses[each.key]
 
   on_destroy = {
-    graceful = var.on_destroy.graceful
-    reboot   = var.on_destroy.reboot
-    reset    = var.on_destroy.reset
+    graceful              = var.on_destroy.graceful
+    reboot                = var.on_destroy.reboot
+    reset                 = var.on_destroy.reset
+    system_labels_to_wipe = var.on_destroy.system_labels_to_wipe
+    user_disks_to_wipe    = var.on_destroy.user_disks_to_wipe
   }
 }
 

--- a/infrastructure/modules/talos/variables.tf
+++ b/infrastructure/modules/talos/variables.tf
@@ -63,16 +63,20 @@ variable "talos_machines" {
 }
 
 variable "on_destroy" {
-  description = "How to preform node destruction"
+  description = "How to perform node destruction"
   type = object({
-    graceful = bool
-    reboot   = bool
-    reset    = bool
+    graceful              = bool
+    reboot                = bool
+    reset                 = bool
+    system_labels_to_wipe = optional(list(string), ["STATE", "EPHEMERAL"])
+    user_disks_to_wipe    = optional(list(string), ["system_disk"])
   })
   default = {
-    graceful = false
-    reboot   = true
-    reset    = true
+    graceful              = false
+    reboot                = true
+    reset                 = true
+    system_labels_to_wipe = ["STATE", "EPHEMERAL"]
+    user_disks_to_wipe    = ["system_disk"]
   }
 }
 

--- a/infrastructure/stacks/dev/terragrunt.stack.hcl
+++ b/infrastructure/stacks/dev/terragrunt.stack.hcl
@@ -2,6 +2,15 @@ locals {
   name                 = "${basename(get_terragrunt_dir())}"
   features             = ["gateway-api", "longhorn", "prometheus", "spegel"]
   storage_provisioning = "minimal"
+
+  # Full wipe on destroy for clean rebuilds
+  on_destroy = {
+    graceful              = false
+    reboot                = true
+    reset                 = true
+    system_labels_to_wipe = ["STATE", "EPHEMERAL"]
+    user_disks_to_wipe    = ["system_disk"]
+  }
 }
 
 unit "config" {
@@ -12,6 +21,7 @@ unit "config" {
     name                 = local.name
     features             = local.features
     storage_provisioning = local.storage_provisioning
+    on_destroy           = local.on_destroy
   }
 }
 

--- a/infrastructure/stacks/integration/terragrunt.stack.hcl
+++ b/infrastructure/stacks/integration/terragrunt.stack.hcl
@@ -2,6 +2,15 @@ locals {
   name                 = "${basename(get_terragrunt_dir())}"
   features             = ["gateway-api", "longhorn", "prometheus", "spegel"]
   storage_provisioning = "minimal"
+
+  # Full wipe on destroy for clean rebuilds
+  on_destroy = {
+    graceful              = false
+    reboot                = true
+    reset                 = true
+    system_labels_to_wipe = ["STATE", "EPHEMERAL"]
+    user_disks_to_wipe    = ["system_disk"]
+  }
 }
 
 unit "config" {
@@ -12,6 +21,7 @@ unit "config" {
     name                 = local.name
     features             = local.features
     storage_provisioning = local.storage_provisioning
+    on_destroy           = local.on_destroy
   }
 }
 

--- a/infrastructure/stacks/live/terragrunt.stack.hcl
+++ b/infrastructure/stacks/live/terragrunt.stack.hcl
@@ -2,6 +2,15 @@ locals {
   name                 = "${basename(get_terragrunt_dir())}"
   features             = ["gateway-api", "longhorn", "prometheus", "spegel"]
   storage_provisioning = "normal"
+
+  # Full wipe on destroy for clean rebuilds
+  on_destroy = {
+    graceful              = false
+    reboot                = true
+    reset                 = true
+    system_labels_to_wipe = ["STATE", "EPHEMERAL"]
+    user_disks_to_wipe    = ["system_disk"]
+  }
 }
 
 unit "config" {
@@ -12,6 +21,7 @@ unit "config" {
     name                 = local.name
     features             = local.features
     storage_provisioning = local.storage_provisioning
+    on_destroy           = local.on_destroy
   }
 }
 

--- a/infrastructure/units/config/terragrunt.hcl
+++ b/infrastructure/units/config/terragrunt.hcl
@@ -39,6 +39,7 @@ inputs = {
   name                   = values.name
   features               = values.features
   storage_provisioning   = values.storage_provisioning
+  on_destroy             = try(values.on_destroy, null)
   networking             = local.networking_vars.locals.clusters[values.name]
   machines               = local.inventory_vars.locals.hosts
   versions               = local.versions

--- a/infrastructure/units/talos/terragrunt.hcl
+++ b/infrastructure/units/talos/terragrunt.hcl
@@ -47,7 +47,7 @@ dependency "config" {
           ]
         }
       ]
-      on_destroy             = { graceful = false, reboot = true, reset = true }
+      on_destroy             = { graceful = false, reboot = true, reset = true, system_labels_to_wipe = ["STATE", "EPHEMERAL"], user_disks_to_wipe = ["system_disk"] }
       talos_config_path      = "~/.talos"
       kubernetes_config_path = "~/.kube"
       talos_timeout          = "10m"


### PR DESCRIPTION
## Summary

- Adds destroy-time wipe provisioner to ensure disk partitions are cleaned on cluster destroy
- Prevents undersized Longhorn volumes caused by stale u-longhorn partitions persisting across rebuilds
- Configurable via `on_destroy.system_labels_to_wipe` and `on_destroy.user_disks_to_wipe` in stack locals

## Test plan

- [ ] Run `task tg:destroy-dev` and verify nodes enter maintenance with wiped disks via `talosctl get discoveredvolumes`
- [ ] Run `task tg:apply-dev` and verify correct partition sizes via `talosctl get volumestatus`
- [ ] Verify Longhorn storage shows expected ~111 GiB (50% of 240GB minus overhead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)