### PR TITLE
feat(k8s): add PriorityClass tiers for workload scheduling

### DIFF
--- a/kubernetes/platform/CLAUDE.md
+++ b/kubernetes/platform/CLAUDE.md
@@ -39,6 +39,7 @@ The `config/` directory organizes non-Helm resources by concern:
 | `kromgo/` | Kromgo status page configs |
 | `longhorn/` | Longhorn backup and storage configs |
 | `monitoring/` | Prometheus rules, Grafana dashboards |
+| `priority-classes/` | Workload scheduling priority tiers |
 | `secrets/` | Secret generator resources |
 | `tuppr/` | Tuppr upgrade CRs (TalosUpgrade, KubernetesUpgrade) |
 
@@ -152,6 +153,7 @@ inputs:
 | `monitoring-config` | `kube-prometheus-stack`, `canary-checker` | PrometheusRule + Canary CRDs |
 | `canary-checker-config` | `canary-checker` | Canary CRD |
 | `tuppr-config` | `tuppr` | TalosUpgrade/KubernetesUpgrade CRDs |
+| `priority-classes-config` | *(none)* | PriorityClass is a built-in resource (no CRDs needed) |
 | `kromgo-config` | *(none)* | ConfigMap must exist BEFORE app deployment |
 | `flux-notifications-config` | *(none)* | Uses only core Flux CRDs (always present) |
 

--- a/kubernetes/platform/charts/alloy.yaml
+++ b/kubernetes/platform/charts/alloy.yaml
@@ -3,6 +3,7 @@
 fullnameOverride: alloy
 controller:
   type: daemonset
+  priorityClassName: platform
 alloy:
   mounts:
     varlog: true

--- a/kubernetes/platform/charts/cert-manager.yaml
+++ b/kubernetes/platform/charts/cert-manager.yaml
@@ -4,6 +4,7 @@
 global:
   leaderElection:
     namespace: cert-manager
+  priorityClassName: platform
   commonLabels:
 podLabels:
   networking/allow-egress-internet: "true"

--- a/kubernetes/platform/charts/cloudnative-pg.yaml
+++ b/kubernetes/platform/charts/cloudnative-pg.yaml
@@ -1,5 +1,6 @@
 ---
 # https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/values.yaml
+priorityClassName: platform
 crds:
   create: true
 replicaCount: 2

--- a/kubernetes/platform/charts/descheduler.yaml
+++ b/kubernetes/platform/charts/descheduler.yaml
@@ -1,5 +1,6 @@
 ---
 # https://raw.githubusercontent.com/kubernetes-sigs/descheduler/master/charts/descheduler/values.yaml
+priorityClassName: platform
 replicas: 2
 kind: Deployment
 deschedulerPolicyAPIVersion: descheduler/v1alpha2

--- a/kubernetes/platform/charts/dragonfly-operator.yaml
+++ b/kubernetes/platform/charts/dragonfly-operator.yaml
@@ -1,5 +1,7 @@
 ---
 # https://github.com/dragonflydb/dragonfly-operator/blob/main/charts/dragonfly-operator/values.yaml
+manager:
+  priorityClassName: platform
 resources:
   requests:
     cpu: 10m

--- a/kubernetes/platform/charts/external-secrets.yaml
+++ b/kubernetes/platform/charts/external-secrets.yaml
@@ -2,10 +2,12 @@
 # https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/values.yaml
 # yaml-language-server: $schema=https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/values.schema.json
 installCRDs: true
+priorityClassName: platform
 serviceMonitor:
   enabled: true
   interval: 1m
 webhook:
+  priorityClassName: platform
   serviceMonitor:
     enabled: true
     interval: 1m
@@ -14,6 +16,7 @@ webhook:
       cpu: 10m
       memory: 100Mi
 certController:
+  priorityClassName: platform
   serviceMonitor:
     enabled: true
     interval: 1m

--- a/kubernetes/platform/charts/garage-operator.yaml
+++ b/kubernetes/platform/charts/garage-operator.yaml
@@ -1,4 +1,5 @@
 ---
