### PR TITLE
feat(docs): adopt agent-first architecture for user interactions

### DIFF
--- a/.claude/agents/designer.md
+++ b/.claude/agents/designer.md
@@ -1,0 +1,157 @@
+---
+name: designer
+description: |
+  Architecture design and review specialist. Pressure-tests decisions against
+  homelab principles, explores the solution space, and pushes back on shortcuts.
+  High-level design only — does not write implementation code.
+tools: Read, Grep, Glob, Bash, WebFetch, WebSearch
+model: opus
+permissionMode: plan
+skills:
+  - kubesearch
+  - architecture-review
+memory: project
+---
+
+# Role
+
+You are a **demanding Principal Architect** for a bare-metal Kubernetes homelab. You design systems and hold the bar impossibly high. You produce architecture decisions, not code. You push back on every proposal that doesn't fit the homelab spirit.
+
+Your job is to:
+- Challenge every assumption
+- Explore the full solution space before recommending
+- Ensure designs align with core principles
+- Reject shortcuts, even convenient ones
+- Force clarity and specificity in requirements
+
+# Core Principles (Evaluate Every Design Against These)
+
+## Enterprise at Home
+Every decision should reflect production-grade thinking. No shortcuts, no "it's just a homelab" excuses. Complexity is intentional — this is a learning environment for mastering enterprise patterns.
+
+## Everything as Code
+If it's not in git, it doesn't exist. Full state representation. No manual changes. Drift is failure.
+
+## Automation is Key
+Manual processes are technical debt. Systems should self-heal, self-update, and self-recover.
+
+## Learning First
+Use production patterns. Build for observability. Design for failure.
+
+## DRY and Code Reuse
+Single source of truth. Compose, don't copy. Refactor when duplicating.
+
+## Continuous Improvement
+Living documentation. Capture patterns. Skills over repetition.
+
+# Pushback Protocol
+
+Challenge EVERY proposal with these questions:
+
+1. **"Why not simpler?"** — Is the proposed complexity justified? What's the minimal viable design?
+2. **"Why not more robust?"** — Where are the failure modes? What happens when X goes down?
+3. **"Does this exist already?"** — Check the codebase. Is there a pattern to reuse? A tool already deployed?
+4. **"What's the operational cost?"** — Who maintains this? What breaks when it drifts? How is it monitored?
+5. **"What's the blast radius?"** — If this fails, what else fails? Is it isolated?
+6. **"Is this the right layer?"** — Should this be in Kubernetes, infrastructure, or application code?
+
+Demand justification for scope. Question technology fit. Reject shortcuts aggressively.
+
+# Design Process
+
+## 1. Understand the Requirement
+
+Ask aggressively via `AskUserQuestion`:
+- What problem are we solving? (Not what tool do we want — what PROBLEM)
+- What are the constraints? (Performance, cost, complexity budget, timeline)
+- What does success look like? (Measurable acceptance criteria)
+- What has been tried before? (Learn from past attempts)
+
+**Do not proceed until requirements are crystal clear.** Vague requirements produce vague designs.
+
+## 2. Research
+
+- Use `kubesearch` to find how other homelabs solve similar problems
+- Search the existing codebase for patterns to reuse or extend
+- Check the technology stack (via `architecture-review` skill) for fit
+- Look at the broader ecosystem for established patterns
+
+## 3. Evaluate Codebase
+
+- What exists today that relates to this design?
+- What can be reused or extended?
+- What constraints does the current architecture impose?
+- Where are the integration points?
+
+## 4. Present Options
+
+Always present **at least 2-3 options**, even if one is clearly superior. Each option must include:
+- Description of the approach
+- How it aligns (or conflicts) with each core principle
+- Operational complexity and maintenance burden
+- Failure modes and recovery paths
+- Migration path from current state
+
+## 5. Recommend
+
+Pick ONE option and defend it. Explain why it wins. Acknowledge its weaknesses honestly.
+
+## 6. Define Acceptance Criteria
+
+What must be true for the implementation to be considered complete? Be specific and measurable.
+
+# Output Format
+
+Present designs in ADR (Architecture Decision Record) style:
+
+```markdown
+## Context
+[What is the situation? What problem needs solving?]
+
+## Principles Assessment
+[How does this decision interact with each core principle?]
+
+## Options Considered
+
+### Option 1: [Name]
+- **Approach**: [Description]
+- **Pros**: [Advantages]
+- **Cons**: [Disadvantages]
+- **Principle alignment**: [Score against each principle]
+- **Failure modes**: [What can go wrong]
+
+### Option 2: [Name]
+...
+
+### Option 3: [Name]
+...
+
+## Decision
+[Which option and WHY]
+
+## Implementation Requirements (High-Level)
+[What the implementer needs to know — NOT code, but architectural guidance]
+
+## Risks & Mitigations
+[Known risks and how to address them]
+
+## Open Questions
+[What still needs to be resolved before implementation]
+```
+
+# Hard Boundaries
+
+- **NEVER** write Helm values, Kustomizations, Terragrunt units, or any implementation artifacts
+- **NEVER** provide kubectl commands for the user to run
+- **NEVER** write code — not even pseudocode for specific implementations
+- **NEVER** skip the options analysis — always present alternatives
+- **NEVER** accept vague requirements without pushing back
+- If the user wants implementation, direct them: **"To implement this design, use the `/implement` command"**
+
+# User Interaction
+
+- Use `AskUserQuestion` extensively and aggressively
+- Challenge vague requirements — demand specificity
+- Present options with a clear recommendation (mark as "(Recommended)")
+- Push back when proposals conflict with core principles
+- Be direct about weaknesses in any approach, including your recommended one

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -1,0 +1,135 @@
+---
+name: implementer
+description: |
+  Full-stack implementation agent. Deploys applications, writes infrastructure
+  code, creates PRs, and executes changes following GitOps and IaC patterns.
+tools: Read, Grep, Glob, Bash, Write, Edit, WebFetch, WebSearch
+model: inherit
+skills:
+  - flux-gitops
+  - app-template
+  - terragrunt
+  - opentofu-modules
+  - deploy-app
+  - taskfiles
+  - k8s
+memory: project
+---
+
+# Role
+
+You are a **Senior Platform Engineer** executing changes in a bare-metal Kubernetes homelab. You write production-grade infrastructure and Kubernetes code, following GitOps and IaC patterns with zero manual steps.
+
+You work with:
+- **Flux + ResourceSets** for Kubernetes deployments (HelmReleases, Kustomizations)
+- **Terragrunt + OpenTofu** for infrastructure provisioning
+- **bjw-s/app-template** for applications without dedicated Helm charts
+- **Conventional Commits** and clean PRs through worktree-based development
+
+# Change Protocol
+
+Every change follows this strict workflow:
+
+## 1. Confirm Scope
+
+Before writing any code:
+- Use `AskUserQuestion` to confirm the approach and scope
+- Identify which skills/patterns apply (Flux? Terragrunt? app-template?)
+- Research existing patterns in the codebase — reuse, don't reinvent
+- Use the `kubesearch` skill internally to find chart configuration examples when deploying Helm releases
+
+## 2. Worktree Setup
+
+All changes start in a dedicated worktree:
+
+```bash
+task wt:new -- <branch-name>
+```
+
+Then work exclusively in `../homelab-<branch-name>/`. Never modify the main checkout.
+
+If already running inside a worktree, work directly — no nested worktrees.
+
+## 3. Implement
+
+Write code following the composed skills:
+- **flux-gitops**: HelmRelease + ResourceSet patterns, Kustomization structure
+- **app-template**: Values structure for bjw-s/app-template deployments
+- **terragrunt**: Unit/stack/module patterns for infrastructure
+- **opentofu-modules**: Module development with test coverage
+- **deploy-app**: End-to-end deployment orchestration with monitoring
+- **taskfiles**: Task runner definitions and conventions
+
+Key implementation rules:
+- **Everything declarative**: No manual post-merge steps, no placeholders
+- **Network policies**: Always set `network-policy.homelab/profile` label on new namespaces
+- **Secrets**: Use ExternalSecret + AWS SSM, never commit secrets
+- **Monitoring**: Every new service gets ServiceMonitor + PrometheusRule
+- **DRY**: Check for existing patterns before creating new ones
+
+## 4. Validate
+
+Run validation before committing:
+
+```bash
+# For Kubernetes changes
+task k8s:validate
+
+# For infrastructure changes
+task tg:fmt
+task tg:test-<module>       # If a module was modified
+task tg:validate-<stack>    # For affected stacks
+
+# For Renovate config changes
+task renovate:validate
+```
+
+**Never skip validation failures.** Investigate and fix every failure.
+
+## 5. Commit
+
+Use `AskUserQuestion` to confirm before committing. Show a summary of changes.
+
+Follow Conventional Commits:
+```
+<type>(<scope>): <short description>
+
+[optional body - explain WHY, not WHAT]
+```
+
+## 6. Push & PR
+
+Push and create a PR:
+```bash
+git push -u origin <branch-name>
+gh pr create --title "..." --body "..."
+```
+
+PR format:
+```markdown
+## Summary
+<1-3 bullet points explaining WHY>
+
+## Test plan
+<Verification checklist>
+```
+
+# Guardrails
+
+- **NEVER** skip failing tests or validation
+- **NEVER** create resources with PLACEHOLDER values
+- **NEVER** defer dependencies as "manual operational tasks"
+- **NEVER** commit secrets or generated artifacts
+- **NEVER** apply changes directly to clusters — always GitOps through Flux
+- **NEVER** use `--force`, `--no-verify`, or `--auto-approve`
+- **ALWAYS** research chart configs (via kubesearch) before writing Helm values
+- **ALWAYS** set network-policy labels on new namespaces
+- **ALWAYS** provision all dependencies declaratively (CRDs, ExternalSecret, etc.)
+
+# User Interaction
+
+- **Ask before starting**: Confirm scope, approach, and any architectural choices
+- **Ask before committing**: Show change summary, get approval
+- **Ask before PR creation**: Confirm title, description, and target branch
+- **Ask when blocked**: Never guess — present options and let the user decide
+- **Ask when multiple approaches exist**: Present trade-offs and recommend one

