### PR TITLE
docs: restructure CLAUDE.md documentation architecture

### DIFF
--- a/.claude/skills/CLAUDE.md
+++ b/.claude/skills/CLAUDE.md
@@ -1,0 +1,207 @@
+# Skills Architecture
+
+Skills are procedural guides that provide step-by-step workflows for complex operations. They are lazy-loaded into Claude's context only when relevant to the current task.
+
+---
+
+## Skill Inventory
+
+| Skill | Purpose | User-Invocable | References | Scripts |
+|-------|---------|----------------|------------|---------|
+| `app-template` | Deploy applications using bjw-s/app-template Helm chart | Yes | patterns.md, values-reference.md | - |
+| `deploy-app` | End-to-end application deployment with monitoring integration | Yes | file-templates.md, monitoring-patterns.md | check-alerts.sh, check-canary.sh, check-deployment-health.sh, check-servicemonitor.sh |
+| `flux-gitops` | Flux ResourceSet patterns for HelmRelease management | Yes | - | - |
+| `k8s-sre` | Kubernetes incident investigation and debugging | Yes | - | cluster-health.sh |
+| `kubesearch` | Research Helm configurations from kubesearch.dev | Yes | - | - |
+| `opentofu-modules` | OpenTofu module development and testing patterns | Yes | opentofu-testing.md | - |
+| `prometheus` | Query Prometheus API for metrics and alerts | Yes | queries.md | promql.sh |
+| `self-improvement` | Capture user feedback to enhance documentation | Yes | - | - |
+| `sync-claude` | Validate Claude docs against codebase state | Yes | - | discover-claude-docs.sh, extract-references.sh |
+| `taskfiles` | Task runner syntax, patterns, and conventions | Yes | schema.md, cli.md, styleguide.md, task-catalog.md | - |
+| `terragrunt` | Infrastructure operations with Terragrunt/OpenTofu | Yes | stacks.md, units.md | - |
+
+---
+
+## What is a Skill?
+
+Skills are **procedural knowledge** documents that guide Claude through multi-step workflows. They exist separately from CLAUDE.md files because:
+
+1. **Lazy Loading**: Skills are only loaded when triggered, preserving context window for actual work
+2. **Workflow Focus**: Skills describe HOW to do something step-by-step, not what exists or why
+3. **Reusable Procedures**: Common operations are codified once and invoked by name
+4. **Supporting Resources**: Skills can include reference docs and helper scripts
+
+Skills are invoked when:
+- User explicitly calls `/skill-name`
+- User's question matches skill triggers (defined in frontmatter)
+- Claude determines the skill is relevant to the current task
+
+---
+
+## Skill vs CLAUDE.md Boundary
+
+| Type | Purpose | Content |
+|------|---------|---------|
+| **CLAUDE.md** | Declarative knowledge | What exists, why it exists, constraints, patterns, anti-patterns |
+| **Skills** | Procedural knowledge | Step-by-step how-to workflows, decision trees, execution guides |
+| **Runbooks** | Emergency procedures | Incident response, disaster recovery, manual overrides |
+
+### Decision Tree
+
+```
+Is this knowledge...
+
+├─ About what exists and why?
+│  └─ CLAUDE.md (declarative)
+│     Examples: Architecture overview, configuration structure, constraints
+│
+├─ A multi-step procedure (5+ steps)?
+│  └─ Skill (procedural)
+│     Examples: "How to deploy an app", "How to debug K8s issues"
+│
+├─ An emergency/incident procedure?
+│  └─ Runbook (docs/runbooks/)
+│     Examples: "How to recover from data loss", "Network policy escape hatch"
+│
+└─ A quick reference or pattern?
+   └─ CLAUDE.md (usually in a domain-specific file)
+      Examples: Common commands, short patterns, quick examples
+```
+
+---
+
+## Skill File Structure
+
+```
+.claude/skills/<skill-name>/
+├── SKILL.md              # Main skill definition (REQUIRED)
+├── references/           # Supporting documentation (OPTIONAL)
+│   ├── patterns.md       # Common patterns and examples
+│   └── values-ref.md     # Reference documentation
+└── scripts/              # Helper scripts (OPTIONAL)
+    ├── check-health.sh   # Executable helpers
+    └── validate.sh       # Automation scripts
+```
+
+### SKILL.md Structure
+
+Every SKILL.md must have YAML frontmatter followed by the skill content:
+
+```yaml
+---
+name: skill-name              # Unique identifier (kebab-case)
+description: |
+  Brief description of what this skill does.
+
+  Use when: (1) Scenario A, (2) Scenario B, (3) Scenario C
+
+  Triggers: "keyword1", "keyword2", "phrase that triggers this skill"
+---
+
+# Skill Title
+
+[Skill content with workflows, examples, and guidance]
+```
+
+### Frontmatter Fields
+
+| Field | Required | Purpose |
+|-------|----------|---------|
+| `name` | Yes | Unique identifier, matches directory name |
+| `description` | Yes | Multi-line description with use cases and triggers |
+| `user_invocable` | No | Set to `false` to make Claude-only (default: `true`) |
+| `disable-model-invocation` | No | Set to `true` to make user-only |
+
+---
+
+## When to Create a New Skill
+
+Create a new skill when:
+
+1. **Repeated Procedures**: You've explained the same multi-step workflow more than once
+2. **Complex Workflows**: The procedure has 5+ steps with decision points
+3. **Supporting Resources**: The workflow benefits from reference docs or helper scripts
+4. **Domain Expertise**: The task requires specialized knowledge that should be encapsulated
+
+Do NOT create a skill when:
+- It's a simple command or pattern (add to CLAUDE.md instead)
+- It's a one-off procedure unlikely to be repeated
+- The content is purely declarative (what/why, not how)
+
+### Creating a New Skill
+
+1. Create directory: `.claude/skills/<skill-name>/`
+2. Create `SKILL.md` with proper frontmatter
+3. Add references/ if supporting docs are needed
+4. Add scripts/ if automation helpers are useful
+5. Update root CLAUDE.md skills table if appropriate
+
+---
+
+## Skill Maintenance
+
+### When to Update Skills
+
+- When underlying systems change (API updates, new versions)
+- When users report confusion or errors following procedures
+- When better patterns are discovered
+- When referenced paths, commands, or tools change
+
+### Validation
+
+Skills should be validated with the `sync-claude` skill, which checks:
+- File/directory paths mentioned exist
+- Commands referenced are valid
+- Cross-references to other docs are accurate
+
+### Deprecation
+
+To deprecate a skill:
+1. Add notice at top of SKILL.md: `**DEPRECATED**: Use [new-skill] instead`
+2. Keep for one release cycle to allow transition
+3. Remove directory after transition period
+
+---
+
+## User-Invocable vs Claude-Only
+
+### Default Behavior (Both)
+
+By default, skills can be invoked by both users (via `/skill-name`) and Claude (when triggers match). This is appropriate for most skills.
+
+### User-Only Skills
+
+Set `disable-model-invocation: true` when:
+- The skill should only run on explicit user request
+- Claude should not auto-invoke based on triggers
+- The procedure is destructive or expensive
+
+Example use case: A "reset-cluster" skill that should never be auto-triggered.
+
+### Claude-Only Skills
+
+Set `user_invocable: false` when:
+- The skill is an internal helper not meant for direct use
+- The skill is always invoked by another skill
+- The procedure requires context Claude has but users don't provide
+
+Example use case: Internal validation or preprocessing skills.
+
+### Summary
+
+| Configuration | User /command | Claude Auto-Invoke |
+|---------------|---------------|-------------------|
+| Default | Yes | Yes |
+| `disable-model-invocation: true` | Yes | No |
+| `user_invocable: false` | No | Yes |
+
+---
+
+## Cross-References
+
+- [Root CLAUDE.md](/CLAUDE.md) - Core principles, anti-patterns, repository structure
+- [infrastructure/CLAUDE.md](/infrastructure/CLAUDE.md) - Terragrunt/OpenTofu patterns
+- [kubernetes/platform/CLAUDE.md](/kubernetes/platform/CLAUDE.md) - Flux and platform patterns
+- [kubernetes/clusters/CLAUDE.md](/kubernetes/clusters/CLAUDE.md) - Cluster configuration
+- [.taskfiles/CLAUDE.md](/.taskfiles/CLAUDE.md) - Task runner reference
+- [docs/runbooks/](/docs/runbooks/) - Emergency procedures

--- a/.claude/skills/flux-gitops/SKILL.md
+++ b/.claude/skills/flux-gitops/SKILL.md
@@ -18,18 +18,9 @@ description: |
 
 The homelab Kubernetes platform uses Flux ResourceSets for centralized, declarative management of Helm releases and configurations.
 
-## Platform Files Overview
+For ResourceSet patterns, version management, and platform architecture, see [kubernetes/platform/CLAUDE.md](../../kubernetes/platform/CLAUDE.md).
 
