### PR TITLE
fix(network): add port 443 to kube-apiserver egress rules

### DIFF
--- a/kubernetes/platform/config/database/network-policy.yaml
+++ b/kubernetes/platform/config/database/network-policy.yaml
@@ -46,12 +46,14 @@ spec:
             - port: "9443"
               protocol: TCP
   egress:
-    # Allow Kubernetes API access (operator)
+    # Allow Kubernetes API access (operator) - 6443 for node IPs, 443 for ClusterIP service
     - toEntities:
         - kube-apiserver
       toPorts:
         - ports:
             - port: "6443"
+              protocol: TCP
+            - port: "443"
               protocol: TCP
     # Allow S3 backup to Garage
     - toEndpoints:

--- a/kubernetes/platform/config/garage/network-policy.yaml
+++ b/kubernetes/platform/config/garage/network-policy.yaml
@@ -67,10 +67,12 @@ spec:
               protocol: TCP
             - port: "3903"
               protocol: TCP
-    # Allow Kubernetes API access (for node discovery if using K8s discovery)
+    # Allow Kubernetes API access (6443 for node IPs, 443 for ClusterIP service)
     - toEntities:
         - kube-apiserver
       toPorts:
         - ports:
             - port: "6443"
+              protocol: TCP
+            - port: "443"
               protocol: TCP

--- a/kubernetes/platform/config/infrastructure-policies/cert-manager.yaml
+++ b/kubernetes/platform/config/infrastructure-policies/cert-manager.yaml
@@ -36,12 +36,14 @@ spec:
             - port: "6443"
               protocol: TCP
   egress:
-    # Allow Kubernetes API access
+    # Allow Kubernetes API access (6443 for node IPs, 443 for ClusterIP service)
     - toEntities:
         - kube-apiserver
       toPorts:
         - ports:
             - port: "6443"
+              protocol: TCP
+            - port: "443"
               protocol: TCP
     # Allow ACME providers (Let's Encrypt, ZeroSSL) and DNS providers (Cloudflare)
     - toEntities:

--- a/kubernetes/platform/config/infrastructure-policies/external-secrets.yaml
+++ b/kubernetes/platform/config/infrastructure-policies/external-secrets.yaml
@@ -26,12 +26,14 @@ spec:
             - port: "10250"
               protocol: TCP
   egress:
-    # Allow Kubernetes API access
+    # Allow Kubernetes API access (6443 for node IPs, 443 for ClusterIP service)
     - toEntities:
         - kube-apiserver
       toPorts:
         - ports:
             - port: "6443"
+              protocol: TCP
+            - port: "443"
               protocol: TCP
     # Allow AWS SSM and Secrets Manager (HTTPS)
     - toEntities:

--- a/kubernetes/platform/config/infrastructure-policies/flux-system.yaml
+++ b/kubernetes/platform/config/infrastructure-policies/flux-system.yaml
@@ -28,12 +28,14 @@ spec:
             - port: "9443"
               protocol: TCP
   egress:
-    # Allow Kubernetes API access
+    # Allow Kubernetes API access (6443 for node IPs, 443 for ClusterIP service)
     - toEntities:
         - kube-apiserver
       toPorts:
         - ports:
             - port: "6443"
+              protocol: TCP
+            - port: "443"
               protocol: TCP
     # Allow GitHub API and git operations (HTTPS)
     - toEntities:

--- a/kubernetes/platform/config/infrastructure-policies/istio-system.yaml
+++ b/kubernetes/platform/config/infrastructure-policies/istio-system.yaml
@@ -42,12 +42,14 @@ spec:
             - port: "15017"
               protocol: TCP
   egress:
-    # Allow Kubernetes API access
+    # Allow Kubernetes API access (6443 for node IPs, 443 for ClusterIP service)
     - toEntities:
         - kube-apiserver
       toPorts:
         - ports:
             - port: "6443"
+              protocol: TCP
+            - port: "443"
               protocol: TCP
     # Allow HBONE tunnel traffic to data plane pods
     - toEntities:

--- a/kubernetes/platform/config/infrastructure-policies/kube-system.yaml
+++ b/kubernetes/platform/config/infrastructure-policies/kube-system.yaml
@@ -74,12 +74,14 @@ spec:
         - ports:
             - port: "123"
               protocol: UDP
-    # Allow Kubernetes API access
+    # Allow Kubernetes API access (6443 for node IPs, 443 for ClusterIP service)
     - toEntities:
         - kube-apiserver
       toPorts:
         - ports:
             - port: "6443"
