### PR TITLE
fix(ci): derive OCI artifact versions from latest stable tag

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -34,7 +34,8 @@ The promotion pipeline uses OCI artifacts for immutable, auditable deployments.
                                   ▼
 ┌─────────────────────────────────────────────────────────────────────┐
 │  build-platform-artifact.yaml                                       │
-│  ├─ flux push artifact → ghcr.io/.../platform:0.1.0-rc.N           │
+│  ├─ Discovers latest stable tag, bumps patch for next version       │
+│  ├─ flux push artifact → ghcr.io/.../platform:X.Y.Z-rc.N           │
 │  ├─ flux tag artifact → sha-<short-sha>                            │
 │  └─ flux tag artifact → integration-<short-sha>                    │
 └─────────────────────────────────┬───────────────────────────────────┘
@@ -43,7 +44,7 @@ The promotion pipeline uses OCI artifacts for immutable, auditable deployments.
 ┌─────────────────────────────────────────────────────────────────────┐
 │  Integration Cluster                                                │
 │  ├─ OCIRepository polls for semver ">= 0.0.0-0" (includes RCs)     │
-│  ├─ Detects new 0.1.0-rc.N artifact                                │
+│  ├─ Detects new X.Y.Z-rc.N artifact (higher than last stable)      │
 │  └─ Flux reconciles platform                                        │
 └─────────────────────────────────┬───────────────────────────────────┘
                                   │
@@ -59,7 +60,7 @@ The promotion pipeline uses OCI artifacts for immutable, auditable deployments.
 ┌─────────────────────────────────────────────────────────────────────┐
 │  tag-validated-artifact.yaml                                        │
 │  ├─ flux tag artifact → validated-<short-sha> (traceability)       │
-│  └─ flux tag artifact → 0.1.N (stable semver for live)             │
+│  └─ flux tag artifact → X.Y.Z (stable semver, RC suffix stripped)  │
 └─────────────────────────────────┬───────────────────────────────────┘
                                   │
                                   ▼
@@ -75,11 +76,16 @@ The promotion pipeline uses OCI artifacts for immutable, auditable deployments.
 
 | Tag | Created By | Purpose |
 |-----|------------|---------|
-| `0.1.0-rc.N` | build workflow | Semver for OCIRepository polling (integration) |
+| `X.Y.Z-rc.N` | build workflow | Pre-release semver for integration OCIRepository polling |
 | `sha-<short>` | build workflow | Immutable reference to commit |
 | `integration-<short>` | build workflow | Marks artifact for integration |
 | `validated-<short>` | tag workflow | Traceability reference for validated artifacts |
-| `0.1.N` | tag workflow | Stable semver for live OCIRepository polling |
+| `X.Y.Z` | tag workflow | Stable semver for live OCIRepository polling |
+
+**Version numbering**: The build workflow discovers the latest stable tag (`X.Y.Z`) from GHCR,
+bumps the patch version, and creates RC tags like `X.Y.(Z+1)-rc.N`. When validated, the RC
+suffix is stripped to produce the stable tag `X.Y.(Z+1)`. This ensures RC tags always sort
+higher than the previous stable release in semver ordering.
 
 ---
 
@@ -222,27 +228,17 @@ Runs on PRs touching `infrastructure/`:
 
 Triggers on push to main (kubernetes/ changes):
 
-```yaml
-# Key steps
-flux push artifact \
-  oci://ghcr.io/${{ github.repository }}/platform:${SEMVER} \
-  --path=. \
-  --source="https://github.com/${{ github.repository }}" \
-  --revision="${{ github.ref_name }}@sha1:${{ github.sha }}"
-
-flux tag artifact ... --tag integration-${SHORT_SHA}
-```
+1. **Resolve version**: Queries GHCR for latest stable tag, bumps patch, increments RC number
+2. **Push artifact**: `flux push artifact ... :X.Y.Z-rc.N`
+3. **Tag**: Adds `sha-<short>` and `integration-<short>` tags
 
 ### tag-validated-artifact.yaml
 
 Triggers on `repository_dispatch` from canary-checker:
 
-```yaml
-# Validates SHA format and tags
-flux tag artifact \
-  "oci://ghcr.io/.../platform:integration-${SHA}" \
-  --tag "validated-${SHA}"
-```
+1. **Resolve**: Finds `integration-<sha>` artifact, extracts RC tag
+2. **Derive stable**: Strips `-rc.N` suffix (e.g., `0.1.146-rc.3` → `0.1.146`)
+3. **Tag**: Adds `validated-<sha>` and stable semver tags
 
 ---
 

