### PR TITLE
fix(k8s): add restricted security context to kromgo

### DIFF
--- a/kubernetes/platform/charts/kromgo.yaml
+++ b/kubernetes/platform/charts/kromgo.yaml
@@ -10,6 +10,7 @@ controllers:
 
     pod:
       securityContext:
+        runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
@@ -31,8 +32,11 @@ controllers:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
           capabilities:
             drop: [ALL]
+          seccompProfile:
+            type: RuntimeDefault
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
## Summary
- Add `runAsNonRoot: true` and `seccompProfile` to kromgo pod and container security contexts to satisfy PodSecurity `restricted` admission in the `kromgo` namespace
- This was exposed by the app-template v3→v4 upgrade — the old chart likely injected defaults that the new chart does not

## Test plan
- [ ] Verify kromgo pods start successfully on integration and dev after promotion
- [ ] Confirm no PodSecurity admission violations in events