### PR TITLE
fix(k8s): correct PodLifeTime plugin name casing and pod state value

### DIFF
--- a/kubernetes/platform/charts/descheduler.yaml
+++ b/kubernetes/platform/charts/descheduler.yaml
@@ -31,11 +31,11 @@ deschedulerPolicy:
               - Job
             includingInitContainers: true
             minPodLifetimeSeconds: 3600
-        - name: PodLifetime
+        - name: PodLifeTime
           args:
-            maxPodLifetimeSeconds: 86400
+            maxPodLifeTimeSeconds: 86400
             states:
-              - Completed
+              - Succeeded
       plugins:
         balance:
           enabled:
@@ -46,7 +46,7 @@ deschedulerPolicy:
             - RemovePodsViolatingNodeAffinity
             - RemovePodsViolatingNodeTaints
             - RemoveFailedPods
-            - PodLifetime
+            - PodLifeTime
 service:
   enabled: true
 serviceMonitor:


### PR DESCRIPTION
## Summary
- Fix descheduler crash on startup introduced in PR #345 by correcting three configuration errors: the plugin name is `PodLifeTime` (not `PodLifetime`), the argument is `maxPodLifeTimeSeconds` (not `maxPodLifetimeSeconds`), and the valid Kubernetes pod phase is `Succeeded` (not `Completed`)

## Test plan
- [x] `task k8s:validate` passes (YAML lint, ResourceSet expansion, Helm templating, kubeconform)
- [ ] Descheduler pods start without crash after merge
- [ ] Completed pods older than 24h are evicted by the PodLifeTime strategy