### PR TITLE
fix(docs): use kebab-case for skill user-invocable frontmatter field

### DIFF
--- a/.claude/skills/CLAUDE.md
+++ b/.claude/skills/CLAUDE.md
@@ -132,7 +132,7 @@ description: |
 |-------|----------|---------|
 | `name` | Yes | Unique identifier, matches directory name |
 | `description` | Yes | Multi-line description with use cases and triggers |
-| `user_invocable` | No | Set to `false` to make Claude-only (default: `true`) |
+| `user-invocable` | No | Set to `false` to make Claude-only (default: `true`) |
 | `disable-model-invocation` | No | Set to `true` to make user-only |
 
 ---
@@ -203,7 +203,7 @@ User → /design       → dispatch skill → designer agent       → composes:
 | Configuration | User /command | Agent Composition | Use Case |
 |---------------|---------------|-------------------|----------|
 | Dispatch skill (`disable-model-invocation: true`) | Yes | No | Entry points: troubleshoot, implement, design |
-| Background skill (`user_invocable: false`) | No | Yes | Domain knowledge composed by agents |
+| Background skill (`user-invocable: false`) | No | Yes | Domain knowledge composed by agents |
 
 ### Agents
 

--- a/.claude/skills/app-template/SKILL.md
+++ b/.claude/skills/app-template/SKILL.md
@@ -11,7 +11,7 @@ description: |
   "sidecar container", "multi-container pod helm", "deploy container image", "no helm chart available",
   "custom container deployment", "bjw-s", "app-template chart", "deploy docker image to kubernetes",
   "container without helm chart", "generic helm chart"
-user_invocable: false
+user-invocable: false
 ---
 
 # app-template Helm Chart

--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -10,7 +10,7 @@ description: |
 
   Triggers: "architecture review", "evaluate technology", "stack fit", "should we use",
   "technology comparison", "design review", "architecture decision"
-user_invocable: false
+user-invocable: false
 ---
 
 # Architecture Evaluation Framework

--- a/.claude/skills/cnpg-database/SKILL.md
+++ b/.claude/skills/cnpg-database/SKILL.md
@@ -12,7 +12,7 @@ description: |
   Triggers: "database", "postgresql", "postgres", "cnpg", "cloudnative-pg", "pooler",
   "pgbouncer", "database credentials", "db password", "initdb", "postInitApplicationSQL",
   "database cluster", "shared database", "dedicated database", "cnpg cluster"
-user_invocable: false
+user-invocable: false
 ---
 
 # CNPG Database Management

--- a/.claude/skills/deploy-app/SKILL.md
+++ b/.claude/skills/deploy-app/SKILL.md
@@ -9,7 +9,7 @@ description: |
 
   Triggers: "deploy app", "add new application", "deploy to kubernetes", "install helm chart",
   "/deploy-app", "set up new service", "add monitoring for", "deploy with monitoring"
-user_invocable: false
+user-invocable: false
 ---
 
 # Deploy App Workflow

--- a/.claude/skills/flux-gitops/SKILL.md
+++ b/.claude/skills/flux-gitops/SKILL.md
@@ -12,7 +12,7 @@ description: |
   "flux resourceset", "flux reconciliation", "flux not syncing", "flux stuck", "gitops",
   "helm-charts.yaml", "platform values", "flux debug", "HelmRelease not ready", "kustomization",
   "helmrelease", "add chart", "deploy helm chart"
-user_invocable: false
+user-invocable: false
 ---
 
 # Flux GitOps Platform

--- a/.claude/skills/gateway-routing/SKILL.md
+++ b/.claude/skills/gateway-routing/SKILL.md
@@ -10,7 +10,7 @@ description: |
   Triggers: "httproute", "gateway", "expose service", "add route", "certificate", "tls",
   "coraza", "waf", "internal gateway", "external gateway", "dns", "ingress",
   "routing", "cert-manager", "letsencrypt", "homelab-ca"
-user_invocable: false
+user-invocable: false
 ---
 
 # Gateway Routing

--- a/.claude/skills/k8s/SKILL.md
+++ b/.claude/skills/k8s/SKILL.md
@@ -11,7 +11,7 @@ description: |
   Triggers: "kubectl", "kubeconfig", "flux get", "flux reconcile", "flux status", "cluster access",
   "internal URL", "service URL", "prometheus URL", "grafana URL", "helm release status",
   "check flux", "which cluster", "how to access", "port-forward"
-user_invocable: false
+user-invocable: false
 ---
 
 # ACCESSING CLUSTERS

--- a/.claude/skills/kubesearch/SKILL.md
+++ b/.claude/skills/kubesearch/SKILL.md
@@ -11,7 +11,7 @@ description: |
   "configuration examples", "values.yaml examples", "kubesearch", "homelab examples",
   "how do other homelabs", "real-world config", "chart configuration", "helm values examples",
   "compare helm configs", "best practices for helm"
-user_invocable: false
+user-invocable: false
 ---
 
 # KubeSearch - Homelab Helm Configuration Research

--- a/.claude/skills/loki/SKILL.md
+++ b/.claude/skills/loki/SKILL.md
@@ -11,7 +11,7 @@ description: |
   Triggers: "check logs", "search logs", "query loki", "logql", "show me logs",
   "what happened in", "log errors", "find in logs", "tail logs", "kubernetes events",
   "recent logs", "log query", "debug logs"
-user_invocable: false
+user-invocable: false
 ---
 
 # Loki Log Querying

--- a/.claude/skills/monitoring-authoring/SKILL.md
+++ b/.claude/skills/monitoring-authoring/SKILL.md
@@ -12,7 +12,7 @@ description: |
   Triggers: "create alert", "add alerting", "PrometheusRule", "ServiceMonitor", "PodMonitor",
   "AlertmanagerConfig", "silence alert", "canary check", "recording rule", "add monitoring",
   "scrape target", "alert rule", "prometheus rule", "health check canary"
