### PR TITLE
feat(k8s): replace Grafana hardcoded credentials with Authelia OIDC SSO

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -159,7 +159,7 @@ configMap:
 
   identity_providers:
     oidc:
-      enabled: false
+      enabled: true
       jwks:
         - key:
             path: /secrets/oidc-jwk/tls.key
@@ -170,7 +170,35 @@ configMap:
           - revocation
           - introspection
           - userinfo
-      clients: []
+      claims_policies:
+        grafana:
+          id_token:
+            - email
+            - name
+            - groups
+            - preferred_username
+      clients:
+        - client_id: grafana
+          client_name: Grafana
+          client_secret:
+            path: /secrets/grafana-oidc-client-secret/client-secret
+          public: false
+          authorization_policy: two_factor
+          require_pkce: true
+          pkce_challenge_method: S256
+          redirect_uris:
+            - https://grafana.${internal_domain}/login/generic_oauth
+          scopes:
+            - openid
+            - profile
+            - groups
+            - email
+          response_types:
+            - code
+          grant_types:
+            - authorization_code
+          token_endpoint_auth_method: client_secret_basic
+          claims_policy: grafana
 
   regulation:
     max_retries: 3
@@ -189,3 +217,4 @@ secret:
     cnpg-superuser-replica: { }
     authelia-db-credentials: { }
     dragonfly-password: { }
+    grafana-oidc-client-secret: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/grafana-oidc-client-secret.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/grafana-oidc-client-secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-oidc-client-secret
+  namespace: authelia
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: client-secret
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "64"
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "monitoring"
+data: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - dragonfly-secret-replication.yaml
   - lldap-db-credentials.yaml
   - authelia-db-credentials.yaml
+  - grafana-oidc-client-secret.yaml

--- a/kubernetes/platform/charts/grafana.yaml
+++ b/kubernetes/platform/charts/grafana.yaml
@@ -3,24 +3,44 @@
 deploymentStrategy:
   type: Recreate
 admin:
-  user: admin
-  password: admin
+  existingSecret: grafana-admin
+  userKey: admin-user
+  passwordKey: admin-password
 env:
   GF_DATE_FORMATS_USE_BROWSER_LOCALE: true
   GF_EXPLORE_ENABLED: true
   GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: natel-discrete-panel,pr0ps-trackmap-panel,panodata-map-panel
   GF_SECURITY_ANGULAR_SUPPORT_ENABLED: true
   GF_SERVER_ROOT_URL: https://grafana.${internal_domain}
+envValueFrom:
+  GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET:
+    secretKeyRef:
+      name: grafana-oidc-client-secret
+      key: client-secret
+      optional: true
 grafana.ini:
   analytics:
     check_for_updates: false
     check_for_plugin_updates: false
     reporting_enabled: false
-  auth.anonymous:
+  auth:
+    signout_redirect_url: https://auth.${internal_domain}/logout
+  auth.generic_oauth:
     enabled: true
-    org_id: 1
-    org_name: Main Org.
-    org_role: Viewer
+    name: Authelia
+    icon: signin
+    client_id: grafana
+    scopes: openid profile email groups
+    empty_scopes: false
+    auth_url: https://auth.${internal_domain}/api/oidc/authorization
+    token_url: https://auth.${internal_domain}/api/oidc/token
+    api_url: https://auth.${internal_domain}/api/oidc/userinfo
+    login_attribute_path: preferred_username
+    groups_attribute_path: groups
+    name_attribute_path: name
+    use_pkce: true
+    auto_login: false
+    role_attribute_path: contains(groups[*], 'admin') && 'Admin' || 'Viewer'
   news:
     news_feed_enabled: false
 datasources:

--- a/kubernetes/platform/config/monitoring/grafana-admin-secret.yaml
+++ b/kubernetes/platform/config/monitoring/grafana-admin-secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-admin
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: admin-password
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+stringData:
+  admin-user: admin

--- a/kubernetes/platform/config/monitoring/grafana-oidc-secret-replication.yaml
+++ b/kubernetes/platform/config/monitoring/grafana-oidc-secret-replication.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-oidc-client-secret
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: authelia/grafana-oidc-client-secret
+data: { }

--- a/kubernetes/platform/config/monitoring/kustomization.yaml
+++ b/kubernetes/platform/config/monitoring/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
   - heartbeat-secret.yaml
   - alertmanager-route.yaml
   - alertmanager-canary.yaml
+  - grafana-admin-secret.yaml
+  - grafana-oidc-secret-replication.yaml
   - grafana-route.yaml
   - grafana-canary.yaml
   - prometheus-route.yaml


### PR DESCRIPTION
## Summary
- Eliminates plaintext `admin:admin` credentials committed to git by using secret-generator for the admin password and Authelia OIDC for day-to-day authentication
- Enables Authelia's OIDC provider (previously disabled) and registers Grafana as the first client, with PKCE and two-factor authorization policy
- Maps LLDAP group membership to Grafana roles (`admin` group -> Admin, others -> Viewer)

## Test plan
- [ ] `task k8s:validate` passes (verified locally)
- [ ] Grafana starts with secret-generator admin password on all clusters
- [ ] On live cluster: Grafana login page shows "Sign in with Authelia" button
- [ ] OIDC flow completes through Authelia with two-factor authentication
- [ ] Users in `admin` LLDAP group get Grafana Admin role
- [ ] Users not in `admin` group get Grafana Viewer role
- [ ] On non-live clusters: OIDC button appears but admin password fallback works

Closes #301