### PR TITLE
docs(k8s): add PodSecurity enforcement and PriorityClass naming guidance

### DIFF
--- a/.claude/skills/app-template/SKILL.md
+++ b/.claude/skills/app-template/SKILL.md
@@ -274,7 +274,40 @@ controllers:
 
 ## Security Context
 
-### Pod-Level
+### Restricted Profile (Required for restricted namespaces)
+
+Namespaces with `security: restricted` (cert-manager, external-secrets, system, database, kromgo) enforce the PodSecurity `restricted` profile. All containers MUST have the following security context or pods will be rejected at admission time.
+
+```yaml
+defaultPodOptions:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534             # Use if image runs as root; omit if image already runs non-root
+    runAsGroup: 65534
+    fsGroup: 65534
+    fsGroupChangePolicy: OnRootMismatch
+    seccompProfile:
+      type: RuntimeDefault
+
+controllers:
+  main:
+    containers:
+      main:
+        image:
+          repository: myapp
+          tag: v1.0.0
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+```
+
+If the application writes to the filesystem, mount writable `emptyDir` volumes at the required paths rather than disabling `readOnlyRootFilesystem`.
+
+### Pod-Level (Baseline namespaces)
+
+For namespaces with `security: baseline`, a lighter security context is sufficient:
 
 ```yaml
 defaultPodOptions:
@@ -294,6 +327,8 @@ controllers:
 ```
 
 ### Container-Level (Privileged Sidecar)
+
+Only applicable in namespaces with `security: privileged`:
 
 ```yaml
 controllers:

--- a/.claude/skills/deploy-app/SKILL.md
+++ b/.claude/skills/deploy-app/SKILL.md
@@ -151,10 +151,20 @@ Add to `kubernetes/platform/namespaces.yaml` inputs array:
 
 ```yaml
 - name: <namespace>
-  labels:
-    pod-security.kubernetes.io/enforce: baseline
-    network-policy.homelab/profile: standard  # REQUIRED - choose: isolated, internal, internal-egress, standard
+  dataplane: ambient
+  security: baseline                    # Choose: restricted, baseline, privileged
+  networkPolicy: false                  # Or object with profile/enforcement
 ```
+
+**PodSecurity Level Selection:**
+
+| Level | Use When | Security Context Required |
+|-------|----------|--------------------------|
+| `restricted` | Standard controllers, databases, simple apps | Full restricted context on all containers |
+| `baseline` | Apps needing elevated capabilities (e.g., `NET_BIND_SERVICE`) | Moderate |
+| `privileged` | Host access, BPF, device access | None |
+
+**If `security: restricted`**: You MUST set full security context in chart values (see step 3.4a below).
 
 **Network Policy Profile Selection:**
 
@@ -216,6 +226,32 @@ ingress:
 ```
 
 See [references/file-templates.md](references/file-templates.md) for complete templates.
+
+### 3.4a Add Security Context for Restricted Namespaces
+
+If the target namespace uses `security: restricted`, add security context to the chart values. Check the container image's default user first -- if it runs as root, set `runAsUser: 65534`.
+
+```yaml
+# Pod-level (key varies by chart: podSecurityContext, securityContext, pod.securityContext)
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level (every container and init container)
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+```
+
+**Restricted namespaces**: cert-manager, external-secrets, system, database, kromgo.
+
+**Validation gap**: `task k8s:validate` does NOT catch PodSecurity violations -- only server-side dry-run or actual deployment reveals them. Always verify security context manually for restricted namespaces.
 
 ### 3.5 Register in kustomization.yaml
 
@@ -555,6 +591,7 @@ spec:
 | Namespace exists | Ask user: reuse or new name |
 | Secret needed | Apply decision tree above |
 | Port-forward fails | Check if Prometheus is running in dev |
+| Pods rejected by PodSecurity | Missing security context for restricted namespace | Add restricted security context to chart values (see step 3.4a) |
 
 ---
 

