### PR TITLE
feat(k8s): tighten PSA enforcement from privileged to restricted/baseline

### DIFF
--- a/kubernetes/clusters/live/config/immich/namespace.yaml
+++ b/kubernetes/clusters/live/config/immich/namespace.yaml
@@ -5,10 +5,9 @@ metadata:
   name: immich
   labels:
     istio.io/dataplane-mode: ambient
-    pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/enforce-version: latest
-    pod-security.kubernetes.io/audit: baseline
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
     network-policy.homelab/profile: standard
     access.network-policy.homelab/postgres: "true"
     access.network-policy.homelab/dragonfly: "true"

--- a/kubernetes/platform/namespaces.yaml
+++ b/kubernetes/platform/namespaces.yaml
@@ -9,14 +9,37 @@ metadata:
     fluxcd.controlplane.io/reconcileTimeout: 10m
 spec:
   inputs:
+    # --- restricted: standard controllers with no privileged requirements ---
     - name: cert-manager
       dataplane: ambient
-      security: privileged
+      security: restricted
       networkPolicy: false
     - name: external-secrets
       dataplane: ambient
-      security: privileged
+      security: restricted
       networkPolicy: false
+    - name: system
+      dataplane: ambient
+      security: restricted
+      networkPolicy: false
+    - name: database
+      dataplane: ambient
+      security: restricted
+      networkPolicy: false
+    - name: kromgo
+      dataplane: ambient
+      security: restricted
+      networkPolicy: false
+    # --- baseline: require some elevated capabilities (e.g. NET_BIND_SERVICE) ---
+    - name: istio-gateway
+      dataplane: ambient
+      security: baseline
+      networkPolicy: false
+    - name: garage
+      dataplane: ambient
+      security: baseline
+      networkPolicy: false
+    # --- privileged: require host access, BPF, privileged containers, or device access ---
     - name: kube-system
       dataplane: standard
       security: privileged
@@ -29,27 +52,7 @@ spec:
       dataplane: ambient
       security: privileged
       networkPolicy: false
-    - name: istio-gateway
-      dataplane: ambient
-      security: privileged
-      networkPolicy: false
     - name: monitoring
-      dataplane: ambient
-      security: privileged
-      networkPolicy: false
-    - name: system
-      dataplane: ambient
-      security: privileged
-      networkPolicy: false
-    - name: garage
-      dataplane: ambient
-      security: privileged
-      networkPolicy: false
-    - name: database
-      dataplane: ambient
-      security: privileged
-      networkPolicy: false
-    - name: kromgo
       dataplane: ambient
       security: privileged
       networkPolicy: false
@@ -97,6 +100,6 @@ spec:
         pod-security.kubernetes.io/warn: baseline
         <<- else >>
         pod-security.kubernetes.io/enforce: baseline
-        pod-security.kubernetes.io/audit: baseline
-        pod-security.kubernetes.io/warn: baseline
+        pod-security.kubernetes.io/audit: restricted
+        pod-security.kubernetes.io/warn: restricted
         <<- end >>


### PR DESCRIPTION
## Summary
- Apply principle of least privilege to namespace Pod Security Admission levels
- App and operator namespaces that don't need host access are now `restricted` or `baseline`
- Infrastructure namespaces that genuinely require elevated privileges retain `privileged`
- Baseline namespaces now audit/warn at `restricted` level for visibility into further tightening

### Namespace changes

| Namespace | Previous | New | Rationale |
|-----------|----------|-----|-----------|
| cert-manager | privileged | restricted | Standard controller, non-root |
| external-secrets | privileged | restricted | ESO runs as non-root |
| system | privileged | restricted | Reloader, replicator, secret-generator |
| database | privileged | restricted | CNPG operator + PostgreSQL non-root |
| kromgo | privileged | restricted | Already has restricted-compatible securityContext |
| istio-gateway | privileged | baseline | NET_BIND_SERVICE capability needed |
| garage | privileged | baseline | Storage operator may need elevated caps |
| immich (live) | privileged | baseline | No host access, no explicit securityContext |
| zipline (live) | restricted | restricted | No change needed |
| authelia (live) | restricted | restricted | No change needed |

## Test plan
- [ ] `task k8s:validate` passes locally
- [ ] Integration cluster deploys without pod admission rejections
- [ ] Verify pods in tightened namespaces start successfully
- [ ] Check for PSA audit/warn messages in newly baseline namespaces

Closes #305