### PR TITLE
fix(ci): increase renovate update throughput

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,8 @@
     "github>ionfury/homelab//.renovate/labels.json5"
   ],
   "dependencyDashboardTitle": "Dependency Dashboard",
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 20,
   "terraform": {
     "managerFilePatterns": ["/(^|/)infrastructure/.+\\.tf$/"],
     "registryUrls": ["https://registry.opentofu.org"]

--- a/.renovate/automerge.json5
+++ b/.renovate/automerge.json5
@@ -2,10 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     // AUTOMERGE RULES (applied first, then overridden by exclusions below)
-    // Aggressive: All minor and patch updates (Flux handles rollback)
+    // Patch updates are low-risk and the promotion pipeline validates before live
     {
-      "description": "Automerge minor and patch updates",
-      "matchUpdateTypes": ["minor", "patch"],
+      "description": "Automerge patch updates",
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "minimumReleaseAge": "1 day"
+    },
+    // Minor updates carry more risk, keep a longer stabilization window
+    {
+      "description": "Automerge minor updates",
+      "matchUpdateTypes": ["minor"],
       "automerge": true,
       "automergeType": "pr",
       "minimumReleaseAge": "3 days"


### PR DESCRIPTION
## Summary
- Raise `prHourlyLimit` to 5 and `prConcurrentLimit` to 20 so Renovate can process the current queue depth (11+ pending updates) without artificial throttling
- Reduce patch update `minimumReleaseAge` from 3 days to 1 day since patch updates are low-risk and the promotion pipeline (integration -> canary validation -> live) provides an additional safety net before reaching production
- Keep minor update `minimumReleaseAge` at 3 days since minor updates carry more risk of breaking changes

## Test plan
- [x] `task renovate:validate` passes
- [ ] Verify Renovate dashboard shows no config errors after merge
- [ ] Confirm pending patch PRs automerge within 1 day instead of 3
- [ ] Confirm concurrent PR count can exceed the previous limit of 10