### PR TITLE
fix(k8s): replace Alertmanager PVC storage with emptyDir

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -17,12 +17,7 @@ alertmanager:
         resolveTimeout: 5m
     externalUrl: https://alertmanager.${external_domain}
     storage:
-      volumeClaimTemplate:
-        spec:
-          storageClassName: fast
-          resources:
-            requests:
-              storage: 1Gi
+      emptyDir: { }
 kubeApiServer:
   serviceMonitor:
     selector:


### PR DESCRIPTION
## Summary
- Alertmanager's PVC persistence is unnecessary: silence state is managed declaratively by silence-operator (reconstructable from git), and notification dedup/history is ephemeral and gossiped between replicas
- Removes 9 Longhorn volume replicas (3 PVCs x 3 replicas on `fast` storage class) that stored fully reconstructable data

Closes #347

## Test plan
- [x] `task k8s:validate` passes
- [ ] After merge, verify silence-operator reconciles silences correctly after Alertmanager restart
- [ ] Verify Alertmanager gossip recovers cluster state after a single-pod restart
- [ ] Delete stale PVCs from previous StatefulSet (`kubectl delete pvc -n monitoring -l app.kubernetes.io/name=alertmanager`)