-user_invocable: false
+user-invocable: false
 ---
 
 # Monitoring Resource Authoring

--- a/.claude/skills/opentofu-modules/SKILL.md
+++ b/.claude/skills/opentofu-modules/SKILL.md
@@ -15,7 +15,7 @@ description: |
 
   This skill covers OpenTofu v1.11 testing syntax, variable inheritance patterns,
   assertion best practices, and repository-specific conventions in infrastructure/modules/.
-user_invocable: false
+user-invocable: false
 ---
 
 # OpenTofu Modules & Testing

--- a/.claude/skills/prometheus/SKILL.md
+++ b/.claude/skills/prometheus/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prometheus
 description: Query Prometheus API for cluster metrics, alerts, and observability data. Use when investigating cluster health, performance issues, resource utilization, or alert status. Triggers on questions like "what's the CPU usage", "show me firing alerts", "check memory pressure", "query prometheus for", or any PromQL-related requests.
-user_invocable: false
+user-invocable: false
 ---
 
 # Prometheus Querying

--- a/.claude/skills/promotion-pipeline/SKILL.md
+++ b/.claude/skills/promotion-pipeline/SKILL.md
@@ -11,7 +11,7 @@ description: |
   "stuck in integration", "not deploying", "ghcr", "build artifact", "tag validated",
   "repository_dispatch", "canary-checker", "rollback", "semver", "image policy",
   "promotion pipeline", "why isn't live updating"
-user_invocable: false
+user-invocable: false
 ---
 
 # Promotion Pipeline

--- a/.claude/skills/secrets/SKILL.md
+++ b/.claude/skills/secrets/SKILL.md
@@ -11,7 +11,7 @@ description: |
   Triggers: "secret", "ExternalSecret", "secret-generator", "aws ssm", "parameter store",
   "kubernetes-replicator", "replicate secret", "app-secrets", "persistent secret",
   "cross-namespace secret", "secret not syncing", "ClusterSecretStore"
-user_invocable: false
+user-invocable: false
 ---
 
 # Secrets Management

--- a/.claude/skills/self-improvement/SKILL.md
+++ b/.claude/skills/self-improvement/SKILL.md
@@ -12,7 +12,7 @@ description: |
   Triggers: "remember this", "update the skill", "add this to documentation", "you should know",
   "in the future", "always do", "never do", "that's wrong", "actually it should be",
   "/self-improvement", "capture this", "document this pattern", "add to CLAUDE.md"
-user_invocable: false
+user-invocable: false
 ---
 
 # Self-Improvement Skill

--- a/.claude/skills/sre/SKILL.md
+++ b/.claude/skills/sre/SKILL.md
@@ -15,7 +15,7 @@ description: |
   "deployment not working", "helm install failed", "flux not reconciling", "root cause",
   "5 whys", "incident", "network policy blocking", "hubble dropped", "stalled helmrelease",
   "live not updating", "promotion pipeline stuck", "artifact not promoted"
-user_invocable: false
+user-invocable: false
 ---
 
 > **Cluster access, KUBECONFIG patterns, and internal service URLs** are in the `k8s` skill.

--- a/.claude/skills/sync-claude/SKILL.md
+++ b/.claude/skills/sync-claude/SKILL.md
@@ -14,7 +14,7 @@ description: |
   Two modes:
   - full: Exhaustive validation of all Claude docs in repository
   - changed: Smart detection of docs affected by current branch changes
-user_invocable: false
+user-invocable: false
 ---
 
 # Claude Documentation Sync

--- a/.claude/skills/taskfiles/SKILL.md
+++ b/.claude/skills/taskfiles/SKILL.md
@@ -13,7 +13,7 @@ description: |
   "how to run", "available tasks", "task syntax", "taskfile.dev"
 
   This skill covers the repository's specific conventions in .taskfiles/ and the root Taskfile.yaml.
-user_invocable: false
+user-invocable: false
 ---
 
 # Taskfiles

--- a/.claude/skills/terragrunt/SKILL.md
+++ b/.claude/skills/terragrunt/SKILL.md
@@ -15,7 +15,7 @@ description: |
   "stacks", "units", "modules architecture"
 
   Always use task commands (task tg:*) instead of running terragrunt directly.
-user_invocable: false
+user-invocable: false
 ---
 
 # Terragrunt Infrastructure Skill

--- a/.claude/skills/versions-renovate/SKILL.md
+++ b/.claude/skills/versions-renovate/SKILL.md
@@ -10,7 +10,7 @@ description: |
   Triggers: "versions.env", "renovate annotation", "renovate not updating", "add version",
   "renovate ignore", "datasource", "extractVersion", "package rule", "automerge",
   "renovate validate", "dependency tracking", "version management"
-user_invocable: false
+user-invocable: false
 ---
 
 # Versions and Renovate Management


### PR DESCRIPTION
## Summary
- All 20 background skills used `user_invocable` (underscore) instead of `user-invocable` (hyphen) in their YAML frontmatter
- Claude Code only recognizes the kebab-case variant, so the field was silently ignored and all background skills appeared as user-facing slash commands
- Also fixes the skills CLAUDE.md documentation table that propagated the wrong field name

## Test plan
- [ ] Verify background skills (e.g. `app-template`, `loki`, `prometheus`) no longer appear in `/` slash command autocomplete
- [ ] Verify dispatch skills (`/troubleshoot`, `/implement`, `/design`) still appear as slash commands
- [ ] Verify agents can still compose background skills internally