### PR TITLE
fix(apps): add restricted PodSecurity compliance for authelia stack

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -14,6 +14,20 @@ pod:
     - name: oidc-jwk
       secret:
         secretName: authelia-oidc-jwk
+  securityContext:
+    pod:
+      runAsNonRoot: true
+      runAsUser: 999
+      runAsGroup: 999
+      fsGroup: 999
+      fsGroupChangePolicy: OnRootMismatch
+      seccompProfile:
+        type: RuntimeDefault
+    container:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: [ALL]
   extraInitContainers:
     - name: init-db
       # renovate: datasource=docker depName=ghcr.io/home-operations/postgres-init
@@ -38,6 +52,7 @@ pod:
         - name: INIT_POSTGRES_DBNAME
           value: authelia
       securityContext:
+        runAsNonRoot: true
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true
         capabilities:

--- a/kubernetes/clusters/live/charts/lldap.yaml
+++ b/kubernetes/clusters/live/charts/lldap.yaml
@@ -10,6 +10,7 @@ controllers:
 
     pod:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000


### PR DESCRIPTION
## Summary
- LLDAP and Authelia pods are rejected by PodSecurity `restricted` enforcement because they lack `runAsNonRoot: true`
- Adds `runAsNonRoot: true` to LLDAP's pod-level securityContext (it already ran as UID 1000 but the explicit field is required)
- Adds full pod and container securityContext to Authelia chart values, plus `runAsNonRoot: true` on the init-db container

## Test plan
- [ ] Verify `k8s:validate` passes (done locally)
- [ ] After promotion, verify LLDAP pods start successfully in the `authelia` namespace
- [ ] Verify Authelia pods start successfully after LLDAP is ready
- [ ] Verify both HelmReleases reach Ready state