### PR TITLE
fix(ci): switch promotion provider from githubdispatch to github (commit status)

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -14,7 +14,7 @@ For core principles and deployment philosophy, see [CLAUDE.md](../CLAUDE.md).
 | `infrastructure-validate.yaml` | PR (infrastructure/ changes) | Format checks, module tests |
 | `renovate-validate.yaml` | PR (renovate config) | Validate Renovate configuration |
 | `build-platform-artifact.yaml` | Push to main (kubernetes/) | Build OCI artifact for promotion |
-| `tag-validated-artifact.yaml` | repository_dispatch | Promote validated artifact to live |
+| `tag-validated-artifact.yaml` | status event (commit status) | Promote validated artifact to live |
 | `renovate.yaml` | Scheduled (hourly) | Dependency update automation |
 | `label-sync.yaml` | Scheduled/manual | Sync GitHub labels |
 
@@ -52,7 +52,7 @@ The promotion pipeline uses OCI artifacts for immutable, auditable deployments.
 ┌─────────────────────────────────────────────────────────────────────┐
 │  Flux Alert (validation-success)                                     │
 │  ├─ Watches platform Kustomization for "Reconciliation finished"     │
-│  ├─ Fires repository_dispatch (event_type: Kustomization/platform.flux-system) │
+│  ├─ Provider posts commit status (context: kustomization/platform/*) │
 │  └─ Workflow has idempotency guard for repeated reconciliation events │
 └─────────────────────────────────┬───────────────────────────────────┘
                                   │
@@ -168,8 +168,8 @@ flux get kustomizations -A
 |---------|-------|-----|
 | Build succeeds but integration doesn't update | Semver not matching `>= 0.0.0-0` | Check OCIRepository spec |
 | Validation passes but live doesn't update | `validated-*` tag not applied | Check tag-validated workflow |
-| `repository_dispatch` not received | `flux-system` secret token lacks `repo` scope or `contents:write` permission | Verify token: `gh api repos/{owner}/{repo}/dispatches -X POST -f event_type=test` with the same token |
-| Notification controller logs "dispatching event" but no workflow triggers | Token accepted by GitHub (204) but lacks dispatch permission | Recreate token with `repo` scope or fine-grained `contents:write` |
+| Commit status not posted | `flux-system` secret token lacks `statuses:write` permission | Check notification-controller logs for explicit API errors, update token in SSM |
+| Commit status posted but workflow doesn't trigger | Job-level `if` filter not matching context prefix | Check `github.event.context` format: should start with `kustomization/platform/` |
 | Artifact push fails | GHCR auth issue | Check `GITHUB_TOKEN` permissions |
 | Workflow triggers every ~10min | Alert fires on every reconciliation | Idempotency guard skips already-validated artifacts |
 
@@ -236,11 +236,12 @@ Triggers on push to main (kubernetes/ changes):
 
 ### tag-validated-artifact.yaml
 
-Triggers on `repository_dispatch` from Flux Alert (`Kustomization/platform.flux-system`):
+Triggers on `status` event (GitHub commit status posted by Flux's `github` Provider):
 
-1. **Resolve**: Finds `integration-<sha>` artifact, extracts RC tag
-2. **Derive stable**: Strips `-rc.N` suffix (e.g., `0.1.146-rc.3` → `0.1.146`)
-3. **Tag**: Adds `validated-<sha>` and stable semver tags
+1. **Filter**: Only runs on `state == 'success'` with context prefix `kustomization/platform/`
+2. **Resolve**: Extracts short SHA from commit, finds `integration-<sha>` artifact, extracts RC tag
+3. **Derive stable**: Strips `-rc.N` suffix (e.g., `0.1.146-rc.3` → `0.1.146`)
+4. **Tag**: Adds `validated-<sha>` and stable semver tags
 
 ---
 

--- a/.github/workflows/tag-validated-artifact.yaml
+++ b/.github/workflows/tag-validated-artifact.yaml
@@ -2,8 +2,7 @@
 name: Tag Validated Artifact
 
 on:
-  repository_dispatch:
-    types: ["Kustomization/platform.flux-system"]
+  status:
   workflow_dispatch:
     inputs:
       artifact_sha:
@@ -17,8 +16,13 @@ env:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.state == 'success' &&
+       startsWith(github.event.context, 'kustomization/platform/'))
     permissions:
       packages: write
+      statuses: read
 
     steps:
       - uses: fluxcd/flux2/action@main
@@ -45,8 +49,14 @@ jobs:
               per_page: 100,
             });
 
-            // Determine the artifact SHA - from input or auto-detect latest integration tag
+            // Determine the artifact SHA - from input, status event, or auto-detect
             let sha = inputSha;
+
+            if (!sha && '${{ github.event_name }}' === 'status') {
+              // Extract short SHA from the commit that received the status
+              sha = '${{ github.event.sha }}'.substring(0, 7);
+              core.info(`Status event for commit ${sha}`);
+            }
 
             if (!sha) {
               core.info('No SHA provided, discovering latest integration tag...');

--- a/kubernetes/platform/config/flux-notifications/canary-alert.yaml
+++ b/kubernetes/platform/config/flux-notifications/canary-alert.yaml
@@ -4,12 +4,13 @@
 # NOTE: This Alert watches the platform Kustomization, not canary-checker's Canary CRD.
 # Flux Alert only supports watching Flux-native resources. The flow is:
 # 1. Platform Kustomization becomes Ready after all HelmReleases deploy
-# 2. Alert triggers GitHub repository_dispatch
-# 3. tag-validated-artifact workflow tags the OCI artifact
+# 2. Alert triggers the github (commit status) Provider
+# 3. Provider posts a commit status to the reconciled commit on GitHub
+# 4. GitHub fires a `status` event, triggering the tag-validated-artifact workflow
 #
-# The githubdispatch provider hardcodes event_type as "{Kind}/{Name}.{Namespace}",
-# so this Alert dispatches with event_type: "Kustomization/platform.flux-system".
-# The workflow trigger must match this exact string.
+# The `github` provider posts a commit status with context
+# "kustomization/platform/<uid-prefix>" on the commit referenced by originRevision.
+# The workflow filters on state == 'success' and context prefix.
 #
 # For deeper health validation, canary-checker performs additional checks.
 # A future enhancement could have canary-checker directly call GitHub API

--- a/kubernetes/platform/config/flux-notifications/github-provider.yaml
+++ b/kubernetes/platform/config/flux-notifications/github-provider.yaml
@@ -5,7 +5,7 @@ metadata:
   name: github-dispatch
   namespace: flux-system
 spec:
-  type: githubdispatch
+  type: github
   address: https://github.com/${github_org}/${github_repository}
   secretRef:
     name: flux-system


### PR DESCRIPTION
## Summary

- Switch Flux Provider from `type: githubdispatch` to `type: github` (commit status) to work around fluxcd/flux2#3933 where the `githubdispatch` provider silently drops all `commit_status: update` events
- Replace `repository_dispatch` workflow trigger with `status` event, filtered to `state == 'success'` with context prefix `kustomization/platform/`
- Extract commit SHA directly from the status event payload instead of scanning GHCR tags

## Test plan

- [x] `task k8s:validate` passes (lint, ResourceSet expansion, Helm templating, kubeconform, deprecation checks)
- [ ] After merge: check notification-controller logs for errors (explicit errors replace silent drops)
- [ ] Verify commit status appears on the merge commit in GitHub
- [ ] Verify `tag-validated-artifact` workflow triggers via `status` event
- [ ] If token lacks `statuses:write`: update SSM parameter `/homelab/infrastructure/accounts/github/token`