### PR TITLE
fix(k8s): add restricted security context to reloader, replicator, and dragonfly-operator

### DIFF
--- a/kubernetes/platform/charts/dragonfly-operator.yaml
+++ b/kubernetes/platform/charts/dragonfly-operator.yaml
@@ -2,6 +2,12 @@
 # https://github.com/dragonflydb/dragonfly-operator/blob/main/charts/dragonfly-operator/values.yaml
 manager:
   priorityClassName: platform
+
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
 resources:
   requests:
     cpu: 10m

--- a/kubernetes/platform/charts/reloader.yaml
+++ b/kubernetes/platform/charts/reloader.yaml
@@ -5,6 +5,12 @@
 reloader:
   deployment:
     priorityClassName: platform
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
   podMonitor:
     enabled: true
   reloadStrategy: annotations

--- a/kubernetes/platform/charts/replicator.yaml
+++ b/kubernetes/platform/charts/replicator.yaml
@@ -7,6 +7,17 @@ image:
 serviceAccount:
   create: true
 
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
 resources:
   requests:
     cpu: 10m


### PR DESCRIPTION
## Summary
- Reloader, replicator, and dragonfly-operator pods fail to create in namespaces enforcing PodSecurity `restricted:latest` due to missing security context fields
- Follows the same pattern as #337 (secret-generator), supplementing only the missing fields per chart while preserving existing defaults

## Test plan
- [x] Verified each chart's supported values structure via `helm show values`
- [x] Confirmed existing security context defaults are preserved (not overwritten)
- [x] `task k8s:validate` passes (all 29 charts template, 0 invalid schemas)
- [ ] Pods create successfully after promotion to integration