### PR TITLE
fix(k8s): evict completed pods after 24h via descheduler PodLifetime

### DIFF
--- a/kubernetes/platform/charts/descheduler.yaml
+++ b/kubernetes/platform/charts/descheduler.yaml
@@ -31,6 +31,11 @@ deschedulerPolicy:
               - Job
             includingInitContainers: true
             minPodLifetimeSeconds: 3600
+        - name: PodLifetime
+          args:
+            maxPodLifetimeSeconds: 86400
+            states:
+              - Completed
       plugins:
         balance:
           enabled:
@@ -41,6 +46,7 @@ deschedulerPolicy:
             - RemovePodsViolatingNodeAffinity
             - RemovePodsViolatingNodeTaints
             - RemoveFailedPods
+            - PodLifetime
 service:
   enabled: true
 serviceMonitor:


### PR DESCRIPTION
## Summary
- Completed (Succeeded) pods were accumulating on the integration cluster for 8+ days because descheduler had no strategy targeting that phase
- Add `PodLifetime` plugin scoped to `Completed` state with a 24h (`86400s`) eviction threshold

## Test plan
- [ ] Validate CI passes (`task k8s:validate`)
- [ ] After deploy, verify descheduler logs show `PodLifetime` in the active plugin list
- [ ] Confirm stale Succeeded pods are evicted within the next descheduler cycle