### PR TITLE
fix(ci): pin Flux GitHub Action to specific version

### DIFF
--- a/.github/workflows/build-platform-artifact.yaml
+++ b/.github/workflows/build-platform-artifact.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: fluxcd/flux2/action@main
+      - uses: fluxcd/flux2/action@v2.7.5
 
       - uses: docker/login-action@v3
         with:

--- a/.github/workflows/tag-validated-artifact.yaml
+++ b/.github/workflows/tag-validated-artifact.yaml
@@ -25,7 +25,7 @@ jobs:
       statuses: read
 
     steps:
-      - uses: fluxcd/flux2/action@main
+      - uses: fluxcd/flux2/action@v2.7.5
 
       - uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- Pin `fluxcd/flux2/action` from `@main` to `@v2.7.5` in both CI workflows to eliminate supply chain risk
- Renovate's built-in `github-actions` manager (included in `config:recommended` preset) will automatically manage future version updates

Closes #312

## Test plan
- [ ] CI workflows still pass with pinned version
- [ ] Renovate detects the pinned action for future updates