### PR TITLE
fix(apps): repair immich and zipline on live cluster

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -291,15 +291,6 @@
       "datasourceTemplate": "helm",
       "registryUrlTemplate": "https://immich-app.github.io/immich-charts"
     },
-    // immich app image (v-prefixed Docker tags)
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^kubernetes/platform/versions\\.env$/"],
-      "matchStrings": ["immich_app_version=(?<currentValue>v\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-.]+)?)"],
-      "depNameTemplate": "immich-server",
-      "datasourceTemplate": "docker",
-      "packageNameTemplate": "ghcr.io/immich-app/immich-server"
-    },
     // vectorchord (CNPG image for Immich)
     {
       "customType": "regex",

--- a/kubernetes/clusters/live/charts/immich.yaml
+++ b/kubernetes/clusters/live/charts/immich.yaml
@@ -3,8 +3,6 @@ controllers:
   main:
     containers:
       main:
-        image:
-          tag: "${immich_app_version}"
         env:
           DB_HOSTNAME: immich-database-rw.database.svc.cluster.local
           DB_PORT: "5432"

--- a/kubernetes/clusters/live/charts/zipline.yaml
+++ b/kubernetes/clusters/live/charts/zipline.yaml
@@ -10,6 +10,7 @@ controllers:
 
     pod:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -35,5 +35,4 @@ spegel_version=0.6.0
 tuppr_version=0.0.52
 silence_operator_version=0.20.0
 immich_version=0.10.3
-immich_app_version=v2.0.0
 vectorchord_version=18.1-1.0.0


### PR DESCRIPTION
## Summary

- **Immich**: Remove broken `${immich_app_version}` tag override — Flux variable substitution doesn't reach inside ConfigMap data generated by Kustomize `configMapGenerator`, so the literal string was being used as an image tag (`InvalidImageName`). The Immich Helm chart already defaults to the correct image tags from its appVersion.
- **Zipline**: Add missing `runAsNonRoot: true` to pod-level securityContext — required by the `restricted` PodSecurity standard enforced on the zipline namespace.
- **Cleanup**: Remove unused `immich_app_version` from `versions.env` and its Renovate regex manager.

## Test plan

- [ ] CI validation passes (k8s:validate, renovate:validate)
- [ ] After merge, verify Immich pods start with correct image tags on live
- [ ] After merge, verify Zipline pods pass PodSecurity admission on live