### PR TITLE
feat(k8s): add storage and database health checks to Tuppr upgrades

### DIFF
--- a/kubernetes/platform/config/tuppr/kubernetes-upgrade.yaml
+++ b/kubernetes/platform/config/tuppr/kubernetes-upgrade.yaml
@@ -14,3 +14,38 @@ spec:
         object.status.conditions.exists(c,
           c.type == 'Ready' && c.status == 'True')
       timeout: 10m
+    - apiVersion: longhorn.io/v1beta2
+      kind: Volume
+      namespace: longhorn-system
+      description: All attached Longhorn volumes must be robust (detached volumes are excluded)
+      expr: |
+        status.state != 'attached' ||
+          status.robustness == 'healthy'
+      timeout: 30m
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      name: platform
+      namespace: database
+      description: CNPG cluster must be healthy with all instances ready
+      expr: |
+        status.phase == 'Cluster in healthy state' &&
+          status.readyInstances == object.spec.instances
+      timeout: 15m
+    - apiVersion: garage.rajsingh.info/v1alpha1
+      kind: GarageCluster
+      name: garage
+      namespace: garage
+      description: Garage cluster must be running with all replicas ready
+      expr: |
+        status.phase == 'Running' &&
+          status.readyReplicas == object.spec.replicas
+      timeout: 10m
+    - apiVersion: dragonflydb.io/v1alpha1
+      kind: Dragonfly
+      name: dragonfly
+      namespace: database
+      description: Dragonfly must be ready and not in a rolling update
+      expr: |
+        status.phase == 'ready' &&
+          !status.isRollingUpdate
+      timeout: 10m

--- a/kubernetes/platform/config/tuppr/talos-upgrade.yaml
+++ b/kubernetes/platform/config/tuppr/talos-upgrade.yaml
@@ -17,3 +17,38 @@ spec:
         object.status.conditions.exists(c,
           c.type == 'Ready' && c.status == 'True')
       timeout: 10m
+    - apiVersion: longhorn.io/v1beta2
+      kind: Volume
+      namespace: longhorn-system
+      description: All attached Longhorn volumes must be robust (detached volumes are excluded)
+      expr: |
+        status.state != 'attached' ||
+          status.robustness == 'healthy'
+      timeout: 30m
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      name: platform
+      namespace: database
+      description: CNPG cluster must be healthy with all instances ready
+      expr: |
+        status.phase == 'Cluster in healthy state' &&
+          status.readyInstances == object.spec.instances
+      timeout: 15m
+    - apiVersion: garage.rajsingh.info/v1alpha1
+      kind: GarageCluster
+      name: garage
+      namespace: garage
+      description: Garage cluster must be running with all replicas ready
+      expr: |
+        status.phase == 'Running' &&
+          status.readyReplicas == object.spec.replicas
+      timeout: 10m
+    - apiVersion: dragonflydb.io/v1alpha1
+      kind: Dragonfly
+      name: dragonfly
+      namespace: database
+      description: Dragonfly must be ready and not in a rolling update
+      expr: |
+        status.phase == 'ready' &&
+          !status.isRollingUpdate
+      timeout: 10m


### PR DESCRIPTION
## Summary
- Gate rolling node upgrades on storage/database replication convergence, not just Node readiness
- Prevents double-degraded Longhorn volumes, CNPG quorum loss, and Garage/Dragonfly write failures when Tuppr proceeds to the next node too quickly

## Health checks added
| Check | Target | CEL condition | Timeout |
|-------|--------|---------------|---------|
| Longhorn volumes | All `Volume` in `longhorn-system` | Attached volumes must report `robustness == healthy`; detached volumes are excluded | 30m |
| CNPG cluster | `platform` Cluster in `database` | Phase is healthy and all instances are ready | 15m |
| Garage cluster | `garage` GarageCluster in `garage` | Phase is Running and all replicas are ready | 10m |
| Dragonfly | `dragonfly` Dragonfly in `database` | Phase is ready and no rolling update in progress | 10m |
| Node readiness | All Nodes (existing) | Ready condition is True | 10m |

## Test plan
- [ ] `task k8s:validate` passes
- [ ] Health checks are identical in both `talos-upgrade.yaml` and `kubernetes-upgrade.yaml`
- [ ] CEL expressions verified against actual CRD status field names from upstream source code
- [ ] After merge, trigger a Talos upgrade on integration and confirm Tuppr waits for all checks before proceeding to the next node