### PR TITLE
fix(k8s): use readiness check for Flux pods canary

### DIFF
--- a/kubernetes/platform/config/canary-checker/platform-health.yaml
+++ b/kubernetes/platform/config/canary-checker/platform-health.yaml
@@ -19,4 +19,4 @@ spec:
         name: flux-system
       resource:
         labelSelector: app.kubernetes.io/part-of=flux
-      healthy: true
+      ready: true


### PR DESCRIPTION
## Summary

- Change `flux-pods-healthy` canary from `healthy: true` to `ready: true`
- Eliminates 24-hour false-positive windows after transient Flux controller restarts

## Test plan

- [x] `task k8s:validate` passes
- [ ] CanaryCheckFailure and CanaryCheckHighFailureRate alerts resolve on dev and integration after merge