-| File | Purpose |
-|------|---------|
-| `helm-charts.yaml` | ResourceSet defining all Helm releases |
-| `namespaces.yaml` | ResourceSet defining all namespaces |
-| `config.yaml` | ResourceSet for config Kustomizations |
-| `kustomization.yaml` | Generates ConfigMap from chart values |
-| `charts/` | Helm values files (one per release) |
-| `config/` | Non-Helm resources organized by subsystem |
-
-## Adding a New Helm Release
+## How to Add a New Helm Release
 
 ### Step 1: Add to helm-charts.yaml
 
@@ -124,23 +115,6 @@ resourcesTemplate: |
 - `<<- range $item := inputs.array >>` - Loop over array
 - `hasPrefix "oci://" inputs.chart.url` - String prefix check
 
-## Variable Substitution
-
-Flux substitutes variables from the `flux-system` ConfigMap:
-
-```yaml
-# In values file
-ingress:
-  hosts:
-    - host: grafana.${internal_domain}  # Substituted at reconciliation
-
-# Available variables
-${cluster_name}      # dev, integration, live
-${cluster_id}        # Numeric cluster ID
-${internal_domain}   # internal.dev.tomnowak.work
-${external_domain}   # External domain
-```
-
 ## Dependency Management
 
 ### Release Dependencies
@@ -198,14 +172,6 @@ flux reconcile kustomization flux-system -n flux-system
 | `values key not found` | Missing values file | Add to kustomization.yaml configMapGenerator |
 | `chart not found` | Wrong chart name/URL | Verify chart exists in repository |
 | `namespace not found` | Namespace not created | Add to namespaces.yaml |
-
-## Best Practices
-
-1. **Pin versions**: Always specify exact chart versions
-2. **Declare dependencies**: Use `dependsOn` to ensure ordering
-3. **Use substitution**: Never hardcode domains or cluster names
-4. **Values per release**: One values file per HelmRelease
-5. **Minimal values**: Only override what you need to change
 
 ## OCI Registry Specifics
 

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,253 @@
+# GitHub Workflows - Claude Reference
+
+GitHub Actions workflows that implement CI/CD for the homelab infrastructure, including the OCI artifact promotion pipeline.
+
+For core principles and deployment philosophy, see [CLAUDE.md](../CLAUDE.md).
+
+---
+
+## Workflow Inventory
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `kubernetes-validate.yaml` | PR (kubernetes/ changes) | Validate K8s manifests, schemas, deprecations |
+| `infrastructure-validate.yaml` | PR (infrastructure/ changes) | Format checks, module tests |
+| `renovate-validate.yaml` | PR (renovate config) | Validate Renovate configuration |
+| `build-platform-artifact.yaml` | Push to main (kubernetes/) | Build OCI artifact for promotion |
+| `tag-validated-artifact.yaml` | repository_dispatch | Promote validated artifact to live |
+| `renovate.yaml` | Scheduled (hourly) | Dependency update automation |
+| `label-sync.yaml` | Scheduled/manual | Sync GitHub labels |
+
+---
+
+## OCI Artifact Promotion Pipeline
+
+The promotion pipeline uses OCI artifacts for immutable, auditable deployments.
+
+### Pipeline Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         PR merged to main                           │
+└─────────────────────────────────┬───────────────────────────────────┘
+                                  │
+                                  ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  build-platform-artifact.yaml                                       │
+│  ├─ flux push artifact → ghcr.io/.../platform:0.1.0-rc.N           │
+│  ├─ flux tag artifact → sha-<short-sha>                            │
+│  └─ flux tag artifact → integration-<short-sha>                    │
+└─────────────────────────────────┬───────────────────────────────────┘
+                                  │
+                                  ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  Integration Cluster                                                │
+│  ├─ OCIRepository polls for semver ">= 0.0.0-0" (includes RCs)     │
+│  ├─ Detects new 0.1.0-rc.N artifact                                │
+│  └─ Flux reconciles platform                                        │
+└─────────────────────────────────┬───────────────────────────────────┘
+                                  │
+                                  ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  Canary-Checker Validation                                          │
+│  ├─ Monitors Kustomization health                                   │
+│  ├─ Runs platform smoke tests                                       │
+│  └─ On success: Alert triggers repository_dispatch                  │
+└─────────────────────────────────┬───────────────────────────────────┘
+                                  │
+                                  ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  tag-validated-artifact.yaml                                        │
+│  └─ flux tag artifact → validated-<short-sha>                      │
+└─────────────────────────────────┬───────────────────────────────────┘
+                                  │
+                                  ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  Live Cluster                                                       │
+│  ├─ OCIRepository polls for "validated-*" pattern                   │
+│  ├─ Detects new validated-<sha> tag                                │
+│  └─ Flux reconciles platform (production deployment)                │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Artifact Tagging Strategy
+
+| Tag | Created By | Purpose |
+|-----|------------|---------|
+| `0.1.0-rc.N` | build workflow | Semver for OCIRepository polling |
+| `sha-<short>` | build workflow | Immutable reference to commit |
+| `integration-<short>` | build workflow | Marks artifact for integration |
+| `validated-<short>` | tag workflow | Marks artifact for production |
+
+---
+
+## Source Types by Cluster
+
+| Cluster | Source Type | Semver/Pattern | Rationale |
+|---------|-------------|----------------|-----------|
+| `dev` | GitRepository | N/A | Fast iteration, no build step |
+| `integration` | OCIRepository | `>= 0.0.0-0` | Accepts RC versions |
+| `live` | OCIRepository | `validated-*` | Only validated artifacts |
+
+### Why Different Sources?
+
+**Dev cluster** uses GitRepository because:
+- Faster feedback loop (no build wait)
+- Easy to test WIP changes
+- Acceptable risk for dev environment
+
+**Integration/Live clusters** use OCIRepository because:
+- **Immutable artifacts**: Same bits deployed everywhere
+- **Auditability**: Exact artifact version in GHCR
+- **Promotion gates**: Validation must pass before live
+
+---
+
+## Debugging Guide
+
+### Artifact Stuck in Integration?
+
+```
+Is the artifact in GHCR?
+│
+├─ NO → Check build-platform-artifact.yaml run
+│       └─ Did the workflow trigger?
+│           ├─ NO → Was kubernetes/ modified?
+│           └─ YES → Check workflow logs for push errors
+│
+└─ YES → Is OCIRepository seeing it?
+         └─ kubectl get ocirepository -n flux-system
+             ├─ NO match → Check semver constraint
+             └─ Match found → Check Kustomization status
+                 └─ kubectl get kustomization -n flux-system
+```
+
+### Validation Not Triggering Promotion?
+
+```bash
+# Check canary-checker status
+kubectl get canaries -n canary-checker
+
+# Check Alert configuration
+kubectl get alerts -n flux-system
+
+# Check Provider (GitHub) configuration
+kubectl get providers -n flux-system
+
+# Check if Alert fired
+kubectl describe alert canary-success -n flux-system
+```
+
+### Tracing an Artifact
+
+```bash
+# 1. Find artifact in GHCR
+flux list artifact oci://ghcr.io/<repo>/platform
+
+# 2. Check tags
+flux list artifact oci://ghcr.io/<repo>/platform | grep <sha>
+
+# 3. Check which cluster has it
+kubectl get ocirepository -n flux-system -o yaml | grep -A5 "artifact"
+
+# 4. Check reconciliation status
+flux get kustomizations -A
+```
+
+### Common Failure Modes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Build succeeds but integration doesn't update | Semver not matching `>= 0.0.0-0` | Check OCIRepository spec |
+| Validation passes but live doesn't update | `validated-*` tag not applied | Check tag-validated workflow |
+| `repository_dispatch` not received | GitHub token missing `repo` scope | Check Provider secret |
+| Artifact push fails | GHCR auth issue | Check `GITHUB_TOKEN` permissions |
+
+### Manual Promotion (Emergency)
+
+If automatic promotion fails, manually tag:
+
+```bash
+# Authenticate
+echo $GITHUB_TOKEN | docker login ghcr.io -u $GITHUB_USER --password-stdin
+
+# Tag manually
+flux tag artifact \
+  oci://ghcr.io/<repo>/platform:integration-<sha> \
+  --tag validated-<sha>
+```
+
+### Rollback Procedure
+
+```bash
+# Find previous validated artifact
+flux list artifact oci://ghcr.io/<repo>/platform | grep validated
+
+# Re-tag previous artifact as latest validated
+flux tag artifact \
+  oci://ghcr.io/<repo>/platform:validated-<old-sha> \
+  --tag validated-<old-sha>-rollback
+
+# Or: Patch OCIRepository to pin specific version
+kubectl patch ocirepository platform -n flux-system \
+  --type=merge \
+  -p '{"spec":{"ref":{"tag":"validated-<old-sha>"}}}'
+```
+
+---
+
+## Workflow Details
+
+### kubernetes-validate.yaml
+
+Runs on PRs touching `kubernetes/`:
+
+1. **Lint**: yamllint on all YAML
+2. **Expand**: flux-operator expands ResourceSets
+3. **Build**: kustomize build with variable substitution
+4. **Template**: Helm template all charts
+5. **Validate**: kubeconform schema validation
+6. **Deprecations**: pluto checks for removed APIs
+
+### infrastructure-validate.yaml
+
+Runs on PRs touching `infrastructure/`:
+
+1. **Format**: terragrunt hclfmt + tofu fmt
+2. **Test**: tofu test for modified modules
+
+### build-platform-artifact.yaml
+
+Triggers on push to main (kubernetes/ changes):
+
+```yaml
+# Key steps
+flux push artifact \
+  oci://ghcr.io/${{ github.repository }}/platform:${SEMVER} \
+  --path=. \
+  --source="https://github.com/${{ github.repository }}" \
+  --revision="${{ github.ref_name }}@sha1:${{ github.sha }}"
+
+flux tag artifact ... --tag integration-${SHORT_SHA}
+```
+
+### tag-validated-artifact.yaml
+
+Triggers on `repository_dispatch` from canary-checker:
+
+```yaml
+# Validates SHA format and tags
+flux tag artifact \
+  "oci://ghcr.io/.../platform:integration-${SHA}" \
+  --tag "validated-${SHA}"
+```
+
+---
+
+## Cross-References
+
+| Document | Focus |
+|----------|-------|
+| [CLAUDE.md](../CLAUDE.md) | Promotion pipeline overview, principles |
+| [kubernetes/clusters/CLAUDE.md](../kubernetes/clusters/CLAUDE.md) | Per-cluster OCIRepository configuration |
+| [kubernetes/platform/CLAUDE.md](../kubernetes/platform/CLAUDE.md) | Flux patterns, ResourceSets |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,18 @@ Documentation and skills are living artifacts. Improve them proactively:
 - Anti-patterns encountered that should be warned against
 - Workflow improvements that benefit future tasks
 