--- a/.claude/skills/flux-gitops/SKILL.md
+++ b/.claude/skills/flux-gitops/SKILL.md
@@ -85,6 +85,39 @@ config/my-new-chart/
 
 Then reference in `config.yaml` ResourceSet.
 
+### Step 5: Verify PodSecurity Compliance
+
+Before finalizing values, check the target namespace's PodSecurity level in `namespaces.yaml`:
+
+- [ ] **Identify the namespace security level**: Look for `security: restricted`, `baseline`, or `privileged` in the namespace inputs
+- [ ] **If `restricted`**: Add full security context to chart values (see below)
+- [ ] **Check the container image's default user**: If it runs as root, set `runAsUser: 65534`
+- [ ] **Verify all init containers and sidecars** also have security context set
+
+**Required security context for `restricted` namespaces:**
+
+```yaml
+# Pod-level (chart-specific key varies: podSecurityContext, securityContext, pod.securityContext)
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level (every container)
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+```
+
+**Restricted namespaces**: cert-manager, external-secrets, system, database, kromgo. See [kubernetes/platform/CLAUDE.md](../../kubernetes/platform/CLAUDE.md) for the full list.
+
+**Validation gap**: `task k8s:validate` does NOT catch PodSecurity violations. These are only caught at admission time in the cluster.
+
 ## ResourceSet Template Syntax
 
 The `resourcesTemplate` uses Go text/template with `<<` `>>` delimiters:

--- a/kubernetes/platform/CLAUDE.md
+++ b/kubernetes/platform/CLAUDE.md
@@ -39,7 +39,7 @@ The `config/` directory organizes non-Helm resources by concern:
 | `kromgo/` | Kromgo status page configs |
 | `longhorn/` | Longhorn backup and storage configs |
 | `monitoring/` | Prometheus rules, Grafana dashboards |
-| `priority-classes/` | Workload scheduling priority tiers |
+| `priority-classes/` | Workload scheduling priority tiers (infrastructure-critical, platform, application) |
 | `secrets/` | Secret generator resources |
 | `tuppr/` | Tuppr upgrade CRs (TalosUpgrade, KubernetesUpgrade) |
 
@@ -107,6 +107,57 @@ inputs:
 - Chart versions use `${var}` pattern (variable from `platform-versions` ConfigMap, guaranteed by bootstrap dependency chain)
 - Dependencies between releases use `dependsOn` arrays
 - Values files contain only Helm chart configuration
+
+---
+
+## PodSecurity Enforcement
+
+Namespaces use PodSecurity admission to enforce security profiles. The `namespaces.yaml` ResourceSet assigns one of three profiles to each namespace: `restricted`, `baseline`, or `privileged`.
+
+### Namespace Security Levels
+
+| Level | Namespaces | Implications |
+|-------|-----------|--------------|
+| `restricted` | cert-manager, external-secrets, system, database, kromgo | Strictest: requires full security context on all pods |
+| `baseline` | istio-gateway, garage | Moderate: allows some elevated capabilities (e.g., `NET_BIND_SERVICE`) |
+| `privileged` | kube-system, longhorn-system, istio-system, monitoring, spegel, system-upgrade | Unrestricted: host access, BPF, privileged containers |
+
+### Required Security Context for `restricted` Namespaces
+
+Charts deployed to `restricted` namespaces **MUST** set these fields or pods will be rejected at admission time:
+
+```yaml
+# Pod-level security context
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level security context (every container and init container)
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65534          # Only if the image runs as root by default
+  seccompProfile:
+    type: RuntimeDefault
+```
+
+If the container image already runs as a non-root user (check with `docker inspect <image>` or image documentation), you can omit `runAsUser`. If the image runs as root by default, set `runAsUser: 65534` (the `nobody` user).
+
+### Validation Gap
+
+`task k8s:validate` catches YAML schema errors but **cannot** detect PodSecurity admission violations. These are only caught by:
+- **Server-side dry-run**: `task k8s:dry-run-dev` (not currently in CI)
+- **Actual deployment**: Pods rejected at admission time in the cluster
+
+Agents must manually verify security context compliance when deploying to restricted namespaces. Check the target namespace's security level in `namespaces.yaml` before writing chart values.
+
+### PriorityClass Naming Constraints
+
+Custom PriorityClass names must never use the `system-` prefix, which Kubernetes reserves for built-in classes (`system-cluster-critical`, `system-node-critical`). Our tiers are: `infrastructure-critical`, `platform`, `application`. See [config/CLAUDE.md](config/CLAUDE.md) for details.
 
 ---
 