+priorityClassName: platform
 resources:
   requests:
     cpu: 10m

--- a/kubernetes/platform/charts/grafana-loki-single-binary.yaml
+++ b/kubernetes/platform/charts/grafana-loki-single-binary.yaml
@@ -31,6 +31,7 @@ loki:
     retention_period: 14d
 singleBinary:
   replicas: 1
+  priorityClassName: platform
   persistence:
     enabled: true
     storageClass: fast

--- a/kubernetes/platform/charts/grafana.yaml
+++ b/kubernetes/platform/charts/grafana.yaml
@@ -1,5 +1,6 @@
 ---
 # https://raw.githubusercontent.com/grafana/helm-charts/main/charts/grafana/values.yaml
+priorityClassName: platform
 deploymentStrategy:
   type: Recreate
 admin:

--- a/kubernetes/platform/charts/istiod.yaml
+++ b/kubernetes/platform/charts/istiod.yaml
@@ -12,6 +12,7 @@ global:
   # Point to istio-csr for certificate requests
   caAddress: cert-manager-istio-csr.cert-manager.svc:443
   logAsJson: true
+  priorityClassName: platform
   defaultResources:
     resources:
       requests:

--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -6,6 +6,7 @@ cleanPrometheusOperatorObjectNames: true
 alertmanager:
   enabled: true
   alertmanagerSpec:
+    priorityClassName: platform
     podMetadata:
       labels:
         networking/allow-egress-internet: "true"
@@ -44,6 +45,7 @@ prometheus:
   ingress:
     enabled: false
   prometheusSpec:
+    priorityClassName: platform
     podMetadata:
       labels:
         networking/allow-ingress-internal: "true"

--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -1,5 +1,17 @@
 ---
 # https://raw.githubusercontent.com/longhorn/charts/master/charts/longhorn/values.yaml
+longhornManager:
+  priorityClass: system-critical
+longhornDriver:
+  priorityClass: system-critical
+longhornUI:
+  priorityClass: system-critical
+longhornAdmissionWebhook:
+  priorityClass: system-critical
+longhornRecoveryBackend:
+  priorityClass: system-critical
+longhornConversionWebhook:
+  priorityClass: system-critical
 persistence:
   defaultFsType: xfs
   defaultClassReplicaCount: ${default_replica_count}

--- a/kubernetes/platform/charts/prometheus-smartctl-exporter.yaml
+++ b/kubernetes/platform/charts/prometheus-smartctl-exporter.yaml
@@ -1,5 +1,6 @@
 ---
 # https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-smartctl-exporter
+priorityClassName: platform
 serviceMonitor:
   enabled: true
   interval: 60s

--- a/kubernetes/platform/charts/prometheus-snmp-exporter.yaml
+++ b/kubernetes/platform/charts/prometheus-snmp-exporter.yaml
@@ -1,4 +1,5 @@
 ---
 # https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-snmp-exporter
+priorityClassName: platform
 serviceMonitor:
   enabled: false  # Using standalone ScrapeConfig for Flux variable substitution

--- a/kubernetes/platform/charts/reloader.yaml
+++ b/kubernetes/platform/charts/reloader.yaml
@@ -3,6 +3,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/stakater/Reloader/master/deployments/kubernetes/chart/reloader/values.schema.json
 
 reloader:
+  deployment:
+    priorityClassName: platform
   podMonitor:
     enabled: true
   reloadStrategy: annotations

--- a/kubernetes/platform/charts/replicator.yaml
+++ b/kubernetes/platform/charts/replicator.yaml
@@ -1,5 +1,6 @@
 ---
 # https://raw.githubusercontent.com/mittwald/kubernetes-replicator/master/deploy/helm-chart/kubernetes-replicator/values.yaml
+priorityClassName: platform
 image:
   pullPolicy: IfNotPresent
 

--- a/kubernetes/platform/charts/secret-generator.yaml
+++ b/kubernetes/platform/charts/secret-generator.yaml
@@ -1,5 +1,6 @@
 ---
 # https://github.com/mittwald/kubernetes-secret-generator/blob/master/deploy/helm-chart/kubernetes-secret-generator/values.yaml
