### PR TITLE
fix(k8s): set runAsUser for replicator to satisfy runAsNonRoot

### DIFF
--- a/kubernetes/platform/charts/replicator.yaml
+++ b/kubernetes/platform/charts/replicator.yaml
@@ -9,6 +9,8 @@ serviceAccount:
 
 podSecurityContext:
   runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
   seccompProfile:
     type: RuntimeDefault
 securityContext:


### PR DESCRIPTION
## Summary
- The kubernetes-replicator image runs as root by default, so `runAsNonRoot: true` (added in #338) causes pod creation to fail with "container has runAsNonRoot and image will run as root"
- Sets `runAsUser: 65534` and `runAsGroup: 65534` (nobody) to satisfy the constraint

## Test plan
- [ ] Validate with `task k8s:validate`
- [ ] Verify replicator pod starts successfully after promotion