### PR TITLE
feat(k8s): scale gateway deployments to match cluster node count

### DIFF
--- a/kubernetes/platform/config/gateway/external-gateway.yaml
+++ b/kubernetes/platform/config/gateway/external-gateway.yaml
@@ -6,6 +6,10 @@ metadata:
   name: external
 spec:
   infrastructure:
+    parametersRef:
+      group: ""
+      kind: ConfigMap
+      name: gateway-deployment-defaults
     annotations:
       lbipam.cilium.io/ips: ${external_ingress_ip}
   gatewayClassName: istio

--- a/kubernetes/platform/config/gateway/gateway-deployment-defaults.yaml
+++ b/kubernetes/platform/config/gateway/gateway-deployment-defaults.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gateway-deployment-defaults
+data:
+  deployment: |
+    spec:
+      replicas: ${default_replica_count}

--- a/kubernetes/platform/config/gateway/internal-gateway.yaml
+++ b/kubernetes/platform/config/gateway/internal-gateway.yaml
@@ -6,6 +6,10 @@ metadata:
   name: internal
 spec:
   infrastructure:
+    parametersRef:
+      group: ""
+      kind: ConfigMap
+      name: gateway-deployment-defaults
     annotations:
       lbipam.cilium.io/ips: ${internal_ingress_ip}
   gatewayClassName: istio

--- a/kubernetes/platform/config/gateway/kustomization.yaml
+++ b/kubernetes/platform/config/gateway/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - gateway-deployment-defaults.yaml
   - internal-gateway.yaml
   - external-gateway.yaml
   - coraza-wasm-plugin.yaml


### PR DESCRIPTION
## Summary

- Configure Istio auto-provisioned gateway deployments with `replicas: ${default_replica_count}` via `infrastructure.parametersRef` ConfigMap overlay
- Complements the scheduler PodTopologySpread default (#238) — multiple replicas give the scheduler something to spread across nodes
- Uses existing `default_replica_count` variable (`min(3, nodes)`) so dev stays at 1 replica and multi-node clusters get full coverage

## Test plan

- [x] `task k8s:validate` passes
- [x] Merge and verify gateway pods scale up on integration (expect 3 replicas across 3 nodes)
- [x] Verify gateway pods spread across different nodes (PodTopologySpread from #238)
- [ ] Re-run BGP failover test — expect near-zero downtime with backends on surviving nodes

Ref #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)