### PR TITLE
fix(k8s): filter CNPG canary check to Running pods only

### DIFF
--- a/kubernetes/platform/config/canary-checker/platform-health.yaml
+++ b/kubernetes/platform/config/canary-checker/platform-health.yaml
@@ -75,12 +75,15 @@ spec:
           )
 
     # CNPG operator is running (manages database clusters)
+    # Filter to Running pods only — completed old-revision pods from operator
+    # upgrades would otherwise cause false-positive failures.
     - name: cnpg-operator-healthy
       kind: Pod
       namespaceSelector:
         name: database
       resource:
         labelSelector: app.kubernetes.io/name=cloudnative-pg
+        fieldSelector: status.phase=Running
       test:
         expr: >
           dyn(results).all(pod,


### PR DESCRIPTION
## Summary
- Add `fieldSelector: status.phase=Running` to the `cnpg-operator-healthy` canary check so completed old-revision pods from operator upgrades don't trigger false-positive critical alerts

## Test plan
- [ ] Verify `CanaryCheckFailure` alert resolves on integration after deployment
- [ ] Confirm canary check still detects actual CNPG operator failures (scale to 0 and verify alert fires)