### PR TITLE
fix(platform): allow cnpg superuser secret replication to authelia namespace

### DIFF
--- a/kubernetes/platform/config/database/superuser-secret.yaml
+++ b/kubernetes/platform/config/database/superuser-secret.yaml
@@ -8,7 +8,7 @@ metadata:
     secret-generator.v1.mittwald.de/length: "32"
     secret-generator.v1.mittwald.de/encoding: base64
     replicator.v1.mittwald.de/replication-allowed: "true"
-    replicator.v1.mittwald.de/replication-allowed-namespaces: "zipline"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "zipline,authelia"
 type: kubernetes.io/basic-auth
 stringData:
   username: postgres


### PR DESCRIPTION
## Summary
- Allow cnpg superuser secret replication to authelia namespace (`replication-allowed-namespaces` only permitted `zipline`)
- Hardcode LLDAP image tag since the `cluster-values` ConfigMap does not receive `postBuild` variable substitution from `platform-versions`

## Test plan
- [ ] Verify `k8s:validate` passes (done locally)
- [ ] After promotion, verify `cnpg-superuser-replica` secret in `authelia` namespace has `password` key
- [ ] Verify LLDAP pod starts and passes init containers
- [ ] Verify both `lldap` and `authelia` HelmReleases reach Ready state