--- a/kubernetes/platform/config/CLAUDE.md
+++ b/kubernetes/platform/config/CLAUDE.md
@@ -231,6 +231,48 @@ longhorn/
 └── storage-classes/     # StorageClass definitions
 ```
 
+### Priority Classes
+
+Three tiers defined in `priority-classes/priority-classes.yaml`:
+
+| Name | Value | Default | Purpose |
+|------|-------|---------|---------|
+| `infrastructure-critical` | 1000000 | No | CNI, DNS, storage, mesh data plane |
+| `platform` | 900000 | No | Monitoring, logging, databases, gateways |
+| `application` | 800000 | Yes | User-facing workloads (global default) |
+
+**Naming constraint**: Never use the `system-` prefix for custom PriorityClass names. Kubernetes reserves this prefix for built-in priority classes (`system-cluster-critical`, `system-node-critical`). Names with the `system-` prefix are rejected at admission time, which causes the entire `priority-classes-config` Kustomization to fail atomically and cascades to all dependent HelmReleases.
+
+### PodSecurity Enforcement
+
+Multiple namespaces enforce the PodSecurity `restricted` profile, which requires strict security context settings on all pods.
+
+**Namespaces with `restricted` enforcement** (from `namespaces.yaml`):
+
+| Namespace | Why Restricted |
+|-----------|---------------|
+| `cert-manager` | Standard controller, no privileged requirements |
+| `external-secrets` | Standard controller, no privileged requirements |
+| `system` | Standard controller workloads |
+| `database` | CNPG PostgreSQL pods run as non-root |
+| `kromgo` | Simple web application |
+
+**What `restricted` enforcement requires** (validated at admission time):
+
+Pod-level:
+- `runAsNonRoot: true`
+- `seccompProfile.type: RuntimeDefault`
+
+Container-level (every container and init container):
+- `allowPrivilegeEscalation: false`
+- `capabilities.drop: ["ALL"]`
+- `readOnlyRootFilesystem: true` (recommended, not strictly required by restricted)
+- `runAsUser: <non-zero-uid>` (if the image runs as root by default, use `65534` for `nobody`)
+
+**Impact on Helm charts**: Any chart deployed to a `restricted` namespace MUST set these fields in its values. If the chart does not expose security context configuration, the chart cannot be deployed to that namespace without patching.
+
+**Validation gap**: `task k8s:validate` catches schema errors but NOT PodSecurity admission violations. Only server-side dry-run (`task k8s:dry-run-dev`) or actual deployment reveals these. Agents must manually verify security context compliance when deploying to restricted namespaces.
+
 ### Monitoring Organization
 
 The `monitoring/` subsystem is the largest, containing:


### PR DESCRIPTION
## Summary
- Encode lessons from the PriorityClass rename and PodSecurity incident into documentation and agent skills
- Ensure agents always check namespace security levels and add required security context when deploying to restricted namespaces
- Document the validation gap between `task k8s:validate` (schema-only) and actual PodSecurity admission enforcement

## Test plan
- [ ] Validated with `task k8s:validate` (docs-only change, no YAML modified)
- [ ] Verify flux-gitops skill now includes Step 5 PodSecurity checklist
- [ ] Verify deploy-app skill includes step 3.4a for restricted namespaces
- [ ] Verify app-template skill documents restricted profile security context
- [ ] Verify `kubernetes/platform/CLAUDE.md` has PodSecurity Enforcement section with namespace table
- [ ] Verify `kubernetes/platform/config/CLAUDE.md` has Priority Classes and PodSecurity subsystem deep dives