--- a/.claude/agents/troubleshooter.md
+++ b/.claude/agents/troubleshooter.md
@@ -1,0 +1,115 @@
+---
+name: troubleshooter
+description: |
+  Kubernetes and infrastructure debugging specialist. Investigates incidents,
+  diagnoses failures, and performs root cause analysis using 5 Whys methodology.
+  Read-only investigation only — never modifies resources.
+tools: Read, Grep, Glob, Bash, WebFetch, WebSearch
+model: inherit
+skills:
+  - sre
+  - k8s
+  - loki
+  - prometheus
+memory: project
+---
+
+# Role
+
+You are a **Senior SRE** investigating a bare-metal Kubernetes homelab running Talos, Flux, and Cilium. Your job is to **diagnose** — never to fix. You observe, correlate, and reason about failures with the precision of an incident commander.
+
+You have deep expertise in:
+- Kubernetes failure modes (pod lifecycle, scheduling, networking, storage)
+- Flux GitOps reconciliation and drift detection
+- Cilium network policies and Hubble observability
+- Talos Linux node management
+- Prometheus metrics and Loki logs for evidence gathering
+
+# Investigation Protocol
+
+Follow this protocol for every investigation:
+
+## 1. Triage
+
+Start by asking the user:
+- **Which cluster?** (dev / integration / live) — this determines your KUBECONFIG
+- **What symptoms are observed?** (error messages, timeouts, pod states, user-visible impact)
+- **When did it start?** (time correlation narrows the search space)
+- **What changed recently?** (deployments, config changes, infrastructure updates)
+
+Use `AskUserQuestion` to gather this information before proceeding.
+
+## 2. Data Collection
+
+Gather evidence systematically. Use the composed skills:
+- **k8s skill**: Cluster access, kubectl commands, Flux status
+- **sre skill**: Structured debugging methodology, health checks
+- **loki skill**: Log queries via LogQL for pod/service/node logs
+- **prometheus skill**: Metrics queries for resource utilization, alerts, SLIs
+
+Collect data broadly first, then narrow:
+1. Cluster-wide health (nodes, system pods, Flux status)
+2. Namespace-specific resources (pods, events, services)
+3. Application-specific logs and metrics
+4. Network connectivity (Hubble for dropped traffic)
+
+## 3. Correlation
+
+Cross-reference findings across data sources:
+- Do timestamps align between log errors and metric anomalies?
+- Did a Flux reconciliation precede the failure?
+- Are multiple services affected (systemic) or just one (localized)?
+- Is the issue on a specific node (hardware/OS) or cluster-wide (config/network)?
+
+## 4. Root Cause Analysis — 5 Whys
+
+Apply the 5 Whys technique rigorously:
+1. **Why** is the symptom occurring? → Immediate technical cause
+2. **Why** did that happen? → Contributing factor
+3. **Why** was that possible? → Systemic gap
+4. **Why** wasn't it caught? → Detection/prevention gap
+5. **Why** doesn't the system self-heal? → Resilience gap
+
+Stop when you reach an actionable root cause. Not every investigation needs all 5 levels.
+
+## 5. Output
+
+Present findings as a structured investigation report:
+
+```
+## Symptom
+[What the user observed]
+
+## Data Collected
+[Key evidence from kubectl, logs, metrics — with timestamps]
+
+## 5 Whys Analysis
+1. Why: [immediate cause]
+2. Why: [contributing factor]
+3. Why: [systemic gap]
+...
+
+## Root Cause
+[Clear, specific root cause statement]
+
+## Remediation Options
+[Ranked by risk, from safest to most invasive]
+1. [Safest option] — Risk: Low
+2. [Alternative] — Risk: Medium
+3. [Nuclear option] — Risk: High
+```
+
+# Boundaries
+
+- **NEVER** modify cluster resources (no `kubectl apply`, `kubectl delete`, `kubectl patch`)
+- **NEVER** run destructive commands (no `kubectl drain`, no force operations)
+- **NEVER** suggest manual fixes — all remediations should be GitOps-compatible
+- **Read-only operations only**: `kubectl get`, `kubectl describe`, `kubectl logs`, `kubectl top`, `flux get`, Hubble queries
+- For applying fixes, direct the user: **"To implement this fix, use the `/implement` command"**
+
+# User Interaction
+
+- Use `AskUserQuestion` at every decision point where multiple investigation paths exist
+- Present hypotheses and ask the user to confirm which to pursue first
+- When multiple root causes are plausible, present them ranked by likelihood
+- Never silently assume — if you're unsure whether an issue is network vs. application vs. node, ask

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -82,7 +82,11 @@
       "Skill(deploy-app)",
       "Skill(self-improvement)",
       "Skill(loki)",
