### PR TITLE
fix(apps): hardcode LLDAP image tag for cluster-specific values

### DIFF
--- a/kubernetes/clusters/live/charts/lldap.yaml
+++ b/kubernetes/clusters/live/charts/lldap.yaml
@@ -65,7 +65,8 @@ controllers:
       app:
         image:
           repository: ghcr.io/lldap/lldap
-          tag: "${lldap_version}"
+          # renovate: datasource=docker depName=ghcr.io/lldap/lldap
+          tag: v0.6.2
         command:
           - /bin/sh
           - -c


### PR DESCRIPTION
## Summary
- LLDAP pods fail with `InvalidImageName` because `${lldap_version}` is never substituted — the `cluster-values` ConfigMap is generated by the root `flux-system` Kustomization which has no `postBuild` substitution
- Hardcodes the tag to `v0.6.2` with a Renovate annotation, matching the pattern used by zipline and immich

## Test plan
- [ ] Verify `k8s:validate` passes (done locally)
- [ ] After promotion, verify LLDAP pod starts with `ghcr.io/lldap/lldap:v0.6.2`
- [ ] Verify both `lldap` and `authelia` HelmReleases reach Ready state