### PR TITLE
fix(k8s): harden Zipline init container and fix Kromgo internal route

### DIFF
--- a/kubernetes/clusters/live/charts/zipline.yaml
+++ b/kubernetes/clusters/live/charts/zipline.yaml
@@ -22,6 +22,11 @@ controllers:
         image:
           repository: ghcr.io/home-operations/postgres-init
           tag: "18"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
         env:
           INIT_POSTGRES_HOST: platform-rw.database.svc.cluster.local
           INIT_POSTGRES_SUPER_USER: postgres
@@ -86,6 +91,16 @@ controllers:
           limits:
             memory: 512Mi
         probes:
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api/health
+                port: 3000
+              initialDelaySeconds: 5
+              periodSeconds: 5
+              failureThreshold: 30
           liveness:
             enabled: true
             custom: true
@@ -93,7 +108,6 @@ controllers:
               httpGet:
                 path: /api/health
                 port: 3000
-              initialDelaySeconds: 15
               periodSeconds: 30
           readiness:
             enabled: true
@@ -102,7 +116,6 @@ controllers:
               httpGet:
                 path: /api/health
                 port: 3000
-              initialDelaySeconds: 10
               periodSeconds: 10
 
 service:

--- a/kubernetes/platform/config/kromgo/internal-route.yaml
+++ b/kubernetes/platform/config/kromgo/internal-route.yaml
@@ -12,5 +12,5 @@ spec:
     - "kromgo.${internal_domain}"
   rules:
     - backendRefs:
-        - name: kromgo-app
+        - name: kromgo
           port: 8080


### PR DESCRIPTION
## Summary
- Post-merge review of #229 found the Zipline init-db container missing container-level securityContext, which would cause PSS admission rejection under the `restricted` profile
- Added startup probe to prevent CrashLoopBackOff during first-boot database migrations
- Fixed pre-existing bug in Kromgo internal-route referencing `kromgo-app` instead of `kromgo` (verified via `helm template`)

## Test plan
- [ ] `task k8s:validate` passes
- [ ] Zipline pod starts without PSS admission errors
- [ ] Kromgo internal route resolves correctly at `kromgo.${internal_domain}`