### PR TITLE
feat(platform): add Loki log querying skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -79,7 +79,9 @@
       "Skill(gha-pipelines)",
       "Skill(k8s-manifest-generator)",
       "Skill(deploy-app)",
-      "Skill(self-improvement)"
+      "Skill(self-improvement)",
+      "Skill(loki)",
+      "Skill(prometheus)"
     ]
   },
   "enabledPlugins": {

--- a/.claude/skills/CLAUDE.md
+++ b/.claude/skills/CLAUDE.md
@@ -13,6 +13,7 @@ Skills are procedural guides that provide step-by-step workflows for complex ope
 | `flux-gitops` | Flux ResourceSet patterns for HelmRelease management | Yes | - | - |
 | `k8s-sre` | Kubernetes incident investigation and debugging | Yes | - | cluster-health.sh |
 | `kubesearch` | Research Helm configurations from kubesearch.dev | Yes | - | - |
+| `loki` | Query Loki API for cluster logs and debugging | Yes | queries.md | logql.sh |
 | `opentofu-modules` | OpenTofu module development and testing patterns | Yes | opentofu-testing.md | - |
 | `prometheus` | Query Prometheus API for metrics and alerts | Yes | queries.md | promql.sh |
 | `self-improvement` | Capture user feedback to enhance documentation | Yes | - | - |

--- a/.claude/skills/loki/SKILL.md
+++ b/.claude/skills/loki/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: loki
+description: |
+  Query Loki API for cluster logs and debugging. Use when investigating application errors,
+  searching logs, debugging pod issues, or querying log patterns.
+
+  Use when: (1) Searching logs for errors or patterns, (2) Investigating pod or service issues via logs,
+  (3) Querying Kubernetes events, (4) Debugging Flux reconciliation or platform service failures,
+  (5) Running LogQL queries, (6) Checking log rates or volumes.
+
+  Triggers: "check logs", "search logs", "query loki", "logql", "show me logs",
+  "what happened in", "log errors", "find in logs", "tail logs", "kubernetes events",
+  "recent logs", "log query", "debug logs"
+---
+
+# Loki Log Querying
+
+## Setup
+
+Loki runs in-cluster. Establish access via port-forward:
+
+```bash
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl port-forward -n monitoring svc/loki-headless 3100:3100
+```
+
+**Clusters**: `dev`, `integration`, `live`
+
+## Quick Queries
+
+Use the bundled script at `.claude/skills/loki/scripts/logql.sh`:
+
+```bash
+# Set URL (default: localhost:3100)
+export LOKI_URL=http://localhost:3100
+
+# Health check
+./scripts/logql.sh health
+
+# Search logs by namespace
+./scripts/logql.sh tail '{namespace="monitoring"}' --since 15m
+
+# Instant query (metric-style aggregation)
+./scripts/logql.sh query 'rate({namespace="monitoring"}[5m])'
+
+# Range query with time window
+./scripts/logql.sh range '{namespace="flux-system"}' --start 1h --step 1m --limit 50
+
+# Discover available labels
+./scripts/logql.sh labels
+./scripts/logql.sh labels namespace
+
+# Find series matching a selector
+./scripts/logql.sh series '{namespace="monitoring"}'
+```
+
+## Common Operations
+
+### Search for Errors
+
+```bash
+# Errors in a namespace
+./scripts/logql.sh tail '{namespace="database"} |= "error"' --since 30m
+
+# Case-insensitive error search
+./scripts/logql.sh tail '{namespace="monitoring"} |~ "(?i)error|fail|panic"' --since 15m
+
+# Specific container logs
+./scripts/logql.sh tail '{namespace="monitoring", container="prometheus"}' --since 10m --limit 50
+```
+
+### Kubernetes Events
+
+```bash
+# Warning events (via Alloy kubernetes_events)
+./scripts/logql.sh tail '{job="integrations/kubernetes/eventhandler"} |= "Warning"' --since 1h
+
+# Events for a specific namespace
+./scripts/logql.sh tail '{job="integrations/kubernetes/eventhandler", namespace="database"}' --since 30m
+```
+
+### Log Rate Metrics
+
+```bash
+# Error rate per namespace
+./scripts/logql.sh query 'sum by(namespace) (rate({namespace=~".+"} |= "error" [5m]))'
+
+# Log volume by namespace
+./scripts/logql.sh query 'sum by(namespace) (bytes_rate({namespace=~".+"}[5m]))'
+
+# Top 5 noisiest pods
+./scripts/logql.sh query 'topk(5, sum by(pod) (rate({namespace=~".+"}[5m])))'
+```
+
+### Direct curl (alternative)
+
+```bash
+# Instant query
+curl -s "http://localhost:3100/loki/api/v1/query?query=%7Bnamespace%3D%22monitoring%22%7D&limit=10" | jq '.data.result'
+
+# Labels
+curl -s "http://localhost:3100/loki/api/v1/labels" | jq '.data'
+```
+
+## Reference
+
+For homelab-specific LogQL queries (Flux, Cilium, CloudNative-PG, etc.), see [references/queries.md](references/queries.md).
+
+## Loki Details
+
+| Property | Value |
+|----------|-------|
+| Namespace | `monitoring` |
+| Service | `loki-headless:3100` |
+| API prefix | `/loki/api/v1/` |
+| Log shipping | Alloy (Grafana Agent) |
+| Ready endpoint | `/ready` |

--- a/.claude/skills/loki/references/queries.md
+++ b/.claude/skills/loki/references/queries.md
@@ -1,0 +1,307 @@
+# Homelab LogQL Query Reference
+
+## Table of Contents
+- [Basic Log Queries](#basic-log-queries)
+- [Error Investigation](#error-investigation)
+- [Kubernetes Events](#kubernetes-events)
+- [Platform Services](#platform-services)
+- [Database (CloudNative-PG)](#database-cloudnative-pg)
+- [GitOps (Flux)](#gitops-flux)
+- [Networking (Cilium)](#networking-cilium)
+- [Log Metrics](#log-metrics)
+- [Advanced Patterns](#advanced-patterns)
+- [Label Reference](#label-reference)
+
+---
+
+## Basic Log Queries
+
+```logql
+# All logs from a namespace
+{namespace="monitoring"}
+
+# Filter by pod name
+{namespace="monitoring", pod=~"prometheus-.*"}
+
+# Filter by container
+{namespace="monitoring", container="prometheus"}
+
+# Text match (contains)
+{namespace="monitoring"} |= "error"
+
+# Negative match (exclude)
+{namespace="monitoring"} != "healthcheck"
+
+# Regex match
+{namespace="monitoring"} |~ "level=(error|warn)"
+
+# Negative regex
+{namespace="monitoring"} !~ "GET /health"
+
+# Chained filters
+{namespace="database"} |= "error" != "context canceled" != "healthcheck"
+```
+
+## Error Investigation
+
+```logql
+# Case-insensitive error search
+{namespace="database"} |~ "(?i)error|fail|panic|fatal"
+
+# Stack traces (multi-word match)
+{namespace="database"} |~ "(?i)exception|traceback|stack trace"
+
+# OOMKilled context - check container logs before kill
+{namespace="database", container="postgres"} |~ "(?i)out of memory|oom|memory allocation"
+
+# Crash loop debugging - recent restarts
+{namespace="database"} |= "error" | json | level="error"
+
+# HTTP 5xx errors
+{namespace="monitoring"} |~ "HTTP/[12].* [5][0-9]{2}"
+
+# Timeout patterns
+{namespace="monitoring"} |~ "(?i)timeout|deadline exceeded|context deadline"
+```
+
+## Kubernetes Events
+
+Events are shipped to Loki via Alloy's `loki.source.kubernetes_events`.
+
+```logql
+# All warning events
+{job="integrations/kubernetes/eventhandler"} |= "Warning"
+
+# Events for a namespace
+{job="integrations/kubernetes/eventhandler", namespace="database"}
+
+# Scheduling failures
+{job="integrations/kubernetes/eventhandler"} |~ "FailedScheduling|Unschedulable"
+
+# Image pull issues
+{job="integrations/kubernetes/eventhandler"} |~ "(?i)pull|image|ErrImagePull|ImagePullBackOff"
+
+# Volume events
+{job="integrations/kubernetes/eventhandler"} |~ "(?i)volume|attach|mount|pvc"
+
+# Node events (cordoning, draining, not ready)
+{job="integrations/kubernetes/eventhandler"} |~ "NodeNotReady|Cordon|Drain|Taint"
+
+# Parse event fields with JSON
+{job="integrations/kubernetes/eventhandler"} | json | reason="BackOff"
+```
+
+## Platform Services
+
+### Prometheus & Grafana
+
+```logql
+# Prometheus errors
+{namespace="monitoring", container="prometheus"} |= "err"
+
+# Prometheus config reload
+{namespace="monitoring", container="prometheus"} |= "reload"
+
+# Grafana errors
+{namespace="monitoring", container="grafana"} |~ "level=(error|eror)"
+```
+
+### Cert-Manager
+
+```logql
+# Certificate issuance
+{namespace="cert-manager"} |~ "(?i)certificate|issue|renew"
+
+# Certificate errors
+{namespace="cert-manager"} |~ "(?i)error|fail" != "no error"
+```
+
+### External Secrets
+
+```logql
+# Secret sync status
+{namespace="external-secrets"} |~ "(?i)sync|reconcil"
+
+# External secret errors
+{namespace="external-secrets"} |~ "(?i)error|fail"
+```
+
+### Alloy (Grafana Agent)
+
+```logql
+# Alloy errors
+{namespace="monitoring", container="alloy"} |~ "level=error"
+
+# Alloy target discovery
+{namespace="monitoring", container="alloy"} |= "target"
+```
+
+## Database (CloudNative-PG)
+
+```logql
+# Postgres errors
+{namespace="database", container="postgres"} |~ "(?i)ERROR|FATAL|PANIC"
+
+# Slow queries (if log_min_duration_statement is set)
+{namespace="database", container="postgres"} |= "duration:"
+
+# Connection events
+{namespace="database", container="postgres"} |~ "(?i)connection|disconnect|authentication"
+
+# WAL activity
+{namespace="database", container="postgres"} |~ "(?i)WAL|wal_level|archive"
+
+# Replication status
+{namespace="database", container="postgres"} |~ "(?i)replica|replication|standby|primary"
+
+# CNPG operator logs
+{namespace="database", container="manager"} |~ "(?i)error|reconcil|failover|switchover"
+```
+
+## GitOps (Flux)
+
+```logql
+# All Flux controller errors
+{namespace="flux-system"} |~ "(?i)error|fail"
+
+# Source controller (git/OCI fetch issues)
+{namespace="flux-system", container="manager", pod=~"source-controller-.*"} |~ "(?i)error|reconcil"
+
+# Kustomize controller (apply issues)
+{namespace="flux-system", container="manager", pod=~"kustomize-controller-.*"} |~ "(?i)error|reconcil"
+
+# Helm controller
+{namespace="flux-system", container="manager", pod=~"helm-controller-.*"} |~ "(?i)error|reconcil|upgrade|install"
+
+# Reconciliation failures
+{namespace="flux-system"} |= "Reconciliation failed"
+
+# Dependency not ready
+{namespace="flux-system"} |= "dependency"
+```
+
+## Networking (Cilium)
+
+```logql
+# Cilium agent errors
+{namespace="kube-system", container="cilium-agent"} |~ "level=(error|warning)"
+
+# Policy verdicts
+{namespace="kube-system", container="cilium-agent"} |= "verdict"
+
+# Policy drops
+{namespace="kube-system", container="cilium-agent"} |= "Policy denied"
+
+# Endpoint events
+{namespace="kube-system", container="cilium-agent"} |~ "(?i)endpoint|regenerat"
+
+# Cilium operator
+{namespace="kube-system", container="cilium-operator"} |~ "level=(error|warning)"
+```
+
+## Log Metrics
+
+LogQL supports metric queries that aggregate log data into numeric values.
+
+```logql
+# Error rate per namespace (errors/sec)
+sum by(namespace) (rate({namespace=~".+"} |= "error" [5m]))
+
+# Log line count over time per namespace
+sum by(namespace) (count_over_time({namespace=~".+"}[5m]))
+
+# Log volume (bytes/sec) per namespace
+sum by(namespace) (bytes_rate({namespace=~".+"}[5m]))
+
+# Top 5 noisiest pods
+topk(5, sum by(pod) (rate({namespace=~".+"}[5m])))
+
+# Top 5 error-producing namespaces
+topk(5, sum by(namespace) (rate({namespace=~".+"} |= "error" [5m])))
+
+# Flux reconciliation failure rate
+rate({namespace="flux-system"} |= "Reconciliation failed" [15m])
+
+# Postgres error rate
+rate({namespace="database", container="postgres"} |~ "ERROR|FATAL" [5m])
+```
+
+## Advanced Patterns
+
+### JSON Log Parsing
+
+```logql
+# Parse JSON and filter by field
+{namespace="monitoring"} | json | level="error"
+
+# Extract specific fields
+{namespace="monitoring"} | json | line_format "{{.level}} {{.msg}}"
+
+# Filter by parsed numeric value
+{namespace="monitoring"} | json | duration > 5s
+```
+
+### Logfmt Parsing
+
+```logql
+# Parse logfmt (key=value) format
+{namespace="monitoring"} | logfmt | level="error"
+
+# Extract and filter
+{namespace="monitoring"} | logfmt | status >= 500
+```
+
+### Label Extraction with Regex
+
+```logql
+# Extract HTTP status code
+{namespace="monitoring"} | regexp "status=(?P<status>\\d+)" | status >= 500
+
+# Extract duration
+{namespace="monitoring"} | regexp "duration=(?P<duration>[\\d.]+)s" | unwrap duration | duration > 5
+```
+
+### Unwrap for Numeric Aggregation
+
+```logql
+# Average request duration from parsed logs
+avg_over_time({namespace="monitoring"} | logfmt | unwrap duration [5m])
+
+# 99th percentile of response size
+quantile_over_time(0.99, {namespace="monitoring"} | json | unwrap bytes [5m])
+```
+
+---
+
+## Label Reference
+
+Common labels available in this cluster:
+
+| Label | Example Values | Description |
+|-------|---------------|-------------|
+| `namespace` | `monitoring`, `database`, `flux-system` | Kubernetes namespace |
+| `pod` | `prometheus-kps-0`, `loki-0` | Pod name |
+| `container` | `prometheus`, `manager`, `postgres` | Container name |
+| `job` | `monitoring/alloy`, `integrations/kubernetes/eventhandler` | Scrape job |
+| `node_name` | `k8s-1`, `k8s-2` | Kubernetes node |
+| `stream` | `stdout`, `stderr` | Log output stream |
+| `cluster` | `dev`, `integration`, `live` | Cluster name |
+
+## LogQL Syntax Cheat Sheet
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `\|=` | Contains | `{app="x"} \|= "error"` |
+| `!=` | Not contains | `{app="x"} != "debug"` |
+| `\|~` | Regex match | `{app="x"} \|~ "err\|warn"` |
+| `!~` | Not regex match | `{app="x"} !~ "health"` |
+| `\| json` | Parse JSON | `{app="x"} \| json` |
+| `\| logfmt` | Parse logfmt | `{app="x"} \| logfmt` |
+| `\| regexp` | Regex extract | `{app="x"} \| regexp "..."` |
+| `\| line_format` | Reformat line | `{app="x"} \| line_format "{{.msg}}"` |
+| `\| unwrap` | Extract numeric | `... \| unwrap duration` |
+| `rate()` | Lines per second | `rate({app="x"}[5m])` |
+| `count_over_time()` | Line count | `count_over_time({app="x"}[5m])` |
+| `bytes_rate()` | Bytes per second | `bytes_rate({app="x"}[5m])` |
+| `sum by()` | Aggregate | `sum by(ns) (rate(...))` |
+| `topk()` | Top N | `topk(5, sum by(pod) (...))` |

--- a/.claude/skills/loki/scripts/logql.sh
+++ b/.claude/skills/loki/scripts/logql.sh
@@ -1,0 +1,384 @@
+#!/bin/bash
+# Query Loki API - supports instant, range, tail, labels, series, and health queries
+# Usage: ./logql.sh <query|range|tail|labels|series|health> [options]
+#
+# Examples:
+#   ./logql.sh query 'rate({namespace="monitoring"}[5m])'
+#   ./logql.sh range '{namespace="monitoring"}' --start 1h --step 1m --limit 50
+#   ./logql.sh tail '{namespace="flux-system"}' --since 15m
+#   ./logql.sh labels
+#   ./logql.sh labels namespace
+#   ./logql.sh series '{namespace="monitoring"}'
+#   ./logql.sh health
+
+set -euo pipefail
+
+LOKI_URL="${LOKI_URL:-http://localhost:3100}"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") <command> [options]
+
+Commands:
+  query <logql>      Instant query (metric aggregations or log snapshot)
+  range <logql>      Range query over time period
+  tail <logql>       Recent logs (shorthand for range with --since)
+  labels [name]      List label names, or values for a label
+  series <selector>  Find log streams matching selector
+  health             Check Loki health and readiness
+
+Query Options:
+  --time <timestamp>  Evaluation time for instant query (RFC3339 or Unix)
+  --limit <n>         Maximum log lines to return [default: 100]
+  --direction <dir>   Sort order: forward or backward [default: backward]
+
+Range Options:
+  --start <duration>  Start time as duration ago (e.g., 1h, 30m, 7d) [default: 1h]
+  --end <duration>    End time as duration ago [default: now]
+  --step <duration>   Query resolution step [default: 15s]
+  --limit <n>         Maximum log lines to return [default: 100]
+  --direction <dir>   Sort order: forward or backward [default: backward]
+
+Tail Options:
+  --since <duration>  How far back to look (e.g., 5m, 15m, 1h) [default: 15m]
+  --limit <n>         Maximum log lines to return [default: 100]
+  --direction <dir>   Sort order: forward or backward [default: backward]
+
+Series Options:
+  --start <duration>  Start time as duration ago [default: 1h]
+  --end <duration>    End time as duration ago [default: now]
+
+Output Options:
+  --raw              Output raw JSON without formatting
+  --verbose          Show full response including status
+
+Environment:
+  LOKI_URL           Loki base URL [default: http://localhost:3100]
+
+Examples:
+  # Recent errors in a namespace
+  $(basename "$0") tail '{namespace="database"} |= "error"' --since 30m
+
+  # Error rate per namespace
+  $(basename "$0") query 'sum by(namespace) (rate({namespace=~".+"} |= "error" [5m]))'
+
+  # Range query with custom window
+  $(basename "$0") range '{namespace="monitoring"}' --start 2h --step 30s --limit 50
+
+  # Kubernetes warning events
+  $(basename "$0") tail '{job="integrations/kubernetes/eventhandler"} |= "Warning"' --since 1h
+
+  # Discover labels
+  $(basename "$0") labels namespace
+EOF
+    exit 1
+}
+
+# Parse duration to seconds (1h -> 3600, 30m -> 1800, 7d -> 604800)
+duration_to_seconds() {
+    local duration="$1"
+    local num="${duration%[smhdw]}"
+    local unit="${duration: -1}"
+
+    case "$unit" in
+        s) echo "$num" ;;
+        m) echo $((num * 60)) ;;
+        h) echo $((num * 3600)) ;;
+        d) echo $((num * 86400)) ;;
+        w) echo $((num * 604800)) ;;
+        *) echo "$duration" ;;  # Assume already seconds
+    esac
+}
+
+# URL encode a string safely using python3 sys.argv (no shell injection)
+urlencode() {
+    python3 -c "import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=''))" "$1"
+}
+
+# Format Loki query results based on resultType
+format_response() {
+    local response="$1"
+    local raw="$2"
+    local verbose="$3"
+
+    if [[ "$raw" == "true" ]]; then
+        echo "$response"
+        return
+    fi
+
+    if [[ "$verbose" == "true" ]]; then
+        echo "$response" | jq .
+        return
+    fi
+
+    local result_type
+    result_type=$(echo "$response" | jq -r '.data.resultType // empty' 2>/dev/null)
+
+    case "$result_type" in
+        streams)
+            format_streams "$response"
+            ;;
+        matrix)
+            format_matrix "$response"
+            ;;
+        vector)
+            format_vector "$response"
+            ;;
+        *)
+            # Fallback: print data or status
+            echo "$response" | jq -r '.data // .status'
+            ;;
+    esac
+}
+
+# Format stream results as: TIMESTAMP [labels] LOG_LINE
+format_streams() {
+    local response="$1"
+    echo "$response" | jq -r '
+        .data.result[] |
+        .stream as $labels |
+        .values[] |
+        (.[0] | tonumber / 1000000000 | strftime("%Y-%m-%d %H:%M:%S")) as $ts |
+        .[1] as $line |
+        ($labels | to_entries | map("\(.key)=\(.value)") | join(",")) as $lbl |
+        "\($ts) [\($lbl)] \($line)"
+    ' 2>/dev/null || echo "$response" | jq -r '.data // .status'
+}
+
+# Format matrix results (metric queries over time)
+format_matrix() {
+    local response="$1"
+    echo "$response" | jq -r '
+        .data.result[] |
+        (.metric | to_entries | map("\(.key)=\(.value)") | join(",")) as $metric |
+        "--- \($metric) ---",
+        (.values[] | "\(.[0] | strftime("%Y-%m-%d %H:%M:%S")) \(.[1])")
+    ' 2>/dev/null || echo "$response" | jq -r '.data // .status'
+}
+
+# Format vector results (instant metric queries)
+format_vector() {
+    local response="$1"
+    echo "$response" | jq -r '
+        .data.result[] |
+        (.metric | to_entries | map("\(.key)=\(.value)") | join(",")) as $metric |
+        "\($metric): \(.value[1])"
+    ' 2>/dev/null || echo "$response" | jq -r '.data // .status'
+}
+
+# Make API request to Loki
+api_request() {
+    local endpoint="$1"
+
+    local response
+    response=$(curl -s -f "${LOKI_URL}/loki/api/v1/${endpoint}") || {
+        echo "Error: Failed to query ${LOKI_URL}/loki/api/v1/${endpoint}" >&2
+        echo "Is Loki reachable? Try: curl -s ${LOKI_URL}/ready" >&2
+        exit 1
+    }
+
+    echo "$response"
+}
+
+cmd_query() {
+    local query=""
+    local time=""
+    local limit="100"
+    local direction="backward"
+    local raw="false"
+    local verbose="false"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --time) time="$2"; shift 2 ;;
+            --limit) limit="$2"; shift 2 ;;
+            --direction) direction="$2"; shift 2 ;;
+            --raw) raw="true"; shift ;;
+            --verbose) verbose="true"; shift ;;
+            -*) echo "Unknown option: $1" >&2; exit 1 ;;
+            *) query="$1"; shift ;;
+        esac
+    done
+
+    [[ -z "$query" ]] && { echo "Error: Query required" >&2; exit 1; }
+
+    local endpoint="query?query=$(urlencode "$query")&limit=${limit}&direction=${direction}"
+    [[ -n "$time" ]] && endpoint+="&time=$(urlencode "$time")"
+
+    local response
+    response=$(api_request "$endpoint")
+    format_response "$response" "$raw" "$verbose"
+}
+
+cmd_range() {
+    local query=""
+    local start="1h"
+    local end=""
+    local step="15s"
+    local limit="100"
+    local direction="backward"
+    local raw="false"
+    local verbose="false"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --start) start="$2"; shift 2 ;;
+            --end) end="$2"; shift 2 ;;
+            --step) step="$2"; shift 2 ;;
+            --limit) limit="$2"; shift 2 ;;
+            --direction) direction="$2"; shift 2 ;;
+            --raw) raw="true"; shift ;;
+            --verbose) verbose="true"; shift ;;
+            -*) echo "Unknown option: $1" >&2; exit 1 ;;
+            *) query="$1"; shift ;;
+        esac
+    done
+
+    [[ -z "$query" ]] && { echo "Error: Query required" >&2; exit 1; }
+
+    local now
+    now=$(date +%s)
+    local start_ts=$((now - $(duration_to_seconds "$start")))
+    local end_ts="$now"
+    [[ -n "$end" ]] && end_ts=$((now - $(duration_to_seconds "$end")))
+
+    local endpoint="query_range?query=$(urlencode "$query")&start=${start_ts}&end=${end_ts}&step=${step}&limit=${limit}&direction=${direction}"
+
+    local response
+    response=$(api_request "$endpoint")
+    format_response "$response" "$raw" "$verbose"
+}
+
+cmd_tail() {
+    local query=""
+    local since="15m"
+    local limit="100"
+    local direction="backward"
+    local raw="false"
+    local verbose="false"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --since) since="$2"; shift 2 ;;
+            --limit) limit="$2"; shift 2 ;;
+            --direction) direction="$2"; shift 2 ;;
+            --raw) raw="true"; shift ;;
+            --verbose) verbose="true"; shift ;;
+            -*) echo "Unknown option: $1" >&2; exit 1 ;;
+            *) query="$1"; shift ;;
+        esac
+    done
+
+    [[ -z "$query" ]] && { echo "Error: Query required" >&2; exit 1; }
+
+    local now
+    now=$(date +%s)
+    local start_ts=$((now - $(duration_to_seconds "$since")))
+
+    local endpoint="query_range?query=$(urlencode "$query")&start=${start_ts}&end=${now}&limit=${limit}&direction=${direction}"
+
+    local response
+    response=$(api_request "$endpoint")
+    format_response "$response" "$raw" "$verbose"
+}
+
+cmd_labels() {
+    local label_name=""
+    local raw="false"
+    local verbose="false"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --raw) raw="true"; shift ;;
+            --verbose) verbose="true"; shift ;;
+            -*) echo "Unknown option: $1" >&2; exit 1 ;;
+            *) label_name="$1"; shift ;;
+        esac
+    done
+
+    local endpoint="labels"
+    [[ -n "$label_name" ]] && endpoint="label/${label_name}/values"
+
+    local response
+    response=$(api_request "$endpoint")
+
+    if [[ "$raw" == "true" ]]; then
+        echo "$response"
+    elif [[ "$verbose" == "true" ]]; then
+        echo "$response" | jq .
+    else
+        echo "$response" | jq -r '.data[]'
+    fi
+}
+
+cmd_series() {
+    local selector=""
+    local start="1h"
+    local end=""
+    local raw="false"
+    local verbose="false"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --start) start="$2"; shift 2 ;;
+            --end) end="$2"; shift 2 ;;
+            --raw) raw="true"; shift ;;
+            --verbose) verbose="true"; shift ;;
+            -*) echo "Unknown option: $1" >&2; exit 1 ;;
+            *) selector="$1"; shift ;;
+        esac
+    done
+
+    [[ -z "$selector" ]] && { echo "Error: Selector required (e.g., '{namespace=\"monitoring\"}')" >&2; exit 1; }
+
+    local now
+    now=$(date +%s)
+    local start_ts=$((now - $(duration_to_seconds "$start")))
+    local end_ts="$now"
+    [[ -n "$end" ]] && end_ts=$((now - $(duration_to_seconds "$end")))
+
+    local endpoint="series?match[]=$(urlencode "$selector")&start=${start_ts}&end=${end_ts}"
+
+    local response
+    response=$(api_request "$endpoint")
+
+    if [[ "$raw" == "true" ]]; then
+        echo "$response"
+    elif [[ "$verbose" == "true" ]]; then
+        echo "$response" | jq .
+    else
+        echo "$response" | jq -r '.data[] | to_entries | map("\(.key)=\(.value)") | join(", ")'
+    fi
+}
+
+cmd_health() {
+    echo "=== Loki Health ==="
+    echo -n "Ready: "
+    curl -fsS "${LOKI_URL}/ready" >/dev/null 2>&1 && echo "OK" || echo "FAILED"
+
+    echo ""
+    echo "=== Build Info ==="
+    curl -s "${LOKI_URL}/loki/api/v1/status/buildinfo" | jq -r '.data // . | "Version: \(.version // "unknown")\nRevision: \(.revision // "unknown" | .[0:8])"' 2>/dev/null || echo "Build info unavailable"
+
+    echo ""
+    echo "=== Ring Status ==="
+    echo -n "Ingester ring: "
+    curl -fsS "${LOKI_URL}/ring" >/dev/null 2>&1 && echo "OK" || echo "UNAVAILABLE"
+}
+
+# Main
+[[ $# -eq 0 ]] && usage
+
+command="$1"
+shift
+
+case "$command" in
+    query) cmd_query "$@" ;;
+    range) cmd_range "$@" ;;
+    tail) cmd_tail "$@" ;;
+    labels) cmd_labels "$@" ;;
+    series) cmd_series "$@" ;;
+    health) cmd_health ;;
+    help|--help|-h) usage ;;
+    *) echo "Unknown command: $command" >&2; usage ;;
+esac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,6 +455,8 @@ Invoke these skills for detailed procedural guidance:
 | `app-template` | Deploying apps with bjw-s/app-template |
 | `kubesearch` | Researching Helm chart configurations |
 | `k8s-sre` | Debugging Kubernetes incidents |
+| `loki` | Query Loki API for logs and debugging |
+| `prometheus` | Query Prometheus API for metrics and alerts |
 | `taskfiles` | Taskfile syntax and patterns |
 | `sync-claude` | Validate and sync Claude docs before commits |
 | `self-improvement` | Capture feedback to enhance documentation and skills |


### PR DESCRIPTION
## Summary
- Add `loki` skill with `logql.sh` script (6 subcommands: query, range, tail, labels, series, health) and LogQL reference covering 10 domains
- Register `Skill(loki)` and missing `Skill(prometheus)` in settings.json permissions

## Test plan
- [ ] `bash -n .claude/skills/loki/scripts/logql.sh` passes syntax check
- [ ] `./scripts/logql.sh --help` renders usage
- [ ] `task k8s:validate` passes with no regressions
- [ ] Port-forward to dev Loki and test: `health`, `labels`, `query`, `range`, `tail`, `series`

🤖 Generated with [Claude Code](https://claude.com/claude-code)