### PR TITLE
fix(docs): correct cluster topology descriptions to match inventory.hcl

### DIFF
--- a/kubernetes/clusters/CLAUDE.md
+++ b/kubernetes/clusters/CLAUDE.md
@@ -217,8 +217,8 @@ KUBECONFIG=~/.kube/live.yaml kubectl describe pod -n monitoring prometheus-0
 | Name | Purpose | Hardware | Notes |
 |------|---------|----------|-------|
 | `live` | Production | node41-43 (Supermicro x86_64) | 3-node HA control plane |
-| `integration` | Upgrade testing | node44 (Supermicro x86_64) | Single node, automated deployment |
-| `dev` | Manual testing | rpi4, node46-48 (mixed ARM64/x86_64) | Multi-node, not in automated pipeline |
+| `integration` | Upgrade testing | node46-48 (Supermicro x86_64) | 3-node HA, automated deployment |
+| `dev` | Manual testing | node45 (Supermicro x86_64) | Single node, not in automated pipeline |
 
 ### Current Bootstrap State
 


### PR DESCRIPTION
## Summary
- Fix materially wrong cluster topology descriptions in `kubernetes/clusters/CLAUDE.md` (closes #311)
- Integration cluster is node46-48 (3-node HA), not node44 (single node)
- Dev cluster is node45 (single node x86_64), not rpi4+node46-48 (mixed architecture)

## Test plan
- [x] Verified node assignments against `infrastructure/inventory.hcl` ground truth
- [x] Searched all CLAUDE.md files for stale topology references
- [x] `task k8s:validate` passes