### PR TITLE
fix(apps): grant table-level privileges for authelia stack db users

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -65,7 +65,7 @@ pod:
         - --host=platform-rw.database.svc.cluster.local
         - --username=postgres
         - --dbname=authelia
-        - --command=GRANT ALL ON SCHEMA public TO authelia; ALTER DATABASE authelia OWNER TO authelia;
+        - --command=GRANT ALL ON SCHEMA public TO authelia; ALTER DATABASE authelia OWNER TO authelia; GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO authelia; GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO authelia;
       env:
         - name: PGPASSWORD
           valueFrom:

--- a/kubernetes/clusters/live/charts/lldap.yaml
+++ b/kubernetes/clusters/live/charts/lldap.yaml
@@ -59,7 +59,7 @@ controllers:
           - --host=platform-rw.database.svc.cluster.local
           - --username=postgres
           - --dbname=lldap
-          - --command=GRANT ALL ON SCHEMA public TO lldap; ALTER DATABASE lldap OWNER TO lldap;
+          - --command=GRANT ALL ON SCHEMA public TO lldap; ALTER DATABASE lldap OWNER TO lldap; GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO lldap; GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO lldap;
         env:
           PGPASSWORD:
             valueFrom:


### PR DESCRIPTION
## Summary
- Tables in the `lldap` and `authelia` databases were created by the initial deployment connecting as the `postgres` superuser, so they are owned by `postgres`
- After switching to dedicated db users (PR #279), schema-level grants alone don't cover existing tables — PostgreSQL requires explicit table-level and sequence-level `GRANT` statements
- This fixes `permission denied for table metadata` errors in LLDAP

## Test plan
- [ ] Verify LLDAP pod starts without permission errors
- [ ] Verify Authelia pod starts successfully
- [ ] Verify both services are accessible via their ingress endpoints