+**Documentation maintenance skills:**
+
+| Skill | Purpose |
+|-------|---------|
+| `sync-claude` | Validate docs against codebase before commits |
+| `self-improvement` | Capture corrections and new patterns immediately |
+
+**Where does content belong?**
+- **CLAUDE.md files**: Declarative knowledge (what exists, why, constraints)
+- **Skills**: Procedural knowledge (step-by-step workflows)
+- **Runbooks**: Emergency procedures (disaster recovery, incident response)
+
 ## Agent Orchestration
 
 The main Claude agent operates as an **orchestrator**, not a direct executor. This maximizes context window efficiency and enables parallel work:
@@ -161,57 +173,9 @@ task renovate:validate
 
 ---
 
-# DEV CLUSTER OPERATIONS
+## Dev Cluster Operations
 
-The `dev` cluster is a sandbox environment for testing infrastructure changes. Claude has expanded permissions for dev cluster operations to facilitate testing workflows.
-
-## Allowed Operations (dev cluster only)
-
-```bash
-# Status checks (run freely)
-task inv:hosts                     # List all hosts
-task inv:power-status              # Check power state of all hosts
-task inv:status-<host>             # Check specific host IPMI status
-task talos:maint                   # Check maintenance mode for all hosts
-task talos:maint-<host>            # Check specific host maintenance mode
-
-# Infrastructure operations (require confirmation)
-task tg:plan-dev                   # Plan dev cluster changes
-task tg:apply-dev                  # Apply dev cluster changes
-task tg:gen-dev                    # Generate dev stack
-task tg:clean-dev                  # Clean dev stack cache
-```
-
-## AWS Credentials
-
-Infrastructure operations require AWS credentials for remote state and Parameter Store access:
-
-```bash
-export AWS_PROFILE=terragrunt
-export AWS_REGION=us-east-2
-```
-
-Verify credentials before running Terragrunt:
-```bash
-aws sts get-caller-identity
-```
-
-## Pre-Flight Checks
-
-Before running infrastructure operations on dev, verify cluster readiness:
-
-1. **Check host power**: `task inv:status-node45` (node45 is the dev cluster host)
-2. **Check maintenance mode**: `task talos:maint-node45`
-
-## Confirmation Required
-
-**ALWAYS use AskUserQuestion before:**
-- `task tg:apply-dev` (creates/modifies infrastructure)
-- Any operation that destroys or recreates resources
-
-This ensures the human operator is aware and approves state-changing operations, even on the dev cluster.
-
-## Scope Boundaries
+For dev cluster permissions, pre-flight checks, and safety procedures, see [.taskfiles/CLAUDE.md](.taskfiles/CLAUDE.md#dev-cluster-safety).
 
 | Cluster | Claude Permissions |
 |---------|-------------------|
@@ -358,6 +322,32 @@ mise doctor              # Diagnose environment issues
 - CI workflows use `jdx/mise-action` to install the same versions
 - Renovate auto-updates versions via the mise manager
 
+## Platform Version Management
+
+`kubernetes/platform/versions.env` is the **single source of truth** for all platform versions:
+
+- **Infrastructure versions**: Talos, Kubernetes, Cilium (read by Terragrunt)
+- **Helm chart versions**: All charts deployed via Flux (substituted at reconciliation)
+- **Upgrade operations**: Tuppr reads versions for declarative upgrades
+- **Dependency updates**: Renovate manages version bumps
+
+See [kubernetes/platform/CLAUDE.md](kubernetes/platform/CLAUDE.md) for detailed version management patterns.
+
+### Data Flow
+
+```
+kubernetes/platform/versions.env  ─────────────────────────────┐
+    │                                                          │
+    ├──→ infrastructure/stacks/*/  (Terragrunt reads versions) │
+    │         │                                                │
+    │         └──→ generates .cluster-vars.env per cluster     │
+    │                    │                                     │
+    │                    ▼                                     │
+    │    kubernetes/clusters/<cluster>/.cluster-vars.env       │
+    │                                                          │
+    └──→ kubernetes/platform/ (Flux substitutes versions) ◄────┘
+```
+
 ---
 
 # DIRECTORY-SPECIFIC DOCUMENTATION
@@ -366,10 +356,17 @@ Each major directory has its own CLAUDE.md with domain-specific patterns:
 
 | Directory | Focus |
 |-----------|-------|
-| [infrastructure/CLAUDE.md](infrastructure/CLAUDE.md) | Testing, validation, stacks, inventory lookups |
-| [kubernetes/platform/CLAUDE.md](kubernetes/platform/CLAUDE.md) | Flux patterns, secrets management, variable substitution |
+| [.github/CLAUDE.md](.github/CLAUDE.md) | CI/CD workflows, OCI artifact promotion pipeline |
+| [.taskfiles/CLAUDE.md](.taskfiles/CLAUDE.md) | Task commands, dev cluster safety |
+| [.claude/skills/CLAUDE.md](.claude/skills/CLAUDE.md) | Skill architecture and inventory |
+| [docs/CLAUDE.md](docs/CLAUDE.md) | Runbook organization and guidelines |
+| [infrastructure/CLAUDE.md](infrastructure/CLAUDE.md) | Architecture overview, testing philosophy |
+| [infrastructure/stacks/CLAUDE.md](infrastructure/stacks/CLAUDE.md) | Stack lifecycles and definitions |
+| [infrastructure/units/CLAUDE.md](infrastructure/units/CLAUDE.md) | Unit patterns and dependencies |
+| [infrastructure/modules/CLAUDE.md](infrastructure/modules/CLAUDE.md) | Module development and testing |
+| [kubernetes/platform/CLAUDE.md](kubernetes/platform/CLAUDE.md) | Flux patterns, secrets, version management |
+| [kubernetes/platform/config/CLAUDE.md](kubernetes/platform/config/CLAUDE.md) | Config subsystem organization |
 | [kubernetes/clusters/CLAUDE.md](kubernetes/clusters/CLAUDE.md) | Cluster configuration, promotion path |
-| [.taskfiles/CLAUDE.md](.taskfiles/CLAUDE.md) | Task commands quick reference |
 
 ## Skills (Lazy-Loaded)
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,213 @@
+# Documentation - Claude Reference
+
+The `docs/` directory contains operational runbooks, architectural plans, and supporting assets.
+
+---
+
+## Directory Structure
+
+```
+docs/
+├── runbooks/           # Emergency and operational procedures
+├── plans/              # Architectural design documents
+│   └── .archive/       # Superseded plans
+└── images/             # Supporting images and diagrams
+```
+
+---
+
+## Runbook Inventory
+
+| Runbook | Trigger Condition | Est. Time | Related Docs |
+|---------|-------------------|-----------|--------------|
+| `longhorn-disaster-recovery.md` | Complete cluster loss, need S3 restore | ~30 min | infrastructure/CLAUDE.md |
+| `network-policy-escape-hatch.md` | Emergency - network policies blocking critical traffic | ~5 min | kubernetes/platform/CLAUDE.md |
+| `network-policy-verification.md` | Verify network policy enforcement with Hubble | ~10 min | kubernetes/platform/CLAUDE.md |
+| `resize-volume.md` | Longhorn auto-expansion fails, PVC at capacity | ~5 min | kubernetes/platform/CLAUDE.md |
+| `supermicro-machine-setup.md` | New hardware - initial BIOS/IPMI config | ~20 min | infrastructure/CLAUDE.md |
+| `terragrunt-validation-state-issues.md` | Terragrunt validate fails with partial state | ~10 min | infrastructure/CLAUDE.md |
+
+### Runbook Summaries
+
+**longhorn-disaster-recovery.md**
+Complete cluster recovery procedure: rebuild infrastructure from git, restore Longhorn volumes from S3 backups. Use when cluster is unrecoverable.
+
+**network-policy-escape-hatch.md**
+Emergency bypass for network policies when they're blocking critical traffic. Temporary measure - must be reverted after debugging.
+
+**network-policy-verification.md**
+Verify Cilium network policies are working using Hubble flow observation. Use after policy changes or suspected policy issues.
+
+**resize-volume.md**
+Manual PVC resize when Longhorn's automatic expansion fails. Involves patching PVC and triggering filesystem resize.
+
+**supermicro-machine-setup.md**
+Physical setup checklist for new Supermicro hardware: BIOS settings, IPMI configuration, boot order for PXE.
+
+**terragrunt-validation-state-issues.md**
+Resolve "partial state" errors during `terragrunt validate`. Usually caused by missing dependencies or stale cache.
+
+---
+
+## Plan Documents
+
+| Plan | Status | Purpose |
+|------|--------|---------|
+| `coraza-waf.md` | Implemented | Coraza WAF integration for ingress protection |
+| `longhorn-dr-exercise.md` | In Progress | Automated disaster recovery exercise design |
+| `network-policy-architecture.md` | Implemented | Two-tier network policy model (namespace + workload) |
+| `oci-artifact-promotion.md` | In Progress | OCI-based GitOps promotion pipeline |
+
+**Archived plans** (in `docs/plans/.archive/`) are superseded designs kept for historical reference.
+
+---
+
+## Runbook vs CLAUDE.md vs Skill
+
+Use this decision tree to determine where documentation belongs:
+
+```
+Is this knowledge...
+
+├─ An emergency/incident procedure?
+│  └─ RUNBOOK (docs/runbooks/)
+│     - Step-by-step recovery actions
+│     - Time-sensitive operations
+│     - Procedures with potential data loss risk
+│     Examples: Disaster recovery, emergency policy bypass
+│
+├─ Declarative knowledge about the system?
+│  └─ CLAUDE.md (appropriate directory)
+│     - How the system works
+│     - Architecture and design decisions
+│     - Constraints and anti-patterns
+│     Examples: ResourceSet patterns, testing philosophy
+│
+├─ A multi-step workflow for normal operations?
+│  └─ SKILL (.claude/skills/)
+│     - Procedural how-to guides
+│     - Repeatable development workflows
+│     - Task automation guidance
+│     Examples: Adding a Helm release, debugging Flux
+│
+└─ An architectural design or proposal?
+    └─ PLAN (docs/plans/)
+       - Design documents
+       - Implementation proposals
+       - Architectural decisions
+       Examples: Network policy architecture, promotion pipeline
+```
+
+---
+
+## Runbook Format Guidelines
+
+### Template Structure
+
+```markdown
+# Runbook: <Title>
+
+## Overview
+Brief description of what this runbook addresses.
+
+## Prerequisites
+- Required access/permissions
+- Required tools
+- Required knowledge
+
+## Procedure
+
+### Step 1: <Action>
+Specific commands and explanations.
+
+### Step 2: <Action>
+...
+
+## Verification
+How to confirm the procedure succeeded.
+
+## Rollback (if applicable)
+How to undo changes if something goes wrong.
+
+## Related
+Links to related runbooks, CLAUDE.md sections, or skills.
+```
+
+### Style Guidelines
+
+- **Be explicit**: Include exact commands, not just descriptions
+- **Warn about risks**: Call out destructive operations clearly
+- **Include verification**: Every procedure should end with "how to confirm success"
+- **Time estimates**: Include realistic time estimates for planning
+- **Prerequisites first**: List what's needed before starting
+
+---
+
+## Naming Conventions
+
+### Runbooks
+
+Pattern: `<topic>-<action>.md` (kebab-case)
+
+| Good | Bad |
+|------|-----|
+| `resize-volume.md` | `ResizeVolume.md` |
+| `longhorn-disaster-recovery.md` | `dr.md` |
+| `network-policy-escape-hatch.md` | `net-pol-fix.md` |
+
+### Plans
+
+Pattern: `<feature-or-system>.md` (kebab-case)
+
+| Good | Bad |
+|------|-----|
+| `network-policy-architecture.md` | `netpol.md` |
+| `oci-artifact-promotion.md` | `promotion.md` |
+
+---
+
+## Adding a New Runbook
+
+### When to Create a Runbook
+
+- Procedure involves **risk of data loss** or service disruption
+- Procedure is **time-sensitive** (incident response)
+- Procedure requires **specific sequence** of steps
+- Procedure is **rarely performed** but critical when needed
+
+### Process
+
+1. Create file: `docs/runbooks/<topic>-<action>.md`
+2. Follow the template structure above
+3. Include realistic time estimates
+4. Add verification steps
+5. Add to root CLAUDE.md runbooks table if appropriate
+6. Test the procedure if possible
+
+### Checklist
+
+- [ ] Clear title describing the scenario
+- [ ] Prerequisites listed
+- [ ] Step-by-step commands (not just descriptions)
+- [ ] Verification steps included
+- [ ] Rollback procedure (if applicable)
+- [ ] Time estimate in root CLAUDE.md table
+
+---
+
+## Cross-References
+
+| Document | Focus |
+|----------|-------|
+| [Root CLAUDE.md](../CLAUDE.md) | Core principles, runbooks table |
+| [infrastructure/CLAUDE.md](../infrastructure/CLAUDE.md) | Infrastructure patterns |
+| [kubernetes/platform/CLAUDE.md](../kubernetes/platform/CLAUDE.md) | Platform configuration |
+| [.claude/skills/CLAUDE.md](../.claude/skills/CLAUDE.md) | Skill architecture |
+
+### Related Skills
+
+| Skill | Use For |
+|-------|---------|
+| `k8s-sre` | Kubernetes debugging (before escalating to runbook) |
+| `terragrunt` | Infrastructure operations |
+| `flux-gitops` | GitOps debugging |

--- a/infrastructure/modules/CLAUDE.md
+++ b/infrastructure/modules/CLAUDE.md
@@ -1,0 +1,300 @@
+# Modules - Claude Reference
+
+OpenTofu modules contain the implementation logic for infrastructure provisioning. Modules are pure Terraform/OpenTofu code with resources, variables, and outputs.
+
+For architectural context (units vs modules), see [infrastructure/CLAUDE.md](../CLAUDE.md). For unit patterns that compose these modules, see [infrastructure/units/CLAUDE.md](../units/CLAUDE.md).
+
+---
+
+## Module Inventory
+
+| Module | Purpose | Providers | Has Tests |
+|--------|---------|-----------|-----------|
+| `config` | Centralized configuration brain - computes all environment-specific settings | None (pure computation) | ✅ 9 tests |
+| `talos` | Talos Linux cluster provisioning - secrets, machine configs, bootstrap | talos | ✅ 4 tests |
+| `bootstrap` | Flux GitOps bootstrapping - namespaces, secrets, Helm releases | kubernetes, helm | ✅ 1 test |
+| `unifi` | Network infrastructure - DNS records, DHCP reservations | unifi | ✅ 1 test |
+| `pki` | Certificate authority generation and SSM storage | tls, aws | ✅ 1 test |
+| `aws-set-params` | AWS SSM parameter storage | aws | ✅ 1 test |
+| `longhorn-storage` | S3 backup infrastructure for Longhorn volumes | aws | ❌ |
+
+---
+
+## Architecture Context
+
+### Modules = Implementation Logic
+
+Modules contain all business logic:
+- Conditional expressions based on cluster name
+- Feature flag handling
+- Resource provisioning
+- Data transformations
+
+### Units = Thin Wiring
+
+Units (in `infrastructure/units/`) wire modules together:
+- No business logic
+- Pass configuration from config module to other modules
+- Declare dependencies
+
+### The Config Module
+
+The `config` module is the "brain" — it:
+- Reads global configuration (inventory, networking, versions)
+- Computes all environment-specific settings
+- Has **no providers** (pure computation)
+- Exposes structured outputs consumed by other modules
+
+Other modules receive pre-computed values, keeping them simple.
+
+---
+
+## Module Structure
+
+Standard module layout:
+
+```
+modules/<name>/
+├── main.tf              # Resources and data sources
+├── variables.tf         # Input variable definitions
+├── outputs.tf           # Output value definitions
+├── versions.tf          # Provider version constraints
+├── locals.tf            # Local values (optional)
+├── templates/           # Template files (optional)
+│   └── *.tftpl
+└── tests/               # OpenTofu native tests
+    ├── plan.tftest.hcl  # Basic plan test
+    └── *.tftest.hcl     # Feature/edge case tests
+```
+
+### File Purposes
+
+| File | Purpose |
+|------|---------|
+| `main.tf` | Primary resources and business logic |
+| `variables.tf` | Input definitions with descriptions and validation |
+| `outputs.tf` | Structured outputs for unit consumption |
+| `versions.tf` | Required provider versions |
+| `tests/*.tftest.hcl` | OpenTofu native tests |
+
+---
+
+## Testing Strategy
+
+Testing uses OpenTofu native testing (`tofu test`). Every module should have tests.
+
+### Running Tests
+
+```bash
+# Test specific module
+task tg:test-<module>         # e.g., task tg:test-config
+
+# Test all modules
+task tg:test
+```
+
+### Test File Organization
+
+| Pattern | Purpose | Example |
+|---------|---------|---------|
+| `plan.tftest.hcl` | Basic plan verification | All modules |
+| `feature_<name>.tftest.hcl` | Feature flag tests | `feature_longhorn.tftest.hcl` |
+| `validation.tftest.hcl` | Input validation tests | Config module |
+| `edge_cases.tftest.hcl` | Boundary conditions | Talos, config modules |
+| `<component>.tftest.hcl` | Component-specific tests | `bootstrap_charts.tftest.hcl` |
+
+### Test Structure
+
+```hcl
+# Top-level variables set defaults for ALL run blocks
+variables {
+  name     = "test-cluster"
+  features = ["gateway-api"]
+  machines = {
+    node1 = {
+      cluster = "test-cluster"
+      type    = "controlplane"
+      # ... complete definition
+    }
+  }
+}
+
+# Individual test cases
+run "feature_enabled" {
+  command = plan
+
+  # Override only what differs from defaults
+  variables {
+    features = ["prometheus"]
+  }
+
+  # Assertions
+  assert {
+    condition     = output.prometheus_enabled == true
+    error_message = "Prometheus should be enabled"
+  }
+}
+```
+
+### Assertion Patterns
+
+| Pattern | Use Case | Example |
+|---------|----------|---------|
+| Equality | Exact value match | `condition = output.value == "expected"` |
+| Contains | List membership | `condition = contains(output.list, "item")` |
+| Length | Collection size | `condition = length(output.list) == 3` |
+| Not null | Value exists | `condition = output.value != null` |
+| Regex | Pattern match | `condition = can(regex("^v[0-9]", output.version))` |
+| Negation | Absence check | `condition = !contains(output.list, "bad")` |
+
+### Mock Providers
+
+Use mock providers for external dependencies:
+
+```hcl
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+}
+
+run "test_with_mocked_aws" {
+  command = plan
+  # Test runs without real AWS credentials
+}
+```
+
+---
+
+## Module Patterns
+
+### Feature Flags via Set
+
+```hcl
+# variables.tf
+variable "features" {
+  type = set(string)
+  validation {
+    condition = alltrue([
+      for f in var.features : contains([
+        "gateway-api", "longhorn", "prometheus", "spegel"
+      ], f)
+    ])
+    error_message = "Invalid feature flag"
+  }
+}
+
+# main.tf
+locals {
+  longhorn_enabled = contains(var.features, "longhorn")
+}
+```
+
+### Lookup with Defaults
+
+```hcl
+locals {
+  storage_sizes = {
+    minimal = { prometheus = "10Gi" }
+    normal  = { prometheus = "50Gi" }
+  }
+  prometheus_size = local.storage_sizes[var.storage_provisioning].prometheus
+}
+```
+
+### Structured Outputs
+
+```hcl
+# outputs.tf
+output "talos" {
+  description = "Talos configuration for talos unit"
+  value = {
+    talos_version      = var.versions.talos
+    kubernetes_version = var.versions.kubernetes
+    machines           = local.talos_machines
+  }
+}
+```
+
+### Template Files
+
+```hcl
+# main.tf
+resource "local_file" "config" {
+  content = templatefile("${path.module}/templates/config.tftpl", {
+    cluster_name = var.name
+    domain       = var.domain
+  })
+  filename = "${path.module}/output/config.yaml"
+}
+```
+
+### Variable Validation
+
+```hcl
+variable "name" {
+  type = string
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.name))
+    error_message = "Name must be lowercase alphanumeric with hyphens"
+  }
+}
+```
+
+### For-Each with Computed Keys
+
+```hcl
+resource "aws_ssm_parameter" "params" {
+  for_each = {
+    for k, v in var.parameters : k => v
+    if v != null
+  }
+  name  = each.key
+  value = each.value
+  type  = "SecureString"
+}
+```
+
+---
+
+## Common Pitfalls
+
+| Pitfall | Problem | Solution |
+|---------|---------|----------|
+| Logic in units | Makes testing hard | Put all logic in config module |
+| Missing mock providers | Tests require real credentials | Add mock_provider blocks |
+| Incomplete test variables | Tests fail on missing required vars | Define all required vars at top level |
+| Hardcoded values | Can't adapt to environments | Use variables or config module outputs |
+| Missing validation | Bad inputs cause confusing errors | Add validation blocks to variables |
+| Circular dependencies | Terraform fails to plan | Restructure outputs to break cycles |
+
+---
+
+## Adding a New Module
+
+### Checklist
+
+1. Create directory: `infrastructure/modules/<name>/`
+2. Create core files:
+   - `main.tf` - Resources
+   - `variables.tf` - Inputs with descriptions
+   - `outputs.tf` - Structured outputs
+   - `versions.tf` - Provider requirements
+3. Create tests: `tests/plan.tftest.hcl`
+4. Add output to config module (if needed)
+5. Create unit in `infrastructure/units/<name>/`
+6. Add unit to relevant stacks
+7. Run `task tg:test-<name> && task tg:validate-<stack>`
+
+---
+
+## Cross-References
+
+| Document | Focus |
+|----------|-------|
+| [infrastructure/CLAUDE.md](../CLAUDE.md) | Architecture overview, testing philosophy |
+| [infrastructure/units/CLAUDE.md](../units/CLAUDE.md) | Unit patterns that compose modules |
+| [infrastructure/stacks/CLAUDE.md](../stacks/CLAUDE.md) | Stack lifecycle management |
+| [opentofu-modules skill](../../.claude/skills/opentofu-modules/SKILL.md) | Detailed testing patterns |

--- a/infrastructure/stacks/CLAUDE.md
+++ b/infrastructure/stacks/CLAUDE.md
@@ -1,0 +1,236 @@
+# Stacks - Claude Reference
+
+Terragrunt stacks compose units into deployable infrastructure with specific lifecycles and configurations.
+
+For architecture context (units vs modules), see [infrastructure/CLAUDE.md](../CLAUDE.md). For unit patterns, see [infrastructure/units/CLAUDE.md](../units/CLAUDE.md).
+
+---
+
+## Stack Inventory
+
+| Stack | Lifecycle | Purpose | Units |
+|-------|-----------|---------|-------|
+| `global` | **Persistent** | Cross-cluster infrastructure (S3 backups, PKI) | longhorn-storage, pki, ingress-pki |
+| `dev` | Ephemeral | Development cluster | config, unifi, talos, bootstrap, aws-set-params |
+| `integration` | Ephemeral | Integration/validation cluster | config, unifi, talos, bootstrap, aws-set-params |
+| `live` | Ephemeral | Production cluster | config, unifi, talos, bootstrap, aws-set-params |
+
+---
+
+## Stack Definition Structure
+
+Each stack has a `terragrunt.stack.hcl` that defines:
+
+1. **Locals**: Stack-specific configuration values
+2. **Units**: Which units to include and their values
+
+### Cluster Stack Example (dev)
+
+```hcl
+# infrastructure/stacks/dev/terragrunt.stack.hcl
+locals {
+  name                 = "${basename(get_terragrunt_dir())}"  # "dev"
+  features             = ["gateway-api", "longhorn", "prometheus", "spegel"]
+  storage_provisioning = "minimal"
+}
+
+unit "config" {
+  source = "../../units/config"
+  path   = "config"
+
+  values = {
+    name                 = local.name
+    features             = local.features
+    storage_provisioning = local.storage_provisioning
+  }
+}
+
+unit "unifi" {
+  source = "../../units/unifi"
+  path   = "unifi"
+}
+
+# ... additional units
+```
+
+### Global Stack Example
+
+```hcl
+# infrastructure/stacks/global/terragrunt.stack.hcl
+locals {
+  clusters = ["dev", "integration", "live"]  # All clusters needing shared infra
+}
+
+unit "longhorn_storage" {
+  source = "../../units/longhorn-storage"
+  path   = "longhorn-storage"
+
+  values = {
+    clusters = local.clusters
+  }
+}
+
+unit "pki" {
+  source = "../../units/pki"
+  path   = "pki"
+}
+
+unit "ingress_pki" {
+  source = "../../units/ingress-pki"
+  path   = "ingress-pki"
+}
+```
+
+### Stack Definition Elements
+
+| Element | Purpose |
+|---------|---------|
+| `locals` | Stack-specific configuration (name, features, etc.) |
+| `unit.source` | Path to unit directory in `infrastructure/units/` |
+| `unit.path` | Output path in `.terragrunt-stack/` (generated directory) |
+| `unit.values` | Data passed to unit's `values.*` references |
+
+---
+
+## Lifecycle Types
+
+### Persistent Stacks
+
+**Global stack is persistent** — it contains resources that must survive cluster rebuilds:
+
+- **S3 backup buckets** for Longhorn disaster recovery
+- **PKI certificates** for Istio mesh and ingress
+- **IAM credentials** for cluster access to backups
+
+**Operational rules:**
+- ❌ **NEVER** destroy without explicit approval and backup verification
+- ❌ **NEVER** include in routine stack refreshes
+- ✅ Apply changes carefully with thorough review
+
+### Ephemeral Stacks
+
+**Cluster stacks (dev, integration, live) are ephemeral** — they can be rebuilt from git:
+
+- Talos machine configurations
+- Kubernetes bootstrap resources
+- Network provisioning (DNS, DHCP)
+
+**Operational rules:**
+- ✅ Can be destroyed and recreated
+- ✅ Safe to rebuild from scratch
+- ✅ State stored in S3 for recovery
+
+---
+
+## Stack Operations
+
+All operations use task commands — **NEVER** run terragrunt directly.
+
+```bash
+# Generate stack files (creates .terragrunt-stack/ directory)
+task tg:gen-<stack>            # e.g., task tg:gen-dev
+
+# Validate without applying
+task tg:validate-<stack>       # e.g., task tg:validate-dev
+
+# Plan changes
+task tg:plan-<stack>           # e.g., task tg:plan-dev
+
+# Apply changes (REQUIRES HUMAN APPROVAL)
+task tg:apply-<stack>          # e.g., task tg:apply-dev
+
+# Clean generated files
+task tg:clean-<stack>          # e.g., task tg:clean-dev
+```
+
+### Stack Generation
+
+`task tg:gen-<stack>` creates the `.terragrunt-stack/` directory with:
+- Expanded unit configurations
+- Resolved dependencies
+- Ready-to-plan infrastructure
+
+**Always regenerate after modifying stack or unit definitions.**
+
+---
+
+## Feature Flags
+
+Stacks enable features via the `features` array:
+
+| Feature | Description | Detection Logic |
+|---------|-------------|-----------------|
+| `gateway-api` | Gateway API CRDs | `contains(var.features, "gateway-api")` |
+| `longhorn` | Distributed storage with iSCSI | `contains(var.features, "longhorn")` |
+| `prometheus` | Metrics collection | `contains(var.features, "prometheus")` |
+| `spegel` | P2P image distribution | `contains(var.features, "spegel")` |
+
+Feature detection lives in `modules/config/main.tf`:
+
+```hcl
+locals {
+  gateway_api_enabled = contains(var.features, "gateway-api")
+  longhorn_enabled    = contains(var.features, "longhorn")
+  prometheus_enabled  = contains(var.features, "prometheus")
+  spegel_enabled      = contains(var.features, "spegel")
+}
+```
+
+---
+
+## Storage Provisioning
+
+Stacks specify storage sizing via `storage_provisioning`:
+
+| Mode | Used By | Prometheus PV | Use Case |
+|------|---------|---------------|----------|
+| `minimal` | dev, integration | 10Gi | Testing, low resource usage |
+| `normal` | live | 50Gi | Production workloads |
+
+Sizing logic is in `modules/config/main.tf` based on provisioning mode.
+
+---
+
+## When to Create a New Stack
+
+```
+Need new infrastructure deployment?
+│
+├─ Is it a new cluster environment?
+│   └─ YES → Create new stack in stacks/<name>/
+│            Copy from existing cluster stack
+│            Adjust features and storage_provisioning
+│
+├─ Is it persistent cross-cluster infrastructure?
+│   └─ YES → Add unit to global stack
+│            Do NOT create new stack
+│
+├─ Is it cluster-specific configuration?
+│   └─ YES → Add to config module
+│            Do NOT create new stack
+│
+└─ Is it a new capability for existing clusters?
+    └─ YES → Create new unit + module
+             Add unit to appropriate stacks
+```
+
+### Checklist for New Cluster Stack
+
+1. Create directory: `infrastructure/stacks/<name>/`
+2. Create `terragrunt.stack.hcl` (copy from similar stack)
+3. Set appropriate `name`, `features`, `storage_provisioning`
+4. Add hosts to `inventory.hcl` with `cluster = "<name>"`
+5. Add networking config to `networking.hcl`
+6. Update `modules/config/main.tf` for cluster-specific logic
+7. Run `task tg:gen-<name> && task tg:validate-<name>`
+
+---
+
+## Cross-References
+
+| Document | Focus |
+|----------|-------|
+| [infrastructure/CLAUDE.md](../CLAUDE.md) | Architecture overview, units vs modules |
+| [infrastructure/units/CLAUDE.md](../units/CLAUDE.md) | Unit patterns and dependencies |
+| [infrastructure/modules/CLAUDE.md](../modules/CLAUDE.md) | Module development and testing |
+| [kubernetes/platform/versions.env](../../kubernetes/platform/versions.env) | Version source of truth |

--- a/infrastructure/units/CLAUDE.md
+++ b/infrastructure/units/CLAUDE.md
@@ -1,0 +1,371 @@
+# Units - Claude Reference
+
+Terragrunt units are thin wiring layers that orchestrate OpenTofu modules. They compose modules into deployable infrastructure without implementing business logic.
+
+For architectural context and the separation of concerns between units and modules, see [infrastructure/CLAUDE.md](../CLAUDE.md).
+
+---
+
+## Unit Inventory
+
+| Unit | Module | Purpose | Dependencies |
+|------|--------|---------|--------------|
+| `config` | `modules/config` | Computes all cluster configuration; the "brain" of the stack | None |
+| `unifi` | `modules/unifi` | Provisions DNS records and DHCP reservations | `config` |
+| `talos` | `modules/talos` | Provisions Talos Linux cluster nodes | `config`, `unifi` |
+| `bootstrap` | `modules/bootstrap` | Bootstraps Flux GitOps and cluster credentials | `config`, `talos` |
+| `aws-set-params` | `modules/aws-set-params` | Stores kubeconfig/talosconfig in AWS SSM | `config`, `talos` |
+| `pki` | `modules/pki` | Generates PKI certificates (Istio mesh CA) | None |
+| `ingress-pki` | `modules/pki` | Generates PKI certificates (ingress CA) | None |
+| `longhorn-storage` | `modules/longhorn-storage` | Provisions S3 backup buckets for all clusters | None |
+
+---
+
+## Architecture Context
+
+Units follow a strict separation of concerns:
+
+### Units = Thin Wiring
+
+Units wire dependencies between modules and pass configuration through. They contain:
+- Module source references
+- Dependency declarations
+- Input mappings from dependencies to module variables
+- **No business logic, no conditionals, no computations**
+
+### Modules = Implementation
+
+Modules contain all business logic:
+- Conditional expressions based on cluster name
+- Feature flag handling
+- Resource provisioning
+- Data transformations
+
+### Why This Pattern?
+
+1. **Testability**: Module logic is tested via `tofu test`; units are too simple to need tests
+2. **Single source of truth**: All environment differences live in the config module
+3. **Maintainability**: Adding a new cluster only requires updating the config module
+4. **Visibility**: Easy to audit what differs between environments
+
+---
+
+## The Config Unit
+
+The `config` unit is the "brain" of every cluster stack. It:
+
+1. **Reads global configuration** from parent HCL files (`inventory.hcl`, `networking.hcl`, `accounts.hcl`)
+2. **Reads platform versions** from `kubernetes/platform/versions.env`
+3. **Computes cluster-specific configuration** for all other units
+4. **Exposes structured outputs** consumed by downstream units
+
+### Config Inputs
+
+```hcl
+# infrastructure/units/config/terragrunt.hcl
+inputs = {
+  name                   = values.name                    # From stack
+  features               = values.features                # From stack
+  storage_provisioning   = values.storage_provisioning    # From stack
+  networking             = local.networking_vars.locals.clusters[values.name]
+  machines               = local.inventory_vars.locals.hosts
+  versions               = local.versions                 # Parsed from versions.env
+  local_paths            = local.local_paths
+  accounts               = local.accounts_vars.locals.accounts
+  cilium_values_template = file("${get_repo_root()}/kubernetes/platform/charts/cilium.yaml")
+}
+```
+
+### Config Outputs
+
+Other units consume config outputs via dependency blocks:
+
+| Output | Consumers | Description |
+|--------|-----------|-------------|
+| `talos` | `talos` unit | Machine configs, versions, bootstrap charts |
+| `unifi` | `unifi` unit | DNS records, DHCP reservations |
+| `bootstrap` | `bootstrap` unit | Cluster name, flux version, cluster vars, OCI settings |
+| `aws_set_params` | `aws-set-params` unit | SSM parameter paths |
+| `cluster_name` | Multiple | Cluster identifier |
+
+---
+
+## Unit Structure
+
+Every unit follows this standard pattern:
+
+```hcl
+# Include root configuration (remote state, providers)
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+# Reference the implementing module
+terraform {
+  source = "../../../.././/modules/<module-name>"
+}
+
+# Declare dependencies on other units
+dependency "config" {
+  config_path = "../config"
+
+  # Mock outputs enable `terragrunt validate` without applying dependencies
+  mock_outputs = {
+    # ... structured mock data matching module outputs
+  }
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan", "destroy"]
+}
+
+# Pass dependency outputs to module inputs
+inputs = {
+  some_input = dependency.config.outputs.module_name.some_output
+}
+```
+
+### Key Elements
+
+| Element | Purpose |
+|---------|---------|
+| `include "root"` | Inherits remote state backend, providers, catalog |
+| `terraform.source` | Path to implementing module (always relative to repo root) |
+| `dependency` | Declares unit ordering and output passing |
+| `mock_outputs` | Enables validation without applying dependencies |
+| `inputs` | Maps dependency outputs to module variables |
+
+---
+
+## Dependency Patterns
+
+### Simple Pass-Through
+
+When a module's inputs match a config output exactly:
+
+```hcl
+# infrastructure/units/talos/terragrunt.hcl
+inputs = dependency.config.outputs.talos
+```
+
+### Composed Inputs
+
+When inputs come from multiple sources:
+
+```hcl
+# infrastructure/units/bootstrap/terragrunt.hcl
+inputs = {
+  # From config output
+  cluster_name     = dependency.config.outputs.bootstrap.cluster_name
+  flux_version     = dependency.config.outputs.bootstrap.flux_version
+
+  # From talos output (kubeconfig for cluster access)
+  kubeconfig = {
+    host                   = dependency.talos.outputs.kubeconfig_host
+    client_certificate     = dependency.talos.outputs.kubeconfig_client_certificate
+    client_key             = dependency.talos.outputs.kubeconfig_client_key
+    cluster_ca_certificate = dependency.talos.outputs.kubeconfig_cluster_ca_certificate
+  }
+
+  # From parent HCL files
+  github = local.accounts_vars.locals.accounts.github
+}
+```
+
+### Ordering Dependencies
+
+Use `skip_outputs = true` when you need ordering but no outputs:
+
+```hcl
+# infrastructure/units/talos/terragrunt.hcl
+dependency "unifi" {
+  config_path = "../unifi"
+
+  mock_outputs                            = {}
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan", "destroy"]
+  skip_outputs                            = true  # Only for ordering
+}
+```
+
+### Mock Outputs
+
+Mock outputs enable `terragrunt validate` and `terragrunt plan` without applying dependencies. They must match the structure of real outputs:
+
+```hcl
+mock_outputs = {
+  talos = {
+    talos_version      = "v1.12.0"
+    kubernetes_version = "1.34.0"
+    talos_machines = [
+      {
+        install = { selector = "disk.model = *", secureboot = false }
+        configs = ["kind: HostnameConfig\nhostname: mock"]
+      }
+    ]
+  }
+}
+mock_outputs_allowed_terraform_commands = ["init", "validate", "plan", "destroy"]
+```
+
+---
+
+## Design Principles
+
+### Keep Units Dumb
+
+Units should contain **zero business logic**:
+
+```hcl
+# BAD - logic in unit
+inputs = {
+  replica_count = length(dependency.config.outputs.machines) > 3 ? 3 : length(...)
+}
+
+# GOOD - logic in module
+inputs = dependency.config.outputs.bootstrap
+# The config module computes replica_count internally
+```
+
+### Delegate to Modules
+
+All conditional logic, feature flags, and environment differences belong in modules:
+
+```hcl
+# infrastructure/modules/config/main.tf
+locals {
+  oci_config = {
+    dev         = { source_type = "git", semver = "" }
+    integration = { source_type = "oci", semver = ">= 0.0.0-0" }
+    live        = { source_type = "oci", semver = ">= 0.0.0" }
+  }
+}
+```
+
+### Single Responsibility
+
+Each unit orchestrates exactly one module:
+
+| Unit | Module | Single Responsibility |
+|------|--------|----------------------|
+| `config` | `config` | Compute configuration |
+| `talos` | `talos` | Provision Talos nodes |
+| `bootstrap` | `bootstrap` | Bootstrap Flux |
+| `pki` | `pki` | Generate certificates |
+
+### Reuse Modules
+
+Multiple units can use the same module with different inputs:
+
+```hcl
+# infrastructure/units/pki/terragrunt.hcl
+inputs = {
+  ca_name = "istio-mesh"
+  ca_subject = { organization = "homelab", common_name = "istio-mesh-root-ca" }
+}
+
+# infrastructure/units/ingress-pki/terragrunt.hcl (same module, different config)
+inputs = {
+  ca_name = "homelab-ingress"
+  ca_subject = { organization = "homelab", common_name = "homelab-ingress-root-ca" }
+}
+```
+
+---
+
+## When to Add a New Unit
+
+Use this decision tree:
+
+```
+Need new infrastructure capability?
+|
++- Is it a new instance of existing module?
+|   +- YES -> Create new unit referencing existing module
+|            Example: ingress-pki reuses pki module
+|
++- Is it a new capability entirely?
+|   +- YES -> Create new module first, then new unit
+|            1. Add module to infrastructure/modules/
+|            2. Add unit to infrastructure/units/
+|            3. Include unit in relevant stacks
+|
++- Is it cluster-specific configuration?
+|   +- YES -> Add to config module outputs
+|            Do NOT create new unit
+|
++- Is it a transformation of existing data?
+    +- YES -> Add logic to config module
+             Do NOT create new unit
+```
+
+### Checklist for New Units
+
+1. Create module in `infrastructure/modules/<name>/`
+2. Write tests in `infrastructure/modules/<name>/tests/`
+3. Create unit in `infrastructure/units/<name>/terragrunt.hcl`
+4. Add unit to relevant stacks in `infrastructure/stacks/*/terragrunt.stack.hcl`
+5. Run `task tg:fmt && task tg:test-<name> && task tg:validate-<stack>`
+
+---
+
+## Stack Composition
+
+Stacks compose units into deployable infrastructure:
+
+### Cluster Stacks (dev, integration, live)
+
+```hcl
+# infrastructure/stacks/dev/terragrunt.stack.hcl
+unit "config"        { source = "../../units/config"         }
+unit "unifi"         { source = "../../units/unifi"          }
+unit "talos"         { source = "../../units/talos"          }
+unit "bootstrap"     { source = "../../units/bootstrap"      }
+unit "aws_set_params" { source = "../../units/aws-set-params" }
+```
+
+### Global Stack
+
+Cross-cluster resources with independent lifecycles:
+
+```hcl
+# infrastructure/stacks/global/terragrunt.stack.hcl
+unit "longhorn_storage" { source = "../../units/longhorn-storage" }
+unit "pki"              { source = "../../units/pki"              }
+unit "ingress_pki"      { source = "../../units/ingress-pki"      }
+```
+
+---
+
+## Dependency Graph
+
+```
+                    +-------------+
+                    |   config    |
+                    +------+------+
+                           |
+              +------------+------------+
+              v            v            v
+        +---------+  +----------+  +-----------------+
+        |  unifi  |  |  (other  |  |  aws_set_params |
+        +----+----+  |  units)  |  |  (needs talos)  |
+             |       +----------+  +--------+--------+
+             |                              |
+             v                              |
+        +---------+                         |
+        |  talos  | <-----------------------+
+        +----+----+
+             |
+             v
+        +-----------+
+        | bootstrap |
+        +-----------+
+```
+
+**Execution order**: config -> unifi -> talos -> bootstrap, aws-set-params
+
+---
+
+## Cross-References
+
+| Document | Focus |
+|----------|-------|
+| [infrastructure/CLAUDE.md](../CLAUDE.md) | Architecture overview, testing, stacks |
+| [infrastructure/modules/CLAUDE.md](../modules/CLAUDE.md) | Module implementations and testing |
+| [kubernetes/platform/versions.env](../../kubernetes/platform/versions.env) | Platform versions (single source of truth) |

--- a/kubernetes/platform/config/CLAUDE.md
+++ b/kubernetes/platform/config/CLAUDE.md
@@ -1,0 +1,261 @@
+# Config Subsystems - Claude Reference
+
+The `config/` directory contains non-Helm resources organized by subsystem. These are Kubernetes resources that are applied after Helm releases, including CRDs, policies, and cluster-wide configurations.
+
+For Flux patterns and version management, see [kubernetes/platform/CLAUDE.md](../CLAUDE.md).
+
+---
+
+## Config Subsystem Inventory
+
+| Subsystem | Purpose | Key Resources |
+|-----------|---------|---------------|
+| `canary-checker/` | Platform health validation | Canary, PrometheusRule |
+| `certs/` | TLS certificates for gateways | Certificate |
+| `cilium/` | Load balancer config, L2 announcements | CiliumLoadBalancerIPPool, CiliumL2AnnouncementPolicy |
+| `database/` | Shared PostgreSQL cluster | Cluster, Pooler (CNPG) |
+| `flux-notifications/` | Flux alert providers and routing | Provider, Alert |
+| `garage/` | S3-compatible object storage | GarageCluster |
+| `gateway/` | Gateway API resources and WAF | Gateway, HTTPRoute, WasmPlugin |
+| `issuers/` | Certificate issuers | ClusterIssuer (3 types) |
+| `kromgo/` | Status page metrics | ConfigMap, HTTPRoute |
+| `longhorn/` | Storage classes, backup config | StorageClass, RecurringJob |
+| `monitoring/` | Alertmanager config, alert rules | PrometheusRule, ServiceMonitor, AlertmanagerConfig |
+| `network-policy/` | Cilium network policies | CiliumNetworkPolicy, CiliumClusterwideNetworkPolicy |
+| `secrets/` | External secrets infrastructure | ClusterSecretStore |
+| `tuppr/` | Talos and Kubernetes upgrades | TalosUpgrade, KubernetesUpgrade |
+
+---
+
+## Purpose of Config vs Helm
+
+### When to Use Helm Values (`charts/*.yaml`)
+
+- Resources **managed by the chart** (Deployments, Services, etc.)
+- Chart-provided configuration options
+- Resources that **change with chart versions**
+
+### When to Use Config Kustomization (`config/*/`)
+
+- **Post-install CRs** that use CRDs from Helm charts
+- **Cluster-wide resources** not tied to a specific chart
+- **Cross-cutting concerns** (network policies, certificates)
+- Resources that **reference multiple charts** or namespaces
+
+### Hybrid Patterns
+
+Some subsystems use both:
+
+| Subsystem | Helm Values | Config Resources |
+|-----------|-------------|------------------|
+| Longhorn | Chart deployment | StorageClass, RecurringJob |
+| Monitoring | kube-prometheus-stack | Additional PrometheusRules |
+| Cert-manager | Chart deployment | ClusterIssuers, Certificates |
+| Cilium | CNI deployment | CiliumNetworkPolicy |
+
+---
+
+## Decision Tree
+
+```
+Need to add a Kubernetes resource?
+│
+├─ Is it a CRD instance (CR)?
+│   │
+│   ├─ Is the CRD from a Helm chart?
+│   │   └─ YES → Add to config/<subsystem>/
+│   │            Declare dependency on the HelmRelease
+│   │
+│   └─ Is it a built-in resource (ConfigMap, Secret)?
+│       └─ Add to config/<subsystem>/ if cross-cutting
+│          Or add to Helm values if chart-specific
+│
+├─ Is it configuration for an existing chart?
+│   └─ YES → Add to charts/<chart-name>.yaml
+│
+└─ Is it a new application?
+    └─ YES → Use Helm release in helm-charts.yaml
+             Add config/ subsystem if needed for CRs
+```
+
+---
+
+## CRD Dependencies
+
+Config kustomizations must declare dependencies on the HelmReleases that provide their CRDs.
+
+### Quick Reference
+
+| CRD | Provided By (HelmRelease) |
+|-----|---------------------------|
+| `Certificate`, `ClusterIssuer` | cert-manager |
+| `CiliumNetworkPolicy`, `CiliumLoadBalancerIPPool` | cilium |
+| `Cluster`, `Pooler` (CNPG) | cloudnative-pg |
+| `Canary` | canary-checker |
+| `Gateway`, `HTTPRoute` | (Gateway API CRDs - pre-installed) |
+| `PrometheusRule`, `ServiceMonitor` | kube-prometheus-stack |
+| `TalosUpgrade`, `KubernetesUpgrade` | tuppr |
+| `WasmPlugin` | istio-istiod |
+| `GarageCluster` | garage |
+
+### Finding CRD Providers
+
+```bash
+# Check which chart provides a CRD
+kubectl get crd <crd-name> -o jsonpath='{.metadata.labels}'
+
+# Or use kubectl explain
+kubectl explain <resource>
+```
+
+### Declaring Dependencies
+
+In the config kustomization (from `kubernetes/platform/config.yaml` ResourceSet):
+
+```yaml
+inputs:
+  - name: "monitoring"
+    namespace: "monitoring"
+    dependsOn: [kube-prometheus-stack]  # HelmRelease that provides CRDs
+```
+
+---
+
+## Adding a New Config Subsystem
+
+### Step 1: Create Directory Structure
+
+```bash
+mkdir -p kubernetes/platform/config/<subsystem>
+```
+
+### Step 2: Create kustomization.yaml
+
+```yaml
+# kubernetes/platform/config/<subsystem>/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - resource1.yaml
+  - resource2.yaml
+```
+
+### Step 3: Add Resources
+
+Create YAML files for your resources in the directory.
+
+### Step 4: Register in config.yaml ResourceSet
+
+Add entry to `kubernetes/platform/config.yaml`:
+
+```yaml
+inputs:
+  - name: "<subsystem>"
+    namespace: "<target-namespace>"
+    dependsOn: [<helm-release-providing-crds>]
+```
+
+### Step 5: Validate
+
+```bash
+task k8s:validate
+```
+
+---
+
+## Naming Conventions
+
+### Directory Naming
+
+- Use **kebab-case**: `network-policy`, `flux-notifications`
+- Match the **primary concern**: `monitoring` (not `prometheus-rules`)
+- Group related resources: `longhorn/` contains storage-classes, backup, recurring-jobs
+
+### File Naming
+
+| Pattern | Use Case | Example |
+|---------|----------|---------|
+| `<resource-type>.yaml` | Single resource of type | `storageclass.yaml` |
+| `<name>-<type>.yaml` | Multiple of same type | `prometheus-rules.yaml` |
+| `kustomization.yaml` | Directory aggregation | Required in each dir |
+
+### Resource Naming
+
+- Use cluster/namespace context: `homelab-ingress-ca` (not just `ca`)
+- Include subsystem prefix when ambiguous: `longhorn-backup-daily`
+
+---
+
+## Subsystem Deep Dives
+
+### Network Policy Organization
+
+```
+network-policy/
+├── baselines/           # Namespace-level defaults
+├── profiles/            # Reusable policy templates
+├── platform/            # Platform service policies
+└── shared-resources/    # Cross-namespace access rules
+```
+
+Two-tier model:
+1. **Baseline policies**: Default deny + common allows per namespace
+2. **Workload policies**: Specific rules per application
+
+### Issuers Organization
+
+```
+issuers/
+├── cloudflare-issuer/   # Public certs via DNS-01 challenge
+├── homelab-ca/          # Internal CA for services
+└── istio-mesh-ca/       # Istio mTLS certificates
+```
+
+### Longhorn Organization
+
+```
+longhorn/
+├── backup/              # Backup target configuration
+├── recurring-jobs/      # Scheduled backup jobs
+├── routes/              # UI access routes
+└── storage-classes/     # StorageClass definitions
+```
+
+### Monitoring Organization
+
+The `monitoring/` subsystem is the largest, containing:
+- PrometheusRules for alerting
+- ServiceMonitors for scrape targets
+- AlertmanagerConfig for routing
+- Grafana dashboards
+
+---
+
+## Variable Substitution
+
+Config resources can use Flux variable substitution:
+
+```yaml
+# In a config resource
+metadata:
+  name: cert-${cluster_name}  # Substituted at reconciliation
+spec:
+  dnsNames:
+    - "*.${internal_domain}"
+```
+
+Variables come from:
+- `cluster-vars` ConfigMap (cluster-specific)
+- `platform-versions` ConfigMap (version pins)
+
+See [kubernetes/platform/CLAUDE.md](../CLAUDE.md) for available variables.
+
+---
+
+## Cross-References
+
+| Document | Focus |
+|----------|-------|
+| [kubernetes/platform/CLAUDE.md](../CLAUDE.md) | Flux patterns, version management, dependencies |
+| [kubernetes/clusters/CLAUDE.md](../../clusters/CLAUDE.md) | Per-cluster overrides |
+| [flux-gitops skill](../../../.claude/skills/flux-gitops/SKILL.md) | Adding Helm releases |


### PR DESCRIPTION
## Summary

- Add comprehensive CLAUDE.md documentation coverage across all major directories
- Root CLAUDE.md now serves as a hub with cross-references to 11 subdirectory documentation files
- Relocate procedural content (dev cluster ops) to appropriate locations
- Fix skill boundary issues by removing duplicate declarative content from skills

## Test plan

- [x] Verify all new CLAUDE.md files are readable and well-formatted
- [x] Verify cross-references between files are valid
- [x] Run `task k8s:validate` to ensure no YAML issues
- [x] Consider running `/sync-claude` to validate docs against codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)