### PR TITLE
fix(apps): remove cross-kind authelia-prereqs dependency from HelmReleases

### DIFF
--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -35,14 +35,14 @@ spec:
         name: app-template
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
-      dependsOn: [cloudnative-pg, secret-generator, authelia-prereqs]
+      dependsOn: [cloudnative-pg, secret-generator]
     - name: authelia
       namespace: authelia
       chart:
         name: authelia
         version: "${authelia_version}"
         url: https://charts.authelia.com
-      dependsOn: [cloudnative-pg, secret-generator, lldap, authelia-prereqs]
+      dependsOn: [cloudnative-pg, secret-generator, lldap]
   resourcesTemplate: |
     ---
     apiVersion: source.toolkit.fluxcd.io/v1


### PR DESCRIPTION
## Summary
- Authelia and LLDAP HelmReleases are stuck on live because they `dependsOn` `authelia-prereqs`, which is a **Kustomization**, not a HelmRelease
- Flux HelmRelease `dependsOn` is kind-scoped — it can only reference other HelmReleases — so the dependency is permanently unsatisfiable
- The dependency is already implicitly guaranteed: the ResourceSet depends on the `platform` Kustomization, and `authelia-prereqs` also depends on `platform`, so prereqs are always reconciled before any HelmRelease is generated

## Test plan
- [ ] Verify `k8s:validate` passes (done locally)
- [ ] After merge and promotion, verify `lldap` HelmRelease becomes Ready on live
- [ ] Verify `authelia` HelmRelease becomes Ready on live
- [ ] Verify pods are running in the `authelia` namespace