+              protocol: TCP
+            - port: "443"
               protocol: TCP
     # Allow health checks to all cluster pods (Cilium)
     - toEntities:

--- a/kubernetes/platform/config/infrastructure-policies/spegel.yaml
+++ b/kubernetes/platform/config/infrastructure-policies/spegel.yaml
@@ -26,12 +26,14 @@ spec:
             - port: "8080"
               protocol: TCP
   egress:
-    # Allow Kubernetes API for node discovery
+    # Allow Kubernetes API for node discovery (6443 for node IPs, 443 for ClusterIP service)
     - toEntities:
         - kube-apiserver
       toPorts:
         - ports:
             - port: "6443"
+              protocol: TCP
+            - port: "443"
               protocol: TCP
     # Allow egress to external registries for cache misses (HTTPS)
     - toEntities:

--- a/kubernetes/platform/config/infrastructure-policies/system.yaml
+++ b/kubernetes/platform/config/infrastructure-policies/system.yaml
@@ -26,10 +26,12 @@ spec:
             - port: "10250"
               protocol: TCP
   egress:
-    # Allow Kubernetes API access (operators watch/modify resources)
+    # Allow Kubernetes API access (6443 for node IPs, 443 for ClusterIP service)
     - toEntities:
         - kube-apiserver
       toPorts:
         - ports:
             - port: "6443"
+              protocol: TCP
+            - port: "443"
               protocol: TCP

--- a/kubernetes/platform/config/longhorn/network-policy.yaml
+++ b/kubernetes/platform/config/longhorn/network-policy.yaml
@@ -49,12 +49,14 @@ spec:
             - port: "9443"
               protocol: TCP
   egress:
-    # Allow Kubernetes API access
+    # Allow Kubernetes API access (6443 for node IPs, 443 for ClusterIP service)
     - toEntities:
         - kube-apiserver
       toPorts:
         - ports:
             - port: "6443"
+              protocol: TCP
+            - port: "443"
               protocol: TCP
     # Allow inter-node storage replication (high ports)
     - toEntities:

--- a/kubernetes/platform/config/monitoring/network-policy.yaml
+++ b/kubernetes/platform/config/monitoring/network-policy.yaml
@@ -60,12 +60,14 @@ spec:
             - port: "10250"
               protocol: TCP
   egress:
-    # Allow Kubernetes API access (for service discovery, kube-state-metrics)
+    # Allow Kubernetes API access (6443 for node IPs, 443 for ClusterIP service)
     - toEntities:
         - kube-apiserver
       toPorts:
         - ports:
             - port: "6443"
+              protocol: TCP
+            - port: "443"
               protocol: TCP
     # Allow Prometheus to scrape all cluster pods
     - toEntities:

--- a/kubernetes/platform/config/network-policy/baselines/kube-api-access.yaml
+++ b/kubernetes/platform/config/network-policy/baselines/kube-api-access.yaml
@@ -14,10 +14,12 @@ spec:
         operator: In
         values: ["true"]
   egress:
-    # Allow access to Kubernetes API server
+    # Allow access to Kubernetes API server (6443 for node IPs, 443 for ClusterIP service)
     - toEntities:
         - kube-apiserver
       toPorts:
         - ports:
             - port: "6443"
+              protocol: TCP
+            - port: "443"
               protocol: TCP

--- a/kubernetes/platform/config/tuppr/network-policy.yaml
+++ b/kubernetes/platform/config/tuppr/network-policy.yaml
@@ -19,12 +19,14 @@ spec:
             - port: "8080"
               protocol: TCP
   egress:
-    # Allow Kubernetes API access (watch TalosUpgrade/KubernetesUpgrade CRs, update node status)
+    # Allow Kubernetes API access (6443 for node IPs, 443 for ClusterIP service)
     - toEntities:
         - kube-apiserver
       toPorts:
         - ports:
             - port: "6443"
+              protocol: TCP
+            - port: "443"
               protocol: TCP
     # Allow Talos API access to nodes (for executing upgrades)
     # Talos API runs on port 50000 on each node


### PR DESCRIPTION
## Summary
- Add port 443 to all CNPs with kube-apiserver egress rules
- Fixes operators timing out when accessing Kubernetes API via ClusterIP service

The Kubernetes service exposes port 443 (→ targetPort 6443), but CNPs only allowed port 6443. This caused CNPG operator to fail with "TLS handshake timeout" when accessing `kubernetes.default.svc:443`.

## Test plan
- [x] Validated on integration cluster - CNPG operator now running
- [x] All kustomizations reconciled successfully
- [x] `task k8s:validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)