### PR TITLE
fix(infra): add token key to flux-system secret for GitHub dispatch

### DIFF
--- a/infrastructure/modules/bootstrap/flux.tf
+++ b/infrastructure/modules/bootstrap/flux.tf
@@ -39,6 +39,7 @@ resource "kubernetes_secret" "git_auth" {
   data = {
     username = "git"
     password = data.aws_ssm_parameter.github_token.value
+    token    = data.aws_ssm_parameter.github_token.value
   }
 
   type = "Opaque"


### PR DESCRIPTION
## Summary

- The `githubdispatch` Flux Provider expects a `token` key in its secret, but the `flux-system` secret only had `username`/`password` (for Git HTTPS clone auth)
- This prevented the `validation-success` Alert from sending `repository_dispatch` events to GitHub, breaking automatic artifact promotion from integration to live
- Adds `token` alongside existing fields since the secret serves both Flux source controller (Git auth) and notification controller (GitHub API)

## Test plan

- [x] `task tg:fmt` passes
- [x] `task tg:test-bootstrap` passes (2/2)
- [ ] After applying to integration/live stacks, verify `kubectl get providers -n flux-system github-dispatch` shows Ready
- [ ] Merge a kubernetes/ change and confirm `Tag Validated Artifact` workflow triggers automatically