### PR TITLE
docs(k8s): document silence-operator and extend Spegel silence

### DIFF
--- a/kubernetes/clusters/dev/config/silences/spegel-single-node.yaml
+++ b/kubernetes/clusters/dev/config/silences/spegel-single-node.yaml
@@ -10,7 +10,7 @@ spec:
   matchers:
     - name: alertname
       matchType: "=~"
-      value: "KubePodCrashLooping|KubeDaemonSetRolloutStuck"
+      value: "KubePodCrashLooping|KubeDaemonSetRolloutStuck|TargetDown"
     - name: namespace
       matchType: "="
       value: spegel

--- a/kubernetes/platform/config/CLAUDE.md
+++ b/kubernetes/platform/config/CLAUDE.md
@@ -96,6 +96,7 @@ Config kustomizations must declare dependencies on the HelmReleases that provide
 | `Canary` | canary-checker |
 | `Gateway`, `HTTPRoute` | (Gateway API CRDs - pre-installed) |
 | `PrometheusRule`, `ServiceMonitor` | kube-prometheus-stack |
+| `Silence` | silence-operator |
 | `TalosUpgrade`, `KubernetesUpgrade` | tuppr |
 | `WasmPlugin` | istio-istiod |
 | `GarageCluster` | garage |


### PR DESCRIPTION
## Summary

- Document silence-operator CRD, matcher syntax, and zero-alert baseline policy in clusters and config CLAUDE.md
- Extend dev Spegel silence to cover TargetDown alert (single-node P2P limitation)

## Test plan

- [x] `task k8s:validate` passes
- [ ] TargetDown alert for spegel namespace silenced on dev after merge