### PR TITLE
fix(apps): use direct Postgres for zipline to prevent advisory lock leaks

### DIFF
--- a/kubernetes/clusters/live/charts/zipline.yaml
+++ b/kubernetes/clusters/live/charts/zipline.yaml
@@ -92,7 +92,7 @@ controllers:
                 key: password
           DATABASE_URL:
             dependsOn: POSTGRES_PASSWORD
-            value: "postgresql://zipline:$(POSTGRES_PASSWORD)@platform-pooler-rw.database.svc.cluster.local:5432/zipline"
+            value: "postgresql://zipline:$(POSTGRES_PASSWORD)@platform-rw.database.svc.cluster.local:5432/zipline"
           # S3 — credentials auto-created by GarageKey operator
           DATASOURCE_TYPE: s3
           DATASOURCE_S3_REGION: garage


### PR DESCRIPTION
## Summary
- Switches zipline's `DATABASE_URL` from `platform-pooler-rw` (PgBouncer) to `platform-rw` (direct Postgres) to prevent Prisma advisory lock leaks on pod crashes
- PgBouncer keeps server connections alive after pods crash, orphaning session-scoped advisory locks that block all subsequent pods from starting

## Test plan
- [x] `task k8s:validate` passes
- [ ] Zipline pods start cleanly without advisory lock contention
- [ ] Both replicas reach Ready simultaneously after rollout