### PR TITLE
fix(apps): allow secret replication for immich and zipline

### DIFF
--- a/kubernetes/clusters/live/config/immich/immich-cluster.yaml
+++ b/kubernetes/clusters/live/config/immich/immich-cluster.yaml
@@ -6,6 +6,10 @@ metadata:
   name: immich-database
   namespace: database
 spec:
+  inheritedMetadata:
+    annotations:
+      replicator.v1.mittwald.de/replication-allowed: "true"
+      replicator.v1.mittwald.de/replication-allowed-namespaces: "immich"
   description: "Immich PostgreSQL with vectorchord for AI vector search"
   imageName: ghcr.io/tensorchord/cloudnative-vectorchord:${vectorchord_version:-17.7-1.0.0}
   instances: ${default_replica_count}

--- a/kubernetes/platform/config/database/superuser-secret.yaml
+++ b/kubernetes/platform/config/database/superuser-secret.yaml
@@ -7,6 +7,8 @@ metadata:
     secret-generator.v1.mittwald.de/autogenerate: password
     secret-generator.v1.mittwald.de/length: "32"
     secret-generator.v1.mittwald.de/encoding: base64
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "zipline"
 type: kubernetes.io/basic-auth
 stringData:
   username: postgres

--- a/kubernetes/platform/config/dragonfly/password-secret.yaml
+++ b/kubernetes/platform/config/dragonfly/password-secret.yaml
@@ -7,5 +7,7 @@ metadata:
     secret-generator.v1.mittwald.de/autogenerate: password
     secret-generator.v1.mittwald.de/length: "32"
     secret-generator.v1.mittwald.de/encoding: base64
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "immich"
 type: Opaque
 data: { }


### PR DESCRIPTION
## Summary

- **Follow-up to #254** — after fixing image tags and pod security, both apps hit the next failure: missing database credentials due to blocked secret replication.
- Source secrets in the `database` namespace were missing `replication-allowed` annotations, preventing the kubernetes-replicator from copying credentials to the `immich` and `zipline` namespaces.
- Each secret is scoped to only its consuming namespace (`replication-allowed-namespaces`).
- For the CNPG-managed `immich-database-app` secret, uses `inheritedMetadata` to propagate the annotation through the operator rather than editing the generated secret directly.

## Test plan

- [ ] CI validation passes (k8s:validate)
- [ ] After merge, verify replicator logs show successful replication (no `does not allow replication` errors)
- [ ] After merge, verify Immich pods reach Running state
- [ ] After merge, verify Zipline init container and app container start successfully