### PR TITLE
fix(apps): use hex encoding for zipline db password

### DIFF
--- a/kubernetes/clusters/live/config/zipline/zipline-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/zipline/zipline-db-credentials.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: zipline
   annotations:
     secret-generator.v1.mittwald.de/autogenerate: password
-    secret-generator.v1.mittwald.de/encoding: base64
+    secret-generator.v1.mittwald.de/encoding: hex
     secret-generator.v1.mittwald.de/length: "32"
 type: kubernetes.io/basic-auth
 stringData:


### PR DESCRIPTION
## Summary
- Zipline's auto-generated database password uses base64 encoding which produces `/` characters — these break `postgresql://` URI parsing, causing the connection string to misinterpret the password as a path separator
- Switches secret-generator encoding from `base64` to `hex` (`[0-9a-f]` only) to ensure URI-safe passwords

## Test plan
- [x] `task k8s:validate` passes
- [ ] secret-generator regenerates the password with hex encoding
- [ ] init-db container updates the password in Postgres via `ALTER ROLE`
- [ ] Zipline connects successfully with the new password