### PR TITLE
fix(apps): use dedicated db user for zipline to fix PgBouncer SASL auth

### DIFF
--- a/kubernetes/clusters/live/charts/zipline.yaml
+++ b/kubernetes/clusters/live/charts/zipline.yaml
@@ -4,7 +4,7 @@
 controllers:
   zipline:
     type: deployment
-    replicas: 1
+    replicas: 2
     annotations:
       reloader.stakater.com/auto: "true"
 
@@ -36,11 +36,11 @@ controllers:
               secretKeyRef:
                 name: cnpg-superuser-replica
                 key: password
-          INIT_POSTGRES_USER: postgres
+          INIT_POSTGRES_USER: zipline
           INIT_POSTGRES_PASS:
             valueFrom:
               secretKeyRef:
-                name: cnpg-superuser-replica
+                name: zipline-db-credentials
                 key: password
           INIT_POSTGRES_DBNAME: zipline
 
@@ -57,13 +57,13 @@ controllers:
               secretKeyRef:
                 name: zipline-secret
                 key: CORE_SECRET
-          # Database — superuser via replicated CNPG secret, $(VAR) substitution
+          # Database — dedicated app user via secret-generator, $(VAR) substitution
           POSTGRES_PASSWORD:
             valueFrom:
               secretKeyRef:
-                name: cnpg-superuser-replica
+                name: zipline-db-credentials
                 key: password
-          DATABASE_URL: "postgresql://postgres:$(POSTGRES_PASSWORD)@platform-pooler-rw.database.svc.cluster.local:5432/zipline"
+          DATABASE_URL: "postgresql://zipline:$(POSTGRES_PASSWORD)@platform-pooler-rw.database.svc.cluster.local:5432/zipline"
           # S3 — credentials auto-created by GarageKey operator
           DATASOURCE_TYPE: s3
           DATASOURCE_S3_REGION: garage

--- a/kubernetes/clusters/live/config/zipline/kustomization.yaml
+++ b/kubernetes/clusters/live/config/zipline/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - namespace.yaml
   - secret.yaml
   - cnpg-superuser-replica.yaml
+  - zipline-db-credentials.yaml
   - garage-bucket.yaml
   - garage-key.yaml
   - external-route.yaml

--- a/kubernetes/clusters/live/config/zipline/zipline-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/zipline/zipline-db-credentials.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: zipline-db-credentials
+  namespace: zipline
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/encoding: base64
+    secret-generator.v1.mittwald.de/length: "32"
+type: kubernetes.io/basic-auth
+stringData:
+  username: zipline


### PR DESCRIPTION
## Summary
- PgBouncer's `auth_query` cannot authenticate the `postgres` superuser, causing SASL failures when zipline connects through `platform-pooler-rw`
- Create a dedicated `zipline` database user with secret-generator credentials that PgBouncer can authenticate normally
- Bump to 2 replicas since zipline is stateless (all state in PostgreSQL + S3)

## Test plan
- [ ] `task k8s:validate` passes
- [ ] After promotion: zipline pods start without SASL errors
- [ ] Verify `init-db` creates `zipline` user and database using superuser credentials
- [ ] Verify zipline app connects through `platform-pooler-rw` as `zipline` user
- [ ] Confirm both replicas reach Ready state