### PR TITLE
fix(k8s): rename system-critical PriorityClass to infrastructure-critical

### DIFF
--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -1,17 +1,17 @@
 ---
 # https://raw.githubusercontent.com/longhorn/charts/master/charts/longhorn/values.yaml
 longhornManager:
-  priorityClass: system-critical
+  priorityClass: infrastructure-critical
 longhornDriver:
-  priorityClass: system-critical
+  priorityClass: infrastructure-critical
 longhornUI:
-  priorityClass: system-critical
+  priorityClass: infrastructure-critical
 longhornAdmissionWebhook:
-  priorityClass: system-critical
+  priorityClass: infrastructure-critical
 longhornRecoveryBackend:
-  priorityClass: system-critical
+  priorityClass: infrastructure-critical
 longhornConversionWebhook:
-  priorityClass: system-critical
+  priorityClass: infrastructure-critical
 persistence:
   defaultFsType: xfs
   defaultClassReplicaCount: ${default_replica_count}

--- a/kubernetes/platform/config/CLAUDE.md
+++ b/kubernetes/platform/config/CLAUDE.md
@@ -23,7 +23,7 @@ For Flux patterns and version management, see [kubernetes/platform/CLAUDE.md](..
 | `longhorn/` | Storage classes, backup config | StorageClass, RecurringJob |
 | `monitoring/` | Alertmanager config, alert rules | PrometheusRule, ServiceMonitor, AlertmanagerConfig |
 | `network-policy/` | Cilium network policies | CiliumNetworkPolicy, CiliumClusterwideNetworkPolicy |
-| `priority-classes/` | Workload scheduling tiers | PriorityClass (system-critical, platform, application) |
+| `priority-classes/` | Workload scheduling tiers | PriorityClass (infrastructure-critical, platform, application) |
 | `secrets/` | External secrets infrastructure | ClusterSecretStore |
 | `tuppr/` | Talos and Kubernetes upgrades | TalosUpgrade, KubernetesUpgrade |
 

--- a/kubernetes/platform/config/priority-classes/priority-classes.yaml
+++ b/kubernetes/platform/config/priority-classes/priority-classes.yaml
@@ -3,7 +3,7 @@
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: system-critical
+  name: infrastructure-critical
 value: 1000000
 preemptionPolicy: PreemptLowerPriority
 globalDefault: false


### PR DESCRIPTION
## Summary
- Kubernetes v1.35.0 reserves the `system-` prefix for PriorityClass names, causing the `priority-classes-config` Kustomization to fail atomically across all three clusters
- This cascades to ~10-11 HelmReleases per cluster that depend on the PriorityClasses (`system-critical`, `platform`, `application`) never being created
- Renames `system-critical` to `infrastructure-critical` in the PriorityClass definition and all references (Longhorn chart values, documentation)

## Test plan
- [x] Searched codebase for all `system-critical` references (excluding built-in `system-cluster-critical` / `system-node-critical`)
- [x] Verified zero remaining references after rename
- [x] `task k8s:validate` passes (ResourceSet expansion, Helm templating, kubeconform schema validation, yamllint, deprecation check)