### PR TITLE
fix(network): use correct port for Cilium health endpoint probes

### DIFF
--- a/kubernetes/platform/config/infrastructure-policies/kube-system.yaml
+++ b/kubernetes/platform/config/infrastructure-policies/kube-system.yaml
@@ -48,14 +48,12 @@ spec:
         - ports:
             - port: "8081"
               protocol: TCP
-    # Allow health checks from Cilium (169.254.x.x link-local)
+    # Allow Cilium health endpoint probes (reserved:health identity on port 4240)
     - fromEntities:
         - health
       toPorts:
         - ports:
-            - port: "8080"
-              protocol: TCP
-            - port: "8081"
+            - port: "4240"
               protocol: TCP
   egress:
     # Allow CoreDNS to reach node-local upstream DNS (Talos host DNS forwarder at 169.254.116.108)


### PR DESCRIPTION
## Summary
- Fix CiliumAgentUnreachableHealthEndpoints alert on integration cluster
- The kube-system-default CNP specified ports 8080/8081 for health entity but cilium-health listens on port 4240

## Root Cause
The `fromEntities: health` ingress rule used generic HTTP ports (8080/8081) instead of the actual cilium-health API port (4240). This blocked inter-node health probes, causing all 3 Cilium agents to report unreachable endpoints.

## Test plan
- [x] Merge PR and wait for integration cluster to reconcile
- [x] Verify `cilium-health status` shows 3/3 reachable on integration
- [x] Confirm CiliumAgentUnreachableHealthEndpoints alert resolves