+priorityClassName: platform
 resources:
   requests:
     cpu: 10m

--- a/kubernetes/platform/charts/silence-operator.yaml
+++ b/kubernetes/platform/charts/silence-operator.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/giantswarm/silence-operator/main/helm/silence-operator/values.schema.json
 ---
+priorityClassName: platform
+
 # Alertmanager service endpoint (kube-prometheus-stack default)
 alertmanagerAddress: "http://alertmanager-operated.monitoring.svc:9093"
 

--- a/kubernetes/platform/config.yaml
+++ b/kubernetes/platform/config.yaml
@@ -70,6 +70,10 @@ spec:
       namespace: ""
       path: kubernetes/platform/config/network-policy
       dependsOn: [cilium]
+    - name: priority-classes-config
+      namespace: ""
+      path: kubernetes/platform/config/priority-classes
+      dependsOn: []
     - name: infrastructure-policies-config
       namespace: ""
       path: kubernetes/platform/config/infrastructure-policies

--- a/kubernetes/platform/config/CLAUDE.md
+++ b/kubernetes/platform/config/CLAUDE.md
@@ -23,6 +23,7 @@ For Flux patterns and version management, see [kubernetes/platform/CLAUDE.md](..
 | `longhorn/` | Storage classes, backup config | StorageClass, RecurringJob |
 | `monitoring/` | Alertmanager config, alert rules | PrometheusRule, ServiceMonitor, AlertmanagerConfig |
 | `network-policy/` | Cilium network policies | CiliumNetworkPolicy, CiliumClusterwideNetworkPolicy |
+| `priority-classes/` | Workload scheduling tiers | PriorityClass (system-critical, platform, application) |
 | `secrets/` | External secrets infrastructure | ClusterSecretStore |
 | `tuppr/` | Talos and Kubernetes upgrades | TalosUpgrade, KubernetesUpgrade |
 

--- a/kubernetes/platform/config/priority-classes/kustomization.yaml
+++ b/kubernetes/platform/config/priority-classes/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - priority-classes.yaml

--- a/kubernetes/platform/config/priority-classes/priority-classes.yaml
+++ b/kubernetes/platform/config/priority-classes/priority-classes.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/scheduling.k8s.io/priorityclass_v1.json
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: system-critical
+value: 1000000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: >-
+  CNI, DNS, storage drivers, and mesh data plane components.
+  These must survive resource pressure to maintain cluster connectivity.
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/scheduling.k8s.io/priorityclass_v1.json
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: platform
+value: 900000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: >-
+  Monitoring, logging, databases, gateways, and control plane services.
+  These support platform operations and should preempt application workloads.
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/scheduling.k8s.io/priorityclass_v1.json
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: application
+value: 800000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: true
+description: >-
+  User-facing application workloads. Default priority for all pods
+  that do not specify an explicit priorityClassName.


### PR DESCRIPTION
## Summary
- Introduces three PriorityClass tiers (system-critical, platform, application) so the scheduler preserves storage and observability services during resource pressure
- Assigns `system-critical` to Longhorn, `platform` to all monitoring/control-plane charts, and `application` as the globalDefault for user workloads
- Charts without `priorityClassName` in their values (canary-checker, istio-csr, tuppr, prometheus-ipmi-exporter) inherit `application` via globalDefault; CNI/mesh data-plane components already use built-in `system-node-critical`

Closes #304

## Test plan
- [ ] `task k8s:validate` passes locally
- [ ] Integration cluster deploys without HelmRelease failures
- [ ] Verify PriorityClasses exist: `kubectl get priorityclasses | grep -E 'system-critical|platform|application'`
- [ ] Verify platform pods have correct class: `kubectl get pods -n monitoring -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.priorityClassName}{"\n"}{end}'`
- [ ] Verify Longhorn pods have system-critical: `kubectl get pods -n longhorn-system -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.priorityClassName}{"\n"}{end}'`