### PR TITLE
fix(k8s): replace hardcoded Dragonfly S3 endpoint with variable substitution

### DIFF
--- a/kubernetes/clusters/live/charts/zipline.yaml
+++ b/kubernetes/clusters/live/charts/zipline.yaml
@@ -97,7 +97,7 @@ controllers:
           DATASOURCE_TYPE: s3
           DATASOURCE_S3_REGION: garage
           DATASOURCE_S3_BUCKET: zipline
-          DATASOURCE_S3_ENDPOINT: http://garage.garage.svc.cluster.local:3900
+          DATASOURCE_S3_ENDPOINT: http://${garage_s3_endpoint}
           DATASOURCE_S3_FORCE_PATH_STYLE: "true"
           DATASOURCE_S3_ACCESS_KEY_ID:
             valueFrom:

--- a/kubernetes/platform/config/dragonfly/dragonfly-instance.yaml
+++ b/kubernetes/platform/config/dragonfly/dragonfly-instance.yaml
@@ -27,7 +27,7 @@ spec:
     - "--dbfilename"
     - "dump"
     - "--s3_endpoint"
-    - "garage.garage.svc.cluster.local:3900"
+    - "${garage_s3_endpoint}"
     - "--s3_use_https=false"
 
   env:

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -81,3 +81,6 @@ lldap_version=v0.6.2
 garage_image_version=v2.2.0
 # renovate: datasource=docker depName=cloudnative-pg-postgresql packageName=ghcr.io/cloudnative-pg/postgresql versioning=loose
 postgresql_image_version=17.2
+
+# Platform service endpoints (internal cluster references)
+garage_s3_endpoint=garage.garage.svc.cluster.local:3900


### PR DESCRIPTION
## Summary
- Add `garage_s3_endpoint` variable to `versions.env` as the single source of truth for the Garage S3 endpoint
- Replace hardcoded `garage.garage.svc.cluster.local:3900` in Dragonfly config and Zipline chart with `${garage_s3_endpoint}` Flux substitution

Closes #314

## Test plan
- [ ] Validation passes (`task k8s:validate`)
- [ ] Flux variable substitution resolves correctly in both Dragonfly and Zipline configs
- [ ] No remaining hardcoded Garage service addresses