### PR TITLE
fix(k8s): remove IPMI exporter CPU limit to prevent CFS throttling

### DIFF
--- a/kubernetes/platform/charts/prometheus-ipmi-exporter.yaml
+++ b/kubernetes/platform/charts/prometheus-ipmi-exporter.yaml
@@ -1,17 +1,18 @@
 ---
 # https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-ipmi-exporter
 serviceMonitor:
-  enabled: false # Using standalone ScrapeConfig for Flux variable substitution
+  enabled: false  # Using standalone ScrapeConfig for Flux variable substitution
 scrapeConfig:
-  enabled: false # Using standalone ScrapeConfig for Flux variable substitution
+  enabled: false  # Using standalone ScrapeConfig for Flux variable substitution
 configSecret:
   enabled: true
   name: hardware-monitoring-credentials
   key: ipmi-config.yml
 resources:
-  limits:
-    cpu: 500m
-    memory: 1Gi
   requests:
     cpu: 100m
+    memory: 64Mi
+  limits:
+    # No CPU limit — ipmitool subprocess forks cause brief spikes incompatible
+    # with CFS rate limiting. Removed twice before (8acbb894, d052a162).
     memory: 128Mi


### PR DESCRIPTION
## Summary
- Remove CPU limit from IPMI exporter to eliminate CFS burst throttling (33-39% throttled despite ~4m average CPU)
- Tighten memory limits from 1Gi to 128Mi to match actual ~7MB usage
- Add comment documenting the history (removed twice before in 8acbb894 and d052a162) to prevent this limit from being re-added a third time

## Test plan
- [x] `task k8s:validate` passes
- [ ] After merge, verify IPMI exporter pods show 0% CPU throttling in Prometheus (`container_cpu_cfs_throttled_periods_total`)
- [ ] Verify memory usage stays within the 128Mi limit