### PR TITLE
feat(k8s): expand platform-validation canary suite for promotion gating

### DIFF
--- a/kubernetes/platform/config/canary-checker/platform-health.yaml
+++ b/kubernetes/platform/config/canary-checker/platform-health.yaml
@@ -1,4 +1,7 @@
 ---
+# Platform health validation suite that gates promotion to live.
+# Each check targets a critical subsystem — if any fails, the CanaryCheckFailure
+# alert fires, signaling the platform is not healthy enough for promotion.
 apiVersion: canaries.flanksource.com/v1
 kind: Canary
 metadata:
@@ -6,15 +9,44 @@ metadata:
   namespace: monitoring
 spec:
   interval: 60
-  # HTTP checks - verify critical services respond
+
+  # --- HTTP checks ---
   http:
+    # Kubernetes API server health
     - name: kubernetes-api
       url: https://kubernetes.default.svc/healthz
       responseCodes: [200, 401]
-  # Kubernetes resource check - verify Flux pods are healthy
-  # Uses CEL test expression instead of ready: true because the built-in flag
+
+    # Gateway serves traffic end-to-end (internal gateway -> Grafana)
+    # Validates: DNS, TLS termination, gateway routing, and backend health
+    - name: internal-gateway
+      url: https://grafana.${internal_domain}/api/health
+      responseCodes: [200]
+      thresholdMillis: 5000
+
+  # --- DNS resolution ---
+  dns:
+    # Verify CoreDNS resolves in-cluster service names
+    - name: dns-resolution
+      server: kube-dns.kube-system.svc
+      port: 53
+      query: kubernetes.default.svc.cluster.local
+      querytype: A
+      minrecords: 1
+      timeout: 5000
+
+  # --- TCP connectivity ---
+  tcp:
+    # Database accepts connections through PgBouncer pooler
+    - name: database-connectivity
+      endpoint: platform-pooler-rw.database.svc:5432
+      thresholdMillis: 5000
+
+  # --- Kubernetes resource checks ---
+  # Uses CEL test expressions instead of ready: true because the built-in flag
   # penalizes pods with restart history, causing false negatives after upgrades
   kubernetes:
+    # Flux controllers are running and ready
     - name: flux-pods-healthy
       kind: Pod
       namespaceSelector:
@@ -26,4 +58,57 @@ spec:
           dyn(results).all(pod,
             pod.Object.status.phase == "Running" &&
             pod.Object.status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+          )
+
+    # Longhorn storage manager pods are operational
+    - name: longhorn-manager-healthy
+      kind: Pod
+      namespaceSelector:
+        name: longhorn-system
+      resource:
+        labelSelector: app=longhorn-manager
+      test:
+        expr: >
+          dyn(results).all(pod,
+            pod.Object.status.phase == "Running" &&
+            pod.Object.status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+          )
+
+    # CNPG operator is running (manages database clusters)
+    - name: cnpg-operator-healthy
+      kind: Pod
+      namespaceSelector:
+        name: database
+      resource:
+        labelSelector: app.kubernetes.io/name=cloudnative-pg
+      test:
+        expr: >
+          dyn(results).all(pod,
+            pod.Object.status.phase == "Running" &&
+            pod.Object.status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+          )
+
+    # cert-manager controller is running (issues TLS certificates)
+    - name: cert-manager-healthy
+      kind: Pod
+      namespaceSelector:
+        name: cert-manager
+      resource:
+        labelSelector: app.kubernetes.io/name=cert-manager
+      test:
+        expr: >
+          dyn(results).all(pod,
+            pod.Object.status.phase == "Running" &&
+            pod.Object.status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+          )
+
+    # Gateway certificates are issued and valid
+    - name: certificates-ready
+      kind: Certificate
+      namespaceSelector:
+        name: istio-gateway
+      test:
+        expr: >
+          dyn(results).all(cert,
+            cert.Object.status.conditions.exists(c, c.type == "Ready" && c.status == "True")
           )


### PR DESCRIPTION
## Summary
- Expand the `platform-validation` Canary from 2 checks to 9, covering all critical subsystems: storage (Longhorn), database (CNPG + PgBouncer TCP), gateway (end-to-end HTTP through internal gateway), DNS resolution (CoreDNS), and certificate issuance (cert-manager pods + Certificate Ready status)
- Existing `CanaryCheckFailure` PrometheusRule alerts on any individual check failure, providing observability into subsystem health that was previously invisible to the promotion pipeline

## Test plan
- [x] `task k8s:validate` passes (lint, ResourceSet expansion, Helm template, kubeconform, deprecation check)
- [ ] Canary status healthy on integration cluster after merge: `kubectl get canaries -n monitoring`
- [ ] All 9 checks show passing: `kubectl describe canary platform-validation -n monitoring`
- [ ] No new `CanaryCheckFailure` alerts firing in Prometheus

Closes #307