### PR TITLE
fix(apps): escape shell variable in LLDAP db-url for Flux postBuild

### DIFF
--- a/kubernetes/clusters/live/charts/lldap.yaml
+++ b/kubernetes/clusters/live/charts/lldap.yaml
@@ -77,7 +77,7 @@ controllers:
           - -c
           - |
             PASSWORD=$(cat /secrets/db/password)
-            echo "postgres://lldap:${PASSWORD}@platform-pooler-rw.database.svc.cluster.local:5432/lldap" > /config/database-url
+            echo "postgres://lldap:$${PASSWORD}@platform-pooler-rw.database.svc.cluster.local:5432/lldap" > /config/database-url
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary
- The `cluster-chart-values` Kustomization (PR #278) applies Flux postBuild substitution to chart values, which consumed the shell `${PASSWORD}` variable as an empty Flux variable — LLDAP connects to postgres with an empty password
- Escape as `$${PASSWORD}` so Flux renders it as literal `${PASSWORD}` for the shell script

## Test plan
- [ ] Verify `cluster-values` ConfigMap shows `${PASSWORD}` (not empty) in the LLDAP db-url script
- [ ] Validate LLDAP connects to postgres successfully through the pooler