### PR TITLE
feat(apps): deploy factorio game server

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -291,6 +291,15 @@
       "datasourceTemplate": "helm",
       "registryUrlTemplate": "https://immich-app.github.io/immich-charts"
     },
+    // factorio-server-charts (HTTP Helm chart)
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^kubernetes/platform/versions\\.env$/"],
+      "matchStrings": ["factorio_version=(?<currentValue>\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-.]+)?)"],
+      "depNameTemplate": "factorio-server-charts",
+      "datasourceTemplate": "helm",
+      "registryUrlTemplate": "https://sqljames.github.io/factorio-server-charts"
+    },
     // vectorchord (CNPG image for Immich)
     {
       "customType": "regex",

--- a/kubernetes/platform/charts/factorio.yaml
+++ b/kubernetes/platform/charts/factorio.yaml
@@ -1,0 +1,75 @@
+---
+replicaCount: 1
+
+strategy:
+  type: Recreate
+
+image:
+  repository: factoriotools/factorio
+  tag: stable
+  pullPolicy: IfNotPresent
+
+securityContext:
+  fsGroup: 845
+
+podSecurityContext:
+  runAsUser: 845
+  runAsGroup: 845
+
+service:
+  type: LoadBalancer
+  port: 34197
+  annotations:
+    lbipam.cilium.io/sharing-key: factorio
+
+hostNetworkEnabled: false
+
+persistence:
+  enabled: true
+  dataDir:
+    Size: 10Gi
+    storageClassName: longhorn
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 1Gi
+  limits:
+    memory: 2Gi
+
+factorioServer:
+  save_name: homelab-server
+  generate_new_save: true
+  load_latest_save: true
+  enable_space_age: true
+  port: 34197
+  rcon_port: 27015
+
+server_settings:
+  name: Homelab Factorio
+  description: Factorio 2.0 on Kubernetes
+  max_players: 0
+  visibility:
+    public: false
+    lan: true
+  require_user_verification: false
+  allow_commands: admins-only
+  autosave_interval: 5
+  autosave_slots: 10
+  auto_pause: true
+  max_heartbeats_per_second: 60
+
+rcon:
+  external: false
+  password: ""
+  passwordSecret: factorio-rcon-secret
+  port: 27015
+
+mods:
+  enabled: false
+
+import_save:
+  enabled: false
+
+port_fixer:
+  enabled: false

--- a/kubernetes/platform/config.yaml
+++ b/kubernetes/platform/config.yaml
@@ -74,6 +74,10 @@ spec:
       namespace: ""
       path: kubernetes/platform/config/infrastructure-policies
       dependsOn: [cilium]
+    - name: factorio-config
+      namespace: factorio
+      path: kubernetes/platform/config/factorio
+      dependsOn: [cilium, secret-generator]
   resourcesTemplate: |
     ---
     apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/kubernetes/platform/config/factorio/kustomization.yaml
+++ b/kubernetes/platform/config/factorio/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - network-policy.yaml
+  - rcon-secret.yaml

--- a/kubernetes/platform/config/factorio/network-policy.yaml
+++ b/kubernetes/platform/config/factorio/network-policy.yaml
@@ -1,0 +1,22 @@
+---
+# Custom CiliumNetworkPolicy overlay for Factorio game server.
+# The namespace uses the "isolated" profile (DNS egress + Prometheus ingress),
+# and this CNP adds the UDP game port ingress that profiles don't cover.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: factorio-game-server
+  namespace: factorio
+spec:
+  description: >-
+    Allow UDP game traffic on port 34197 from any source (internet-accessible).
+    Combined with the isolated profile baseline for DNS egress and Prometheus scraping.
+  endpointSelector: { }
+  ingress:
+    # Game server UDP traffic from any source
+    - fromEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "34197"
+              protocol: UDP

--- a/kubernetes/platform/config/factorio/rcon-secret.yaml
+++ b/kubernetes/platform/config/factorio/rcon-secret.yaml
@@ -1,0 +1,13 @@
+---
+# Auto-generated RCON password for Factorio admin console.
+# Only accessible within the cluster (RCON service is ClusterIP).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: factorio-rcon-secret
+  namespace: factorio
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: rconpw
+    secret-generator.v1.mittwald.de/length: "24"
+type: Opaque
+data: { }

--- a/kubernetes/platform/helm-charts.yaml
+++ b/kubernetes/platform/helm-charts.yaml
@@ -196,6 +196,13 @@ spec:
         version: "${silence_operator_version}"
         url: oci://gsoci.azurecr.io/charts/giantswarm
       dependsOn: [kube-prometheus-stack]
+    - name: factorio
+      namespace: factorio
+      chart:
+        name: factorio-server-charts
+        version: "${factorio_version}"
+        url: https://sqljames.github.io/factorio-server-charts
+      dependsOn: [cilium, longhorn]
   resourcesTemplate: |
     ---
     apiVersion: source.toolkit.fluxcd.io/v1

--- a/kubernetes/platform/kustomization.yaml
+++ b/kubernetes/platform/kustomization.yaml
@@ -38,3 +38,4 @@ configMapGenerator:
       - silence-operator.yaml=charts/silence-operator.yaml
       - spegel.yaml=charts/spegel.yaml
       - tuppr.yaml=charts/tuppr.yaml
+      - factorio.yaml=charts/factorio.yaml

--- a/kubernetes/platform/namespaces.yaml
+++ b/kubernetes/platform/namespaces.yaml
@@ -61,6 +61,12 @@ spec:
       dataplane: ambient
       security: privileged
       networkPolicy: false
+    - name: factorio
+      dataplane: ambient
+      security: baseline
+      networkPolicy:
+        profile: isolated
+        enforcement: ""
   resourcesTemplate: |
     ---
     apiVersion: v1

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -36,3 +36,4 @@ tuppr_version=0.0.52
 silence_operator_version=0.20.0
 immich_version=0.10.3
 vectorchord_version=18.1-1.0.0
+factorio_version=2.5.2


### PR DESCRIPTION
## Summary
- Deploy vanilla Factorio 2.0 (Space Age) to the platform using SQLJames factorio-server-charts
- Internet-accessible game server on Cilium LoadBalancer with layered network policy (isolated profile + custom CNP for UDP/34197 from world)
- Auto-generated RCON password via secret-generator, 10Gi Longhorn persistence

## Test plan
- [x] Validated with `task k8s:validate` (all 27 charts templated, 0 invalid resources)
- [x] Validated with `task renovate:validate`
- [ ] Integration cluster deploys successfully via OCI promotion
- [ ] Factorio pod reaches Ready state
- [ ] UDP game port reachable from LAN via LoadBalancer IP
- [ ] Hubble shows no unexpected DROPPED traffic in factorio namespace