--- a/.github/workflows/build-platform-artifact.yaml
+++ b/.github/workflows/build-platform-artifact.yaml
@@ -11,7 +11,6 @@ on:
 env:
   REGISTRY: ghcr.io
   ARTIFACT_REPO: ${{ github.repository }}/platform
-  BASE_VERSION: "0.1.0"
 
 jobs:
   build:
@@ -31,11 +30,67 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve next RC version
+        id: version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const packageName = `${context.repo.repo}/platform`;
+
+            // Discover all existing tags from GHCR
+            let allTags = [];
+            try {
+              const versions = await github.paginate(
+                github.rest.packages.getAllPackageVersionsForPackageOwnedByUser,
+                {
+                  package_type: 'container',
+                  package_name: packageName,
+                  username: context.repo.owner,
+                  per_page: 100,
+                }
+              );
+              allTags = versions.flatMap(v => v.metadata?.container?.tags || []);
+            } catch (e) {
+              core.info(`No existing package found, starting fresh: ${e.message}`);
+            }
+
+            // Find highest stable semver tag (X.Y.Z, no pre-release)
+            const stableRegex = /^(\d+)\.(\d+)\.(\d+)$/;
+            let latest = [0, 0, 0];
+            for (const tag of allTags) {
+              const m = tag.match(stableRegex);
+              if (m) {
+                const v = [parseInt(m[1]), parseInt(m[2]), parseInt(m[3])];
+                if (v[0] > latest[0] ||
+                    (v[0] === latest[0] && v[1] > latest[1]) ||
+                    (v[0] === latest[0] && v[1] === latest[1] && v[2] > latest[2])) {
+                  latest = v;
+                }
+              }
+            }
+
+            // Next version: bump patch from latest stable
+            const nextVersion = `${latest[0]}.${latest[1]}.${latest[2] + 1}`;
+
+            // Find highest existing RC number for the next version
+            const rcRegex = new RegExp(`^${nextVersion.replace(/\./g, '\\.')}-rc\\.(\\d+)$`);
+            let maxRc = 0;
+            for (const tag of allTags) {
+              const m = tag.match(rcRegex);
+              if (m) maxRc = Math.max(maxRc, parseInt(m[1]));
+            }
+
+            const semver = `${nextVersion}-rc.${maxRc + 1}`;
+            core.info(`Latest stable: ${latest.join('.')}`);
+            core.info(`Next RC: ${semver}`);
+            core.setOutput('semver', semver);
+
       - name: Build and push artifact
+        env:
+          SEMVER: ${{ steps.version.outputs.semver }}
         run: |
           SHORT_SHA="${{ github.sha }}"
           SHORT_SHA="${SHORT_SHA:0:7}"
-          SEMVER="${{ env.BASE_VERSION }}-rc.${{ github.run_number }}"
 
           # Push from repo root so paths match GitRepository structure
           flux push artifact \

--- a/.github/workflows/tag-validated-artifact.yaml
+++ b/.github/workflows/tag-validated-artifact.yaml
@@ -88,9 +88,9 @@ jobs:
               return;
             }
 
-            // Derive stable semver: 0.1.0-rc.130 → 0.1.130
-            const match = rcTag.match(/^(\d+\.\d+)\.\d+-rc\.(\d+)$/);
-            const stable = `${match[1]}.${match[2]}`;
+            // Derive stable semver by stripping RC suffix: 0.1.146-rc.3 → 0.1.146
+            const match = rcTag.match(/^(\d+\.\d+\.\d+)-rc\.\d+$/);
+            const stable = match[1];
 
             core.info(`Found RC tag: ${rcTag}`);
             core.info(`Derived stable semver: ${rcTag} → ${stable}`);


### PR DESCRIPTION
## Summary
- RC tags using a fixed base version (`0.1.0-rc.N`) were numerically lower than stable tags (`0.1.N`) produced by the validation pipeline, causing the integration cluster's semver filter to resolve to the latest stable instead of the newest RC
- Build workflow now queries GHCR for the latest stable tag, bumps the patch version, and increments RC numbers to produce correct pre-release versions (e.g., `0.1.146-rc.1` > `0.1.145`)
- Tag-validated workflow simplified to strip `-rc.N` suffix instead of remapping version components

## Test plan
- [ ] Trigger `build-platform-artifact` via `workflow_dispatch` and verify the resolved version in logs (should be `0.1.X-rc.1` where X = latest stable patch + 1)
- [ ] Verify the integration cluster picks up the new RC artifact
- [ ] Trigger `tag-validated-artifact` via `workflow_dispatch` and verify the stable tag is the RC version with suffix stripped