### PR TITLE
fix(network): add kube-apiserver ingress to monitoring CNP

### DIFF
--- a/kubernetes/platform/config/monitoring/network-policy.yaml
+++ b/kubernetes/platform/config/monitoring/network-policy.yaml
@@ -52,6 +52,13 @@ spec:
         - ports:
             - port: "15008"
               protocol: TCP
+    # Allow webhooks from K8s API server (PrometheusRule, AlertmanagerConfig admission)
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP
   egress:
     # Allow Kubernetes API access (for service discovery, kube-state-metrics)
     - toEntities:


### PR DESCRIPTION
## Summary

- Adds missing kube-apiserver ingress rule to monitoring CNP for webhook admission
- Without this, PrometheusRule and AlertmanagerConfig validation webhooks timeout

## Root Cause

The prometheus-operator runs admission webhooks that validate PrometheusRule and AlertmanagerConfig resources. The API server needs to call these webhooks, but the monitoring CNP was missing the ingress rule to allow this.

## Test plan

- [x] Deploy to integration
- [x] Verify all kustomizations reconcile (no more webhook timeouts)
- [x] Verify kube-state-metrics recovers

🤖 Generated with [Claude Code](https://claude.ai/code)