### PR TITLE
fix(apps): fix Authelia startup by removing conflicting session config

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -125,10 +125,8 @@ configMap:
     cookies:
       - domain: "${internal_domain}"
         subdomain: auth
-        default_redirection_url: "https://auth.${internal_domain}"
       - domain: "${external_domain}"
         subdomain: auth
-        default_redirection_url: "https://auth.${external_domain}"
     redis:
       enabled: true
       host: platform.database.svc.cluster.local
@@ -161,7 +159,7 @@ configMap:
 
   identity_providers:
     oidc:
-      enabled: true
+      enabled: false
       jwks:
         - key:
             path: /secrets/oidc-jwk/tls.key


### PR DESCRIPTION
## Summary
- Authelia v0.10.x rejects `default_redirection_url` when it equals the inferred `authelia_url` (subdomain + domain). In a ForwardAuth setup the redirect target comes from the original request, so this field is unnecessary.
- Disables OIDC until clients are configured — empty `clients: []` is a validation error.

## Test plan
- [x] `task k8s:validate` — all checks pass
- [ ] After merge: verify Authelia pod starts and reaches `Running 1/1`
- [ ] Verify ForwardAuth redirects work for internal/external domains