### PR TITLE
fix(k8s): use variable substitution for Prometheus retentionSize

### DIFF
--- a/.taskfiles/kubernetes/scripts/template-all-charts.sh
+++ b/.taskfiles/kubernetes/scripts/template-all-charts.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #   - VERSION_VARS: Path to versions.env file (for substituting version variables)
 #   - EXPANDED_DIR: Output directory for templated charts
 #   - cluster_name, cluster_pod_subnet, internal_domain, external_domain: Flux substitution vars
-#   - default_replica_count, garage_data_volume_size, garage_meta_volume_size, loki_volume_size, prometheus_volume_size: Flux vars
+#   - default_replica_count, garage_data_volume_size, garage_meta_volume_size, loki_volume_size, prometheus_volume_size, prometheus_retention_size: Flux vars
 
 # Source version variables
 set -a

--- a/.taskfiles/kubernetes/taskfile.yaml
+++ b/.taskfiles/kubernetes/taskfile.yaml
@@ -25,6 +25,7 @@ vars:
   TEST_GARAGE_META_SIZE: "1Gi"
   TEST_LOKI_SIZE: "10Gi"
   TEST_PROMETHEUS_SIZE: "10Gi"
+  TEST_PROMETHEUS_RETENTION: "8GB"
   # Common kubeconform arguments (double-brace escaping for kubeconform templates)
   KUBECONFORM_ARGS: >-
     -schema-location default
@@ -185,6 +186,7 @@ tasks:
       garage_meta_volume_size: "{{.TEST_GARAGE_META_SIZE}}"
       loki_volume_size: "{{.TEST_LOKI_SIZE}}"
       prometheus_volume_size: "{{.TEST_PROMETHEUS_SIZE}}"
+      prometheus_retention_size: "{{.TEST_PROMETHEUS_RETENTION}}"
     cmds:
       - mkdir -p {{.EXPANDED_DIR}}/helm
       - "{{.TASKFILE_DIR}}/scripts/template-all-charts.sh"

--- a/infrastructure/modules/config/main.tf
+++ b/infrastructure/modules/config/main.tf
@@ -2,20 +2,22 @@
 locals {
   storage_sizes = {
     normal = {
-      garage_data = "100Gi"
-      garage_meta = "10Gi"
-      database    = "20Gi"
-      dragonfly   = "2Gi"
-      loki        = "50Gi"
-      prometheus  = "50Gi"
+      garage_data          = "100Gi"
+      garage_meta          = "10Gi"
+      database             = "20Gi"
+      dragonfly            = "2Gi"
+      loki                 = "50Gi"
+      prometheus           = "50Gi"
+      prometheus_retention = "50GB"
     }
     minimal = {
-      garage_data = "10Gi"
-      garage_meta = "2Gi"
-      database    = "5Gi"
-      dragonfly   = "1Gi"
-      loki        = "10Gi"
-      prometheus  = "10Gi"
+      garage_data          = "10Gi"
+      garage_meta          = "2Gi"
+      database             = "5Gi"
+      dragonfly            = "1Gi"
+      loki                 = "10Gi"
+      prometheus           = "10Gi"
+      prometheus_retention = "8GB"
     }
   }
 
@@ -361,6 +363,7 @@ locals {
     { name = "dragonfly_volume_size", value = local.selected_sizes.dragonfly },
     { name = "loki_volume_size", value = local.selected_sizes.loki },
     { name = "prometheus_volume_size", value = local.selected_sizes.prometheus },
+    { name = "prometheus_retention_size", value = local.selected_sizes.prometheus_retention },
     # Flux source kind for ResourceSet Kustomizations (GitRepository for dev, OCIRepository for integration/live)
     { name = "source_kind", value = var.name == "dev" ? "GitRepository" : "OCIRepository" },
     # BGP configuration for Cilium BGP control plane

--- a/kubernetes/clusters/dev/.cluster-vars.env
+++ b/kubernetes/clusters/dev/.cluster-vars.env
@@ -27,6 +27,7 @@ database_volume_size=5Gi
 dragonfly_volume_size=1Gi
 loki_volume_size=10Gi
 prometheus_volume_size=10Gi
+prometheus_retention_size=8GB
 source_kind=GitRepository
 bgp_cluster_asn=64515
 bgp_router_asn=64512

--- a/kubernetes/clusters/integration/.cluster-vars.env
+++ b/kubernetes/clusters/integration/.cluster-vars.env
@@ -27,6 +27,7 @@ database_volume_size=5Gi
 dragonfly_volume_size=1Gi
 loki_volume_size=10Gi
 prometheus_volume_size=10Gi
+prometheus_retention_size=8GB
 source_kind=OCIRepository
 bgp_cluster_asn=64514
 bgp_router_asn=64512

--- a/kubernetes/clusters/live/.cluster-vars.env
+++ b/kubernetes/clusters/live/.cluster-vars.env
@@ -27,6 +27,7 @@ database_volume_size=20Gi
 dragonfly_volume_size=2Gi
 loki_volume_size=50Gi
 prometheus_volume_size=50Gi
+prometheus_retention_size=50GB
 source_kind=OCIRepository
 bgp_cluster_asn=64513
 bgp_router_asn=64512

--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -60,7 +60,7 @@ prometheus:
     enableFeatures:
       - memory-snapshot-on-shutdown
     retention: 14d
-    retentionSize: 50GB
+    retentionSize: ${prometheus_retention_size}
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
## Summary
- Prometheus `retentionSize` was hardcoded at 50GB, which exceeds the 10Gi PVC on dev and integration clusters, causing volume exhaustion and crashes
- Derive `prometheus_retention_size` from the `storage_provisioning` mode (normal=50GB, minimal=8GB), following the same pattern as other volume-related variables

## Test plan
- [x] `task k8s:validate` passes (all 29 charts templated, kubeconform green)
- [x] `task tg:test-config` passes (116/116 tests green)
- [x] `task tg:fmt` passes
- [ ] Integration cluster deploys without Prometheus volume issues
- [ ] Live cluster retains 50GB retention behavior

Closes #308