### PR TITLE
fix(k8s): correct PodLifeTime plugin casing in descheduler config

### DIFF
--- a/kubernetes/platform/charts/descheduler.yaml
+++ b/kubernetes/platform/charts/descheduler.yaml
@@ -31,9 +31,9 @@ deschedulerPolicy:
               - Job
             includingInitContainers: true
             minPodLifetimeSeconds: 3600
-        - name: PodLifetime
+        - name: PodLifeTime
           args:
-            maxPodLifetimeSeconds: 86400
+            maxPodLifeTimeSeconds: 86400
             states:
               - Completed
       plugins:
@@ -46,7 +46,7 @@ deschedulerPolicy:
             - RemovePodsViolatingNodeAffinity
             - RemovePodsViolatingNodeTaints
             - RemoveFailedPods
-            - PodLifetime
+            - PodLifeTime
 service:
   enabled: true
 serviceMonitor:


### PR DESCRIPTION
## Summary
- The descheduler `PodLifeTime` plugin name is case-sensitive, and the typo introduced in PR #345 (`PodLifetime` instead of `PodLifeTime`) causes the descheduler to CrashLoopBackOff on all clusters during policy validation
- Also corrects the `maxPodLifeTimeSeconds` arg field to match the plugin's expected casing

## Test plan
- [x] `task k8s:validate` passes
- [ ] Descheduler pods exit CrashLoopBackOff and become Ready after merge