### PR TITLE
fix(k8s): use default_replica_count for Alertmanager replicas

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -9,7 +9,7 @@ alertmanager:
     podMetadata:
       labels:
         networking/allow-egress-internet: "true"
-    replicas: 1
+    replicas: ${default_replica_count}
     alertmanagerConfiguration:
       name: alertmanager
       global:


### PR DESCRIPTION
## Summary
- Replace hardcoded `replicas: 1` with `${default_replica_count}` for Alertmanager, matching the established pattern used by all other HA components (database, Dragonfly, gateway, Garage, Longhorn)
- On the live 3-node cluster, a single Alertmanager means alert delivery fails if that node goes down -- exactly when alerts are most needed

Closes #309

## Test plan
- [x] `task k8s:validate` passes (0 invalid resources across ResourceSets and Helm charts)
- [ ] Dev cluster continues running 1 Alertmanager replica (`default_replica_count=1`)
- [ ] Live cluster scales to 3 Alertmanager replicas (`default_replica_count=3`)