### PR TITLE
fix(ci): match Flux githubdispatch event_type for automated promotion

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -50,10 +50,10 @@ The promotion pipeline uses OCI artifacts for immutable, auditable deployments.
                                   │
                                   ▼
 ┌─────────────────────────────────────────────────────────────────────┐
-│  Canary-Checker Validation                                          │
-│  ├─ Monitors Kustomization health                                   │
-│  ├─ Runs platform smoke tests                                       │
-│  └─ On success: Alert triggers repository_dispatch                  │
+│  Flux Alert (validation-success)                                     │
+│  ├─ Watches platform Kustomization for "Reconciliation finished"     │
+│  ├─ Fires repository_dispatch (event_type: Kustomization/platform.flux-system) │
+│  └─ Workflow has idempotency guard for repeated reconciliation events │
 └─────────────────────────────────┬───────────────────────────────────┘
                                   │
                                   ▼
@@ -143,7 +143,7 @@ kubectl get alerts -n flux-system
 kubectl get providers -n flux-system
 
 # Check if Alert fired
-kubectl describe alert canary-success -n flux-system
+kubectl describe alert validation-success -n flux-system
 ```
 
 ### Tracing an Artifact
@@ -170,6 +170,7 @@ flux get kustomizations -A
 | Validation passes but live doesn't update | `validated-*` tag not applied | Check tag-validated workflow |
 | `repository_dispatch` not received | GitHub token missing `repo` scope | Check Provider secret |
 | Artifact push fails | GHCR auth issue | Check `GITHUB_TOKEN` permissions |
+| Workflow triggers every ~10min | Alert fires on every reconciliation | Idempotency guard skips already-validated artifacts |
 
 ### Manual Promotion (Emergency)
 
@@ -234,7 +235,7 @@ Triggers on push to main (kubernetes/ changes):
 
 ### tag-validated-artifact.yaml
 
-Triggers on `repository_dispatch` from canary-checker:
+Triggers on `repository_dispatch` from Flux Alert (`Kustomization/platform.flux-system`):
 
 1. **Resolve**: Finds `integration-<sha>` artifact, extracts RC tag
 2. **Derive stable**: Strips `-rc.N` suffix (e.g., `0.1.146-rc.3` → `0.1.146`)

--- a/.github/workflows/tag-validated-artifact.yaml
+++ b/.github/workflows/tag-validated-artifact.yaml
@@ -3,7 +3,7 @@ name: Tag Validated Artifact
 
 on:
   repository_dispatch:
-    types: [artifact-validated]
+    types: ["Kustomization/platform.flux-system"]
   workflow_dispatch:
     inputs:
       artifact_sha:
@@ -35,7 +35,6 @@ jobs:
         with:
           script: |
             const inputSha = '${{ inputs.artifact_sha }}';
-            const payloadSha = '${{ github.event.client_payload.artifact_sha }}';
             const packageName = `${context.repo.repo}/platform`;
 
             // List all versions of the container package
@@ -46,8 +45,8 @@ jobs:
               per_page: 100,
             });
 
-            // Determine the artifact SHA - from input, payload, or auto-detect latest integration tag
-            let sha = inputSha || payloadSha;
+            // Determine the artifact SHA - from input or auto-detect latest integration tag
+            let sha = inputSha;
 
             if (!sha) {
               core.info('No SHA provided, discovering latest integration tag...');
@@ -77,6 +76,15 @@ jobs:
             );
             if (!targetVersion) {
               core.setFailed(`Could not find version tagged integration-${sha}`);
+              return;
+            }
+
+            // Check if already promoted (Alert fires every ~10min reconciliation)
+            const alreadyValidated = targetVersion.metadata.container.tags.some(t =>
+              t === `validated-${sha}`
+            );
+            if (alreadyValidated) {
+              core.info(`Artifact ${sha} already validated — skipping`);
               return;
             }
 

--- a/kubernetes/platform/config/flux-notifications/canary-alert.yaml
+++ b/kubernetes/platform/config/flux-notifications/canary-alert.yaml
@@ -7,6 +7,10 @@
 # 2. Alert triggers GitHub repository_dispatch
 # 3. tag-validated-artifact workflow tags the OCI artifact
 #
+# The githubdispatch provider hardcodes event_type as "{Kind}/{Name}.{Namespace}",
+# so this Alert dispatches with event_type: "Kustomization/platform.flux-system".
+# The workflow trigger must match this exact string.
+#
 # For deeper health validation, canary-checker performs additional checks.
 # A future enhancement could have canary-checker directly call GitHub API
 # when all health checks pass.
@@ -26,5 +30,3 @@ spec:
       namespace: flux-system
   inclusionList:
     - ".*Reconciliation finished.*"
-  eventMetadata:
-    event_type: artifact-validated


### PR DESCRIPTION
## Summary
- The automated OCI artifact promotion from integration → live has never worked because the workflow trigger (`artifact-validated`) didn't match the actual `event_type` dispatched by Flux's githubdispatch provider (`Kustomization/platform.flux-system`)
- Removes dead `client_payload.artifact_sha` extraction that doesn't exist in the Flux event payload
- Adds an idempotency guard so repeated ~10min reconciliation dispatches skip already-promoted artifacts

## Test plan
- [ ] `task k8s:validate` passes (validates Alert manifest change)
- [ ] Workflow YAML syntax is valid (CI check)
- [ ] After merge on integration cluster: `kubectl -n flux-system logs -l app=notification-controller | grep dispatch` confirms events still dispatching
- [ ] GitHub Actions tab shows workflow triggered by `repository_dispatch` (not just `workflow_dispatch`)
- [ ] After first automated promotion: subsequent runs exit with "already validated — skipping"