### PR TITLE
fix(k8s): use CEL for Flux pod canary health check

### DIFF
--- a/kubernetes/platform/config/canary-checker/platform-health.yaml
+++ b/kubernetes/platform/config/canary-checker/platform-health.yaml
@@ -19,4 +19,12 @@ spec:
         name: flux-system
       resource:
         labelSelector: app.kubernetes.io/part-of=flux
-      healthy: true
+      # Use CEL to check only current Ready condition, not restart counts.
+      # The built-in ready/healthy flags use is-healthy which treats any
+      # restarts in the last hour as unhealthy — unsuitable for a canary.
+      test:
+        expr: >
+          dyn(results).all(pod,
+            pod.Object.status.phase == "Running" &&
+            pod.Object.status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+          )


### PR DESCRIPTION
## Summary
- Replace `healthy: true` with a CEL `test.expr` in the platform-validation canary for Flux pod checks
- The built-in `healthy`/`ready` flags use flanksource's `is-healthy` library which treats any pod restarts in the last hour as unhealthy, causing permanent false-positive `CanaryCheckFailure` alerts after routine restarts (cluster upgrades, OCI rollouts)
- The CEL expression checks only current `status.phase == Running` and `Ready` condition — the actual point-in-time health signal

## Test plan
- [x] Applied manually to dev cluster — canary immediately switched from `Failed` to `Passed`
- [x] `task k8s:validate` passes
- [ ] Integration cluster canary recovers after promotion