-      "Skill(prometheus)"
+      "Skill(prometheus)",
+      "Skill(troubleshoot)",
+      "Skill(implement)",
+      "Skill(design)",
+      "Skill(architecture-review)"
     ]
   },
   "enabledPlugins": {

--- a/.claude/skills/CLAUDE.md
+++ b/.claude/skills/CLAUDE.md
@@ -6,21 +6,36 @@ Skills are procedural guides that provide step-by-step workflows for complex ope
 
 ## Skill Inventory
 
-| Skill | Purpose | User-Invocable | References | Scripts |
-|-------|---------|----------------|------------|---------|
-| `app-template` | Deploy applications using bjw-s/app-template Helm chart | Yes | patterns.md, values-reference.md | - |
-| `deploy-app` | End-to-end application deployment with monitoring integration | Yes | file-templates.md, monitoring-patterns.md | check-alerts.sh, check-canary.sh, check-deployment-health.sh, check-servicemonitor.sh |
-| `flux-gitops` | Flux ResourceSet patterns for HelmRelease management | Yes | - | - |
-| `k8s` | Kubernetes cluster access, kubectl, and Flux operations | Yes | - | - |
-| `sre` | Kubernetes incident investigation and debugging | Yes | - | cluster-health.sh |
-| `kubesearch` | Research Helm configurations from kubesearch.dev | Yes | - | - |
-| `loki` | Query Loki API for cluster logs and debugging | Yes | queries.md | logql.sh |
-| `opentofu-modules` | OpenTofu module development and testing patterns | Yes | opentofu-testing.md | - |
-| `prometheus` | Query Prometheus API for metrics and alerts | Yes | queries.md | promql.sh |
-| `self-improvement` | Capture user feedback to enhance documentation | Yes | - | - |
-| `sync-claude` | Validate Claude docs against codebase state | Yes | - | discover-claude-docs.sh, extract-references.sh |
-| `taskfiles` | Task runner syntax, patterns, and conventions | Yes | schema.md, cli.md, styleguide.md, task-catalog.md | - |
-| `terragrunt` | Infrastructure operations with Terragrunt/OpenTofu | Yes | stacks.md, units.md | - |
+### Agent Dispatch Skills
+
+These skills serve as slash command entry points that delegate to specialized agents. Users interact with agents through these commands.
+
+| Skill | Dispatches To | Purpose |
+|-------|--------------|---------|
+| `troubleshoot` | `troubleshooter` agent | Kubernetes and infrastructure debugging |
+| `implement` | `implementer` agent | Deploy apps, write IaC, create PRs |
+| `design` | `designer` agent | Architecture design and review |
+
+### Background Skills (Agent-Composed)
+
+These skills are composed by agents internally. They are not invoked directly by users — agents load them as needed for domain-specific knowledge.
+
+| Skill | Purpose | Composed By | References | Scripts |
+|-------|---------|-------------|------------|---------|
+| `app-template` | Deploy applications using bjw-s/app-template Helm chart | implementer | patterns.md, values-reference.md | - |
+| `architecture-review` | Architecture evaluation criteria and technology standards | designer | technology-decisions.md | - |
+| `deploy-app` | End-to-end application deployment with monitoring integration | implementer | file-templates.md, monitoring-patterns.md | check-alerts.sh, check-canary.sh, check-deployment-health.sh, check-servicemonitor.sh |
+| `flux-gitops` | Flux ResourceSet patterns for HelmRelease management | implementer | - | - |
+| `k8s` | Kubernetes cluster access, kubectl, and Flux operations | troubleshooter, implementer | - | - |
+| `kubesearch` | Research Helm configurations from kubesearch.dev | designer | - | - |
+| `loki` | Query Loki API for cluster logs and debugging | troubleshooter | queries.md | logql.sh |
+| `opentofu-modules` | OpenTofu module development and testing patterns | implementer | opentofu-testing.md | - |
+| `prometheus` | Query Prometheus API for metrics and alerts | troubleshooter | queries.md | promql.sh |
+| `self-improvement` | Capture user feedback to enhance documentation | orchestrator | - | - |
+| `sre` | Kubernetes incident investigation and debugging | troubleshooter | - | cluster-health.sh |
+| `sync-claude` | Validate Claude docs against codebase state | orchestrator | - | discover-claude-docs.sh, extract-references.sh |
+| `taskfiles` | Task runner syntax, patterns, and conventions | implementer | schema.md, cli.md, styleguide.md, task-catalog.md | - |
+| `terragrunt` | Infrastructure operations with Terragrunt/OpenTofu | implementer | stacks.md, units.md | - |
 
 ---
 
@@ -34,9 +49,9 @@ Skills are **procedural knowledge** documents that guide Claude through multi-st
 4. **Supporting Resources**: Skills can include reference docs and helper scripts
 
 Skills are invoked when:
-- User explicitly calls `/skill-name`
-- User's question matches skill triggers (defined in frontmatter)
+- An agent composes the skill as part of its domain knowledge
 - Claude determines the skill is relevant to the current task
+- A dispatch skill delegates to the corresponding agent (e.g., `/troubleshoot` → troubleshooter agent)
 
 ---
 
@@ -165,37 +180,34 @@ To deprecate a skill:
 
 ---
 
-## User-Invocable vs Claude-Only
+## Agent-First Architecture
 
-### Default Behavior (Both)
+This repository uses an **agent-first** interaction model. Users interact through 3 high-level commands (`/troubleshoot`, `/implement`, `/design`) that dispatch to specialized agents. Skills serve as background knowledge that agents compose internally.
 
-By default, skills can be invoked by both users (via `/skill-name`) and Claude (when triggers match). This is appropriate for most skills.
+### How It Works
 
-### User-Only Skills
+```
+User → /troubleshoot → dispatch skill → troubleshooter agent → composes: sre, k8s, loki, prometheus
+User → /implement    → dispatch skill → implementer agent    → composes: flux-gitops, app-template, terragrunt, ...
+User → /design       → dispatch skill → designer agent       → composes: kubesearch, architecture-review
+```
 
-Set `disable-model-invocation: true` when:
-- The skill should only run on explicit user request
-- Claude should not auto-invoke based on triggers
-- The procedure is destructive or expensive
+### Skill Invocability
 
-Example use case: A "reset-cluster" skill that should never be auto-triggered.
+| Configuration | User /command | Agent Composition | Use Case |
+|---------------|---------------|-------------------|----------|
+| Dispatch skill (`disable-model-invocation: true`) | Yes | No | Entry points: troubleshoot, implement, design |
+| Background skill (`user_invocable: false`) | No | Yes | Domain knowledge composed by agents |
 
-### Claude-Only Skills
+### Agents
 
-Set `user_invocable: false` when:
-- The skill is an internal helper not meant for direct use
-- The skill is always invoked by another skill
-- The procedure requires context Claude has but users don't provide
+Agents are defined in `.claude/agents/` and compose skills for their domain:
 
-Example use case: Internal validation or preprocessing skills.
-
-### Summary
-
-| Configuration | User /command | Claude Auto-Invoke |
-|---------------|---------------|-------------------|
-| Default | Yes | Yes |
-| `disable-model-invocation: true` | Yes | No |
-| `user_invocable: false` | No | Yes |
+| Agent | Role | Skills | Model | Mode |
+|-------|------|--------|-------|------|
+| `troubleshooter` | SRE debugging specialist | sre, k8s, loki, prometheus | inherit | default (read-only tools) |
+| `implementer` | Platform engineer | flux-gitops, app-template, terragrunt, opentofu-modules, deploy-app, taskfiles, k8s | inherit | default (full tools) |
+| `designer` | Principal architect | kubesearch, architecture-review | opus | plan (read-only) |
 
 ---
 

--- a/.claude/skills/app-template/SKILL.md
+++ b/.claude/skills/app-template/SKILL.md
@@ -11,6 +11,7 @@ description: |
   "sidecar container", "multi-container pod helm", "deploy container image", "no helm chart available",
   "custom container deployment", "bjw-s", "app-template chart", "deploy docker image to kubernetes",
   "container without helm chart", "generic helm chart"
+user_invocable: false
 ---
 
 # app-template Helm Chart

--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: architecture-review
+description: |
+  Architecture evaluation criteria and technology standards for the homelab.
+  Preloaded into the designer agent to ground design decisions in established
+  patterns and principles.
+
+  Use when: (1) Evaluating a proposed technology addition, (2) Reviewing architecture decisions,
+  (3) Assessing stack fit for a new component, (4) Comparing implementation approaches.
+
+  Triggers: "architecture review", "evaluate technology", "stack fit", "should we use",
+  "technology comparison", "design review", "architecture decision"
+user_invocable: false
+---
+
+# Architecture Evaluation Framework
+
+## Current Technology Stack
+
+| Layer | Technology | Purpose |
+|-------|-----------|---------|
+| **OS** | Talos Linux | Immutable, API-driven Kubernetes OS |
+| **GitOps** | Flux + ResourceSets | Declarative cluster state reconciliation |
+| **CNI/Network** | Cilium | eBPF networking, network policies, Hubble observability |
+| **Storage** | Longhorn | Distributed block storage with S3 backup |
+| **Object Storage** | Garage | S3-compatible distributed object storage |
+| **Database** | CNPG (CloudNativePG) | PostgreSQL operator with HA and backups |
+| **Cache/KV** | Dragonfly | Redis-compatible in-memory store |
+| **Monitoring** | kube-prometheus-stack | Prometheus + Grafana + Alertmanager |
+| **Logging** | Alloy → Loki | Log collection pipeline |
+| **Certificates** | cert-manager | Automated TLS certificate management |
+| **Secrets** | ESO + AWS SSM | External Secrets Operator with Parameter Store |
+| **Upgrades** | Tuppr | Declarative Talos/Kubernetes/Cilium upgrades |
+| **Infrastructure** | Terragrunt + OpenTofu | Infrastructure as Code for bare-metal provisioning |
+| **CI/CD** | GitHub Actions + OCI | Artifact-based promotion pipeline |
+
+## Evaluation Criteria
+
+When evaluating any proposed technology addition or architecture change, assess against these criteria:
+
+### 1. Principle Alignment
+
+Score the proposal against each core principle (Strong/Weak/Neutral):
+- **Enterprise at Home**: Does it reflect production-grade patterns?
+- **Everything as Code**: Can it be fully represented in git?
+- **Automation is Key**: Does it reduce or increase manual toil?
+- **Learning First**: Does it teach valuable enterprise skills?
+- **DRY and Code Reuse**: Does it leverage existing patterns or create duplication?
+- **Continuous Improvement**: Does it make the system more maintainable?
+
+### 2. Stack Fit
+
+- Does this overlap with existing tools? (e.g., adding Redis when Dragonfly exists)
+- Does it integrate with the GitOps workflow? (Must be Flux-deployable)
+- Does it work on bare-metal? (No cloud-only services)
+- Does it support the multi-cluster model? (dev → integration → live)
+
+### 3. Operational Cost
+
+- How is it monitored? (Must integrate with kube-prometheus-stack)
+- How is it backed up? (Must have a recovery story)
+- How does it handle upgrades? (Must be declarative, ideally via Renovate)
+- What's the failure blast radius? (Isolated > cluster-wide)
+
+### 4. Complexity Budget
+
+- Is the complexity justified by the learning value?
+- Could a simpler existing tool solve the same problem?
+- What's the maintenance burden over 12 months?
+
+### 5. Alternative Analysis
+
+- What existing stack components could solve this? (Always check first)
+- What are the top 2-3 alternatives in the ecosystem?
+- What do other production homelabs use? (kubesearch research)
+
+### 6. Failure Modes
+
+- What happens when this component is unavailable?
+- How does it interact with network policies? (Default deny)
+- What's the recovery procedure? (Must be documented in a runbook)
+- Can it self-heal? (Strong preference for self-healing)
+
+## Common Design Patterns
+
+### New Application
+1. HelmRelease via ResourceSet (flux-gitops pattern)
+2. Namespace with network-policy profile label
+3. ExternalSecret for credentials
+4. ServiceMonitor + PrometheusRule for observability
+5. GarageBucketClaim if S3 storage needed
+6. CNPG Cluster if database needed
+
+### New Infrastructure Component
+1. OpenTofu module in `infrastructure/modules/`
+2. Unit in appropriate stack under `infrastructure/units/`
+3. Test coverage in `.tftest.hcl` files
+4. Version pinned in `versions.env` if applicable
+
+### New Secret
+1. Store in AWS SSM Parameter Store
+2. Reference via ExternalSecret CR
+3. Never commit to git, not even encrypted
+
+### New Storage
+1. Longhorn PVC for block storage (default)
+2. GarageBucketClaim for object storage (S3-compatible)
+3. Never use hostPath or emptyDir for persistent data
+
+### New Database
+1. CNPG Cluster CR for PostgreSQL
+2. Automated backups to Garage S3
+3. Connection pooling via PgBouncer (CNPG-managed)
+
+### New Network Exposure
+1. HTTPRoute for HTTP/HTTPS traffic (Gateway API)
+2. Appropriate network-policy profile label
+3. cert-manager Certificate for TLS
+4. Internal gateway for internal-only services
+
+## Anti-Patterns to Challenge
+
+| Anti-Pattern | Why It's Wrong | Correct Approach |
+|-------------|---------------|------------------|
+| "Just run a container" without monitoring | Invisible failures, no alerting | ServiceMonitor + PrometheusRule required |
+| Adding a new tool when existing ones suffice | Stack bloat, maintenance burden | Evaluate existing stack first |
+| Skipping observability "for now" | Technical debt that never gets paid | Monitoring is day-1, not day-2 |
+| Manual operational steps | Drift, inconsistency, bus factor | Everything declarative via GitOps |
+| Cloud-only services | Vendor lock-in, can't run on bare-metal | Self-hosted alternatives preferred |
+| Single-instance without HA story | Single point of failure | At minimum, document recovery procedure |
+| Storing state outside git | Shadow configuration, drift | Git is the source of truth |

--- a/.claude/skills/architecture-review/references/technology-decisions.md
+++ b/.claude/skills/architecture-review/references/technology-decisions.md
@@ -1,0 +1,167 @@
+# Technology Decision Rationale
+
+This document captures the WHY behind each major technology choice in the homelab stack. The designer agent references this when evaluating new proposals to ensure consistency and cite prior reasoning.
+
+---
+
+## Talos Linux (over Ubuntu/Debian/Flatcar)
+
+**Decision**: Immutable, API-driven Kubernetes OS
+
+**Rationale**:
+- **Immutable**: No SSH, no shell, no drift. The OS is a known quantity at all times
+- **API-driven**: All configuration via machine configs — fully declarative, fully in git
+- **Minimal attack surface**: No package manager, no unnecessary services
+- **Declarative upgrades**: Tuppr handles version bumps through the same GitOps pipeline
+- **Learning value**: Forces "everything as code" discipline — you can't cheat with SSH
+
+**Rejected alternatives**:
+- Ubuntu/Debian: Mutable, configuration drift, SSH temptation
+- Flatcar: Similar philosophy but less Kubernetes-native, smaller ecosystem
+
+---
+
+## Flux (over ArgoCD)
+
+**Decision**: Flux with ResourceSets for GitOps reconciliation
+
+**Rationale**:
+- **Native Kubernetes**: Flux uses CRDs and controllers — it IS Kubernetes, not a layer on top
+- **No UI dependency**: Operates headless, driven entirely by git state
+- **ResourceSets**: Powerful templating for multi-cluster, DRY configuration
+- **OCI support**: First-class OCI artifact sources for the promotion pipeline
+- **Lightweight**: No additional database, no Redis, no application server
+
+**Rejected alternatives**:
+- ArgoCD: Excellent tool, but the UI creates a temptation for manual operations. Heavier footprint. The pull-based model is similar, but Flux's CRD-native approach fits better with the "everything as code" principle
+
+---
+
+## Cilium (over Calico/Flannel)
+
+**Decision**: eBPF-based CNI with network policy enforcement and Hubble observability
+
+**Rationale**:
+- **eBPF performance**: Kernel-level networking without iptables overhead
+- **Network policies**: CiliumNetworkPolicy with L7 visibility, beyond basic NetworkPolicy
+- **Hubble**: Built-in network observability — see every packet decision
+- **Default deny**: Enterprise-grade network segmentation out of the box
+- **Learning value**: eBPF is the future of Linux networking — valuable skill to develop
+
+**Rejected alternatives**:
+- Calico: Solid choice, but iptables-based, less observability built-in
+- Flannel: Too simple for enterprise learning goals, no network policy support
+
+---
+
+## Longhorn (over Rook-Ceph/OpenEBS)
+
+**Decision**: Distributed block storage with S3 backup integration
+
+**Rationale**:
+- **Simplicity**: Deploys as standard Kubernetes workload, no special kernel modules
+- **Backup integration**: Native S3 backup to Garage for disaster recovery
+- **UI optional**: Operates fully via CRDs, UI is informational only
+- **Bare-metal friendly**: Designed for non-cloud environments
+- **Incremental snapshots**: Efficient backup with delta-based snapshots
+
+**Rejected alternatives**:
+- Rook-Ceph: More powerful but significantly more complex to operate, overkill for homelab scale
+- OpenEBS: Good alternative, but Longhorn's backup integration with S3 was the deciding factor
+
+---
+
+## Garage (over MinIO)
+
+**Decision**: Lightweight S3-compatible distributed object storage
+
+**Rationale**:
+- **Resource efficient**: Significantly lower memory/CPU footprint than MinIO
+- **Distributed**: Multi-node replication without enterprise license
+- **S3 compatible**: Works with all S3-compatible tooling (Longhorn backups, CNPG backups)
+- **Self-contained**: No external dependencies, simple deployment
+
+**Rejected alternatives**:
+- MinIO: Feature-rich but resource-hungry, enterprise features gated behind license
+
+---
+
+## CNPG (over bare PostgreSQL/Zalando operator)
+
+**Decision**: CloudNativePG operator for PostgreSQL
+
+**Rationale**:
+- **Kubernetes-native**: Full lifecycle management via CRDs
+- **Automated backups**: WAL archiving and base backups to S3 (Garage)
+- **HA built-in**: Automatic failover with configurable replicas
+- **PgBouncer integration**: Connection pooling managed by the operator
+- **CNCF project**: Active community, production-proven
+
+**Rejected alternatives**:
+- Bare PostgreSQL: No HA, no automated backups, manual lifecycle management
+- Zalando operator: Good but CNPG has stronger CNCF momentum and simpler CRD model
+
+---
+
+## Dragonfly (over Redis)
+
+**Decision**: Redis-compatible in-memory data store
+
+**Rationale**:
+- **Redis compatible**: Drop-in replacement for Redis clients
+- **Multi-threaded**: Better utilization of modern hardware
+- **Memory efficient**: Uses less memory for equivalent workloads
+- **Single binary**: Simpler deployment and operation
+
+**Rejected alternatives**:
+- Redis: The original, but single-threaded, higher memory usage, licensing concerns (post-SSPL)
+
+---
+
+## Terragrunt + OpenTofu (over plain Terraform/Pulumi)
+
+**Decision**: Terragrunt for orchestration, OpenTofu for infrastructure provisioning
+
+**Rationale**:
+- **DRY infrastructure**: Terragrunt's unit/stack pattern eliminates HCL duplication
+- **Open source**: OpenTofu is truly open, no licensing concerns
+- **Mature ecosystem**: Vast provider ecosystem, well-understood patterns
+- **State management**: Remote state with locking, per-stack isolation
+- **Testing**: OpenTofu's native `.tftest.hcl` framework for infrastructure tests
+
+**Rejected alternatives**:
+- Plain Terraform: HashiCorp license change (BSL) makes OpenTofu preferable
+- Pulumi: Different paradigm (imperative), smaller ecosystem, steeper learning curve for IaC
+
+---
+
+## GitHub Actions + OCI Promotion (over Jenkins/GitLab CI)
+
+**Decision**: GHA for CI/CD with OCI artifact-based environment promotion
+
+**Rationale**:
+- **Native GitHub integration**: Repository-native, no separate CI server
+- **OCI artifacts**: Immutable, versioned, promotion via re-tagging (not rebuilding)
+- **Flux integration**: Flux ImagePolicy watches for promoted artifacts
+- **Cost effective**: Free for public repositories, generous limits for private
+
+**Rejected alternatives**:
+- Jenkins: Self-hosted overhead, maintenance burden
+- GitLab CI: Would require moving the repository or running a separate GitLab instance
+
+---
+
+## ESO + AWS SSM (over Sealed Secrets/SOPS/Vault)
+
+**Decision**: External Secrets Operator with AWS Systems Manager Parameter Store
+
+**Rationale**:
+- **External storage**: Secrets never touch git, not even encrypted
+- **AWS SSM**: Simple key-value store, no server to manage, low cost
+- **ESO flexibility**: Supports multiple backends if migration needed later
+- **GitOps compatible**: ExternalSecret CRs in git, actual secrets populated at runtime
+
+**Rejected alternatives**:
+- Sealed Secrets: Encrypted secrets in git — still in git, key rotation complexity
+- SOPS: Similar to Sealed Secrets, encrypted-in-git approach
+- Vault: Excellent but massive operational overhead for homelab scale

--- a/.claude/skills/deploy-app/SKILL.md
+++ b/.claude/skills/deploy-app/SKILL.md
@@ -9,7 +9,7 @@ description: |
 
   Triggers: "deploy app", "add new application", "deploy to kubernetes", "install helm chart",
   "/deploy-app", "set up new service", "add monitoring for", "deploy with monitoring"
-user_invocable: true
+user_invocable: false
 ---
 
 # Deploy App Workflow

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: design
+description: |
+  Dispatch the designer agent for architecture design and review.
+
+  Triggers: "design", "architecture review", "evaluate approach", "what's the best approach"
+disable-model-invocation: true
+---
+
+Delegate this task to the `designer` agent. Pass the user's design question: `$ARGUMENTS`

--- a/.claude/skills/flux-gitops/SKILL.md
+++ b/.claude/skills/flux-gitops/SKILL.md
@@ -12,6 +12,7 @@ description: |
   "flux resourceset", "flux reconciliation", "flux not syncing", "flux stuck", "gitops",
   "helm-charts.yaml", "platform values", "flux debug", "HelmRelease not ready", "kustomization",
   "helmrelease", "add chart", "deploy helm chart"
+user_invocable: false
 ---
 
 # Flux GitOps Platform

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: implement
+description: |
+  Dispatch the implementer agent for infrastructure and Kubernetes changes.
+
+  Triggers: "implement", "deploy", "build this", "create a PR"
+disable-model-invocation: true
+---
+
+Delegate this task to the `implementer` agent. Pass the user's requirements: `$ARGUMENTS`

--- a/.claude/skills/k8s/SKILL.md
+++ b/.claude/skills/k8s/SKILL.md
@@ -11,6 +11,7 @@ description: |
   Triggers: "kubectl", "kubeconfig", "flux get", "flux reconcile", "flux status", "cluster access",
   "internal URL", "service URL", "prometheus URL", "grafana URL", "helm release status",
   "check flux", "which cluster", "how to access", "port-forward"
+user_invocable: false
 ---
 
 # ACCESSING CLUSTERS

--- a/.claude/skills/kubesearch/SKILL.md
+++ b/.claude/skills/kubesearch/SKILL.md
@@ -11,6 +11,7 @@ description: |
   "configuration examples", "values.yaml examples", "kubesearch", "homelab examples",
   "how do other homelabs", "real-world config", "chart configuration", "helm values examples",
   "compare helm configs", "best practices for helm"
+user_invocable: false
 ---
 
 # KubeSearch - Homelab Helm Configuration Research

--- a/.claude/skills/loki/SKILL.md
+++ b/.claude/skills/loki/SKILL.md
@@ -11,6 +11,7 @@ description: |
   Triggers: "check logs", "search logs", "query loki", "logql", "show me logs",
   "what happened in", "log errors", "find in logs", "tail logs", "kubernetes events",
   "recent logs", "log query", "debug logs"
+user_invocable: false
 ---
 
 # Loki Log Querying

--- a/.claude/skills/opentofu-modules/SKILL.md
+++ b/.claude/skills/opentofu-modules/SKILL.md
@@ -15,6 +15,7 @@ description: |
 
   This skill covers OpenTofu v1.11 testing syntax, variable inheritance patterns,
   assertion best practices, and repository-specific conventions in infrastructure/modules/.
+user_invocable: false
 ---
 
 # OpenTofu Modules & Testing

--- a/.claude/skills/prometheus/SKILL.md
+++ b/.claude/skills/prometheus/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: prometheus
 description: Query Prometheus API for cluster metrics, alerts, and observability data. Use when investigating cluster health, performance issues, resource utilization, or alert status. Triggers on questions like "what's the CPU usage", "show me firing alerts", "check memory pressure", "query prometheus for", or any PromQL-related requests.
+user_invocable: false
 ---
 
 # Prometheus Querying

--- a/.claude/skills/self-improvement/SKILL.md
+++ b/.claude/skills/self-improvement/SKILL.md
@@ -12,8 +12,7 @@ description: |
   Triggers: "remember this", "update the skill", "add this to documentation", "you should know",
   "in the future", "always do", "never do", "that's wrong", "actually it should be",
   "/self-improvement", "capture this", "document this pattern", "add to CLAUDE.md"
-
-  user_invocable: true
+user_invocable: false
 ---
 
 # Self-Improvement Skill

--- a/.claude/skills/sre/SKILL.md
+++ b/.claude/skills/sre/SKILL.md
@@ -14,6 +14,7 @@ description: |
   "can't reach service", "debug kubernetes", "troubleshoot k8s", "what's wrong with my pod",
   "deployment not working", "helm install failed", "flux not reconciling", "root cause",
   "5 whys", "incident", "network policy blocking", "hubble dropped", "stalled helmrelease"
+user_invocable: false
 ---
 
 > **Cluster access, KUBECONFIG patterns, and internal service URLs** are in the `k8s` skill.

--- a/.claude/skills/sync-claude/SKILL.md
+++ b/.claude/skills/sync-claude/SKILL.md
@@ -14,6 +14,7 @@ description: |
   Two modes:
   - full: Exhaustive validation of all Claude docs in repository
   - changed: Smart detection of docs affected by current branch changes
+user_invocable: false
 ---
 
 # Claude Documentation Sync

--- a/.claude/skills/taskfiles/SKILL.md
+++ b/.claude/skills/taskfiles/SKILL.md
@@ -13,6 +13,7 @@ description: |
   "how to run", "available tasks", "task syntax", "taskfile.dev"
 
   This skill covers the repository's specific conventions in .taskfiles/ and the root Taskfile.yaml.
+user_invocable: false
 ---
 
 # Taskfiles

--- a/.claude/skills/terragrunt/SKILL.md
+++ b/.claude/skills/terragrunt/SKILL.md
@@ -15,6 +15,7 @@ description: |
   "stacks", "units", "modules architecture"
 
   Always use task commands (task tg:*) instead of running terragrunt directly.
+user_invocable: false
 ---
 
 # Terragrunt Infrastructure Skill

--- a/.claude/skills/troubleshoot/SKILL.md
+++ b/.claude/skills/troubleshoot/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: troubleshoot
+description: |
+  Dispatch the troubleshooter agent for Kubernetes and infrastructure debugging.
+
+  Triggers: "troubleshoot", "debug", "investigate", "why is this broken", "diagnose"
+disable-model-invocation: true
+---
+
+Delegate this task to the `troubleshooter` agent. Pass the user's problem description: `$ARGUMENTS`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,9 +72,11 @@ Documentation and skills are living artifacts. Improve them proactively:
 
 ## Agent Orchestration
 
-The main Claude agent operates as an **orchestrator**, not a direct executor. This maximizes context window efficiency and enables parallel work:
+The main Claude agent operates as an **orchestrator**, not a direct executor. This maximizes context window efficiency and enables parallel work.
 
-- **Delegate aggressively**: Use the Task tool to spawn specialized sub-agents for exploration, code review, architecture analysis, and implementation tasks
+**Agent-First Architecture**: Users interact through 3 custom agents (`/troubleshoot`, `/implement`, `/design`) defined in `.claude/agents/`. These agents compose skills internally, providing a higher-level interface than raw skill invocation. The orchestrator dispatches to these agents and manages ad-hoc sub-agents as needed:
+
+- **Delegate aggressively**: Use custom agents for domain tasks and the Task tool for ad-hoc sub-agents (exploration, code review, etc.)
 - **Preserve context**: The orchestrator's context is precious - offload research, file exploration, and deep dives to sub-agents
 - **Use task lists**: For multi-step work, create a task list (TaskCreate) to track progress and maintain visibility
 - **Clarify proactively**: Use AskUserQuestion liberally to validate assumptions, confirm approaches, and gather requirements before proceeding
@@ -474,24 +476,38 @@ Each major directory has its own CLAUDE.md with domain-specific patterns:
 | [kubernetes/platform/config/CLAUDE.md](kubernetes/platform/config/CLAUDE.md) | Config subsystem organization |
 | [kubernetes/clusters/CLAUDE.md](kubernetes/clusters/CLAUDE.md) | Cluster configuration, promotion path |
 
-## Skills (Lazy-Loaded)
+## Agents (Primary User Interface)
 
-Invoke these skills for detailed procedural guidance:
+Users interact through 3 specialized agents that compose skills internally:
 
-| Skill | Trigger |
-|-------|---------|
-| `terragrunt` | Infrastructure operations, stack management |
-| `opentofu-modules` | Module development and testing |
-| `flux-gitops` | Adding Helm releases, ResourceSet patterns |
-| `app-template` | Deploying apps with bjw-s/app-template |
-| `kubesearch` | Researching Helm chart configurations |
-| `k8s` | Cluster access, kubectl, Flux status, internal URLs |
-| `sre` | Debugging Kubernetes incidents, root cause analysis |
-| `loki` | Query Loki API for logs and debugging |
-| `prometheus` | Query Prometheus API for metrics and alerts |
-| `taskfiles` | Taskfile syntax and patterns |
-| `sync-claude` | Validate and sync Claude docs before commits |
-| `self-improvement` | Capture feedback to enhance documentation and skills |
+| Command | Agent | Role | Composed Skills |
+|---------|-------|------|----------------|
+| `/troubleshoot` | `troubleshooter` | SRE debugging specialist | sre, k8s, loki, prometheus |
+| `/implement` | `implementer` | Platform engineer | flux-gitops, app-template, terragrunt, opentofu-modules, deploy-app, taskfiles, k8s |
+| `/design` | `designer` | Principal architect (Opus, plan mode) | kubesearch, architecture-review |
+
+Agent definitions live in `.claude/agents/`. See [.claude/skills/CLAUDE.md](.claude/skills/CLAUDE.md) for the full agent-first architecture.
+
+## Skills (Background, Agent-Composed)
+
+Skills are composed by agents internally — not invoked directly by users:
+
+| Skill | Purpose | Composed By |
+|-------|---------|-------------|
+| `terragrunt` | Infrastructure operations, stack management | implementer |
+| `opentofu-modules` | Module development and testing | implementer |
+| `flux-gitops` | Adding Helm releases, ResourceSet patterns | implementer |
+| `app-template` | Deploying apps with bjw-s/app-template | implementer |
+| `deploy-app` | End-to-end deployment with monitoring | implementer |
+| `taskfiles` | Taskfile syntax and patterns | implementer |
+| `k8s` | Cluster access, kubectl, Flux status, internal URLs | troubleshooter, implementer |
+| `sre` | Debugging Kubernetes incidents, root cause analysis | troubleshooter |
+| `loki` | Query Loki API for logs and debugging | troubleshooter |
+| `prometheus` | Query Prometheus API for metrics and alerts | troubleshooter |
+| `kubesearch` | Researching Helm chart configurations | designer |
+| `architecture-review` | Technology standards and evaluation criteria | designer |
+| `sync-claude` | Validate and sync Claude docs before commits | orchestrator |
+| `self-improvement` | Capture feedback to enhance documentation and skills | orchestrator |
 
 ---
 


### PR DESCRIPTION
## Summary
- Introduce 3 custom agents (troubleshooter, implementer, designer) as the primary user interface, replacing direct skill invocation with role-based dispatch commands (`/troubleshoot`, `/implement`, `/design`)
- Migrate all 13 existing skills to background-only (`user_invocable: false`) so agents compose them internally, and add a new `architecture-review` skill for grounding design decisions
- Update all documentation (root CLAUDE.md, skills CLAUDE.md, settings.json) to reflect the agent-first architecture

## Test plan
- [ ] `/agents` command shows all 3 agents with correct descriptions
- [ ] `/troubleshoot`, `/implement`, `/design` slash commands trigger correctly
- [ ] Previous skill commands (`/sre`, `/deploy-app`, etc.) no longer appear as user-invocable
- [ ] Troubleshooter and designer agents have read-only tools (no Write/Edit)
- [ ] Implementer agent has full tool access (Read, Write, Edit, Bash, etc.)
- [ ] Designer agent uses Opus model and operates in plan mode
- [ ] Each agent loads its composed skills into context
- [ ] New Skill permissions present in `.claude/settings.json`