### PR TITLE
fix(k8s): narrow DragonflyDown alert to data-plane targets only

### DIFF
--- a/kubernetes/platform/charts/dragonfly-operator.yaml
+++ b/kubernetes/platform/charts/dragonfly-operator.yaml
@@ -8,7 +8,7 @@ resources:
     memory: 256Mi
 
 serviceMonitor:
-  enabled: true
+  enabled: false
   interval: 60s
 
 grafanaDashboard:

--- a/kubernetes/platform/config/dragonfly/prometheus-rules.yaml
+++ b/kubernetes/platform/config/dragonfly/prometheus-rules.yaml
@@ -11,7 +11,7 @@ spec:
     - name: dragonfly.rules
       rules:
         - alert: DragonflyDown
-          expr: up{job=~".*dragonfly.*", namespace="database"} == 0
+          expr: up{app="dragonfly", namespace="database"} == 0
           for: 2m
           labels:
             severity: critical


### PR DESCRIPTION
## Summary

- Narrow DragonflyDown PromQL from `job=~".*dragonfly.*"` to `app="dragonfly"` to match only data-plane pods, not the operator
- Disable the broken dragonfly-operator ServiceMonitor (`connection reset by peer` on metrics endpoint)

## Test plan

- [x] `task k8s:validate` passes
- [ ] DragonflyDown and TargetDown (database) alerts resolve on dev and integration after merge