### PR TITLE
fix(platform): correct Dragonfly instance config and naming collision

### DIFF
--- a/kubernetes/platform/config/dragonfly/dragonfly-instance.yaml
+++ b/kubernetes/platform/config/dragonfly/dragonfly-instance.yaml
@@ -2,7 +2,7 @@
 apiVersion: dragonflydb.io/v1alpha1
 kind: Dragonfly
 metadata:
-  name: platform
+  name: dragonfly
 spec:
   replicas: ${default_replica_count}
 
@@ -21,26 +21,26 @@ spec:
   args:
     - "--maxmemory"
     - "768mb"
-    - "--maxmemory-policy"
-    - "allkeys-lru"
+    - "--cache_mode"
     - "--proactor_threads"
     - "2"
     - "--dbfilename"
     - "dump"
+    - "--s3_endpoint"
+    - "garage.garage.svc.cluster.local:3900"
+    - "--s3_use_https=false"
 
   env:
     - name: AWS_ACCESS_KEY_ID
       valueFrom:
         secretKeyRef:
           name: dragonfly-s3-credentials
-          key: accessKeyId
+          key: access-key-id
     - name: AWS_SECRET_ACCESS_KEY
       valueFrom:
         secretKeyRef:
           name: dragonfly-s3-credentials
-          key: secretAccessKey
-    - name: AWS_ENDPOINT_URL
-      value: "http://garage.garage.svc.cluster.local:3900"
+          key: secret-access-key
     - name: AWS_REGION
       value: "garage"
 
@@ -62,4 +62,4 @@ spec:
       labelSelector:
         matchLabels:
           app: dragonfly
-          app.kubernetes.io/instance: platform
+          app.kubernetes.io/name: dragonfly

--- a/kubernetes/platform/config/dragonfly/network-policy.yaml
+++ b/kubernetes/platform/config/dragonfly/network-policy.yaml
@@ -10,6 +10,7 @@ spec:
   endpointSelector:
     matchLabels:
       app: dragonfly
+      app.kubernetes.io/name: dragonfly
   ingress:
     # Redis connections from namespaces with dragonfly access label
     - fromEndpoints:


### PR DESCRIPTION
## Summary
- Fix five issues discovered during Dragonfly integration rollout: S3 secret key casing (garage-operator uses kebab-case), unsupported `--maxmemory-policy` flag (Dragonfly uses `--cache_mode`), S3 endpoint config (requires native `--s3_endpoint` flag, not `AWS_ENDPOINT_URL`), Abseil boolean parsing (`--s3_use_https=false`), and CR name collision with CNPG pods in the database namespace
- Rename Dragonfly CR from `platform` to `dragonfly` to avoid pod naming conflicts with the existing CNPG cluster

## Test plan
- [x] `task k8s:validate` passes
- [x] Applied to integration: all 3 replicas Running/Ready across 3 nodes
- [x] Replication verified: both replicas in stable sync with master
- [x] S3 connectivity confirmed: `https=false; endpoint=garage.garage.svc.cluster.local:3900`

🤖 Generated with [Claude Code](https://claude.com/claude-code)