### PR TITLE
fix(k8s): add restricted security context to secret-generator

### DIFF
--- a/kubernetes/platform/charts/secret-generator.yaml
+++ b/kubernetes/platform/charts/secret-generator.yaml
@@ -1,6 +1,16 @@
 ---
 # https://github.com/mittwald/kubernetes-secret-generator/blob/master/deploy/helm-chart/kubernetes-secret-generator/values.yaml
 priorityClassName: platform
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 resources:
   requests:
     cpu: 10m


### PR DESCRIPTION
## Summary
- The `system` namespace enforces PodSecurity `restricted:latest`, which requires explicit security context fields (runAsNonRoot, seccompProfile, drop ALL capabilities, no privilege escalation) that the mittwald/kubernetes-secret-generator chart does not set by default
- This is blocking `cloudnative-pg` and `dragonfly-operator` deployments across all clusters since they depend on `secret-generator`

## Test plan
- [x] Verified chart supports `securityContext` and `podSecurityContext` top-level values via `helm show values`
- [x] `task k8s:validate` passes (all 29 charts templated successfully)
- [ ] Integration cluster deploys secret-generator pods without PodSecurity violations
- [ ] CNPG and dragonfly-operator unblocked after promotion