### PR TITLE
fix(network): allow remote-node for Cilium cross-node health probes

### DIFF
--- a/kubernetes/platform/config/infrastructure-policies/kube-system.yaml
+++ b/kubernetes/platform/config/infrastructure-policies/kube-system.yaml
@@ -48,9 +48,9 @@ spec:
         - ports:
             - port: "8081"
               protocol: TCP
-    # Allow Cilium health endpoint probes (reserved:health identity on port 4240)
+    # Allow Cilium cross-node health probes (remote nodes probe local health endpoint)
     - fromEntities:
-        - health
+        - remote-node
       toPorts:
         - ports:
             - port: "4240"


### PR DESCRIPTION
## Summary
- Follow-up fix for #224 - cross-node health probes still failing
- Changed `fromEntities: health` to `fromEntities: remote-node` to match actual traffic pattern

## Root Cause Analysis
Hubble showed the traffic was being dropped with source identity `kube-apiserver` (remote node), not `health`:
```
192.168.10.151:55974 (kube-apiserver) <> 172.20.1.50:4240 (health) Policy denied DROPPED
```

The `fromEntities: health` rule allows traffic **from** health endpoints, but cross-node probes come **from** remote nodes **to** the local health endpoint.

## Test plan
- [ ] Merge and wait for reconciliation
- [ ] Verify `cilium-health status` shows 3/3 reachable
- [ ] Confirm no more drops in `hubble observe --verdict DROPPED --to-port 4240`