### PR TITLE
refactor(k8s): move hardcoded container image versions into versions.env

### DIFF
--- a/kubernetes/platform/config/database/cluster.yaml
+++ b/kubernetes/platform/config/database/cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: platform
 spec:
   description: "Shared platform PostgreSQL cluster"
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.2
+  imageName: ghcr.io/cloudnative-pg/postgresql:${postgresql_image_version}
   instances: ${default_replica_count}
   primaryUpdateStrategy: unsupervised
 

--- a/kubernetes/platform/config/garage/garage-cluster.yaml
+++ b/kubernetes/platform/config/garage/garage-cluster.yaml
@@ -4,7 +4,7 @@ kind: GarageCluster
 metadata:
   name: garage
 spec:
-  image: dxflrs/garage:v2.2.0
+  image: dxflrs/garage:${garage_image_version}
   replicas: ${default_replica_count}
   zone: ${cluster_name}
 

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -75,3 +75,9 @@ vectorchord_version=18.1-1.0.0
 authelia_version=0.10.49
 # renovate: datasource=docker depName=lldap packageName=ghcr.io/lldap/lldap
 lldap_version=v0.6.2
+
+# Container image versions (Flux substitution into config CRs)
+# renovate: datasource=docker depName=garage packageName=dxflrs/garage
+garage_image_version=v2.2.0
+# renovate: datasource=docker depName=cloudnative-pg-postgresql packageName=ghcr.io/cloudnative-pg/postgresql versioning=loose
+postgresql_image_version=17.2


### PR DESCRIPTION
## Summary
- Centralizes Garage and CNPG PostgreSQL container image versions into `versions.env` with Renovate annotations, replacing hardcoded tags in manifests with Flux variable substitution
- Enables Renovate to automatically track and update these image versions going forward

## Test plan
- [x] `task k8s:validate` passes
- [x] `task renovate:validate` passes
- [ ] Verify Flux substitutes `${garage_image_version}` and `${postgresql_image_version}` correctly on integration cluster

Closes #300