### PR TITLE
fix(ci): skip tag step when promotion is a no-op

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -168,7 +168,8 @@ flux get kustomizations -A
 |---------|-------|-----|
 | Build succeeds but integration doesn't update | Semver not matching `>= 0.0.0-0` | Check OCIRepository spec |
 | Validation passes but live doesn't update | `validated-*` tag not applied | Check tag-validated workflow |
-| `repository_dispatch` not received | GitHub token missing `repo` scope | Check Provider secret |
+| `repository_dispatch` not received | `flux-system` secret token lacks `repo` scope or `contents:write` permission | Verify token: `gh api repos/{owner}/{repo}/dispatches -X POST -f event_type=test` with the same token |
+| Notification controller logs "dispatching event" but no workflow triggers | Token accepted by GitHub (204) but lacks dispatch permission | Recreate token with `repo` scope or fine-grained `contents:write` |
 | Artifact push fails | GHCR auth issue | Check `GITHUB_TOKEN` permissions |
 | Workflow triggers every ~10min | Alert fires on every reconciliation | Idempotency guard skips already-validated artifacts |
 

--- a/.github/workflows/tag-validated-artifact.yaml
+++ b/.github/workflows/tag-validated-artifact.yaml
@@ -106,6 +106,7 @@ jobs:
             core.setOutput('stable', stable);
 
       - name: Tag as validated
+        if: steps.resolve.outputs.sha
         env:
           SHA: ${{ steps.resolve.outputs.sha }}
           STABLE: ${{ steps.resolve.outputs.stable }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,7 @@ For dev cluster permissions, pre-flight checks, and safety procedures, see [.tas
 - **NEVER** use `git push --force` or `git push --force-with-lease` - always create new commits to fix mistakes
 - **NEVER** commit to `main` when creating a PR - always create the branch first, then commit
 - **NEVER** make changes directly in the main checkout when other agents may be working in parallel - use a worktree
+- **NEVER** reuse a worktree/branch from a merged PR for follow-up work — the remote branch was auto-deleted and the base is stale. Always: `task wt:remove -- <old-branch>`, pull main, `task wt:new -- <new-branch>`
 - **Correct PR workflow**: `task wt:new -- <branch>` → make changes in worktree → `git commit` → `git push -u origin <branch>` → `gh pr create` → `task wt:remove -- <branch>` (after merge)
 
 ## Kubernetes Safety


### PR DESCRIPTION
## Summary
- Follow-up to #290: the idempotency guard correctly detects already-validated artifacts and returns early, but the tag step ran unconditionally with empty outputs causing `flux tag artifact` to fail on an empty OCI reference
- Adds `if: steps.resolve.outputs.sha` so the tag step is skipped when the resolve step produces no outputs (idempotency skip)
- Documents the `flux-system` secret token scope requirement — cluster dispatches silently fail if the token lacks `repo` or `contents:write` permission
- Adds worktree reuse anti-pattern to CLAUDE.md

## Test plan
- [ ] After merge, `gh api repos/{owner}/{repo}/dispatches -X POST -f event_type='Kustomization/platform.flux-system'` — workflow should succeed with "already validated — skipping" and tag step shows as skipped
- [ ] Verify `flux-system` secret token has `repo` scope or fine-grained `contents:write` for end-to-end automated promotion