### PR TITLE
feat(infra): add default PodTopologySpread constraint to scheduler config

### DIFF
--- a/infrastructure/modules/config/resources/talos/talos_machine.yaml.tftpl
+++ b/infrastructure/modules/config/resources/talos/talos_machine.yaml.tftpl
@@ -19,8 +19,21 @@ cluster:
       "${arg.name}": "${arg.value}"
 %{ endfor ~}
 %{ endif ~}
-%{ if length(cluster_scheduler_extraArgs) > 0 ~}
   scheduler:
+    config:
+      apiVersion: kubescheduler.config.k8s.io/v1
+      kind: KubeSchedulerConfiguration
+      profiles:
+        - schedulerName: default-scheduler
+          pluginConfig:
+            - name: PodTopologySpread
+              args:
+                defaultingType: List
+                defaultConstraints:
+                  - maxSkew: 1
+                    topologyKey: kubernetes.io/hostname
+                    whenUnsatisfiable: ScheduleAnyway
+%{ if length(cluster_scheduler_extraArgs) > 0 ~}
     extraArgs:
 %{ for arg in cluster_scheduler_extraArgs ~}
       "${arg.name}": "${arg.value}"


### PR DESCRIPTION
## Summary

- Add cluster-wide `KubeSchedulerConfiguration` with `PodTopologySpread` default constraint to kube-scheduler, ensuring pods prefer spreading across nodes without per-workload opt-in
- Motivated by BGP failover testing (#140) where both Istio gateway pods landed on the same node, causing ~2.5min downtime despite 9s BGP reconvergence
- Uses `ScheduleAnyway` (soft preference) so single-node dev clusters still schedule normally

## Test plan

- [x] `task tg:fmt` passes
- [x] `task tg:test-config` — 115 tests pass (3 new/updated scheduler tests)
- [ ] Apply to dev cluster, verify scheduler starts with new config
- [ ] Deploy a multi-replica workload, verify pods spread across nodes
- [ ] Apply to integration, verify Istio gateway pods land on different nodes
- [ ] Re-run BGP failover test — expect near-zero downtime

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)