### PR TITLE
fix(k8s): explicitly null IPMI exporter CPU limit to override chart default

### DIFF
--- a/.taskfiles/kubernetes/scripts/template-all-charts.sh
+++ b/.taskfiles/kubernetes/scripts/template-all-charts.sh
@@ -54,13 +54,14 @@ for chart_name in $(echo "$charts_json" | jq -r '.[].name'); do
   envsubst < "$values_file" > "$tmp_values"
 
   # Handle OCI vs HTTP registries
+  output_file="${EXPANDED_DIR}/helm/${chart_name}.yaml"
   case "$chart_url" in
     oci://*)
       echo "Templating (OCI): $chart_name"
       if helm template "$chart_name" "${chart_url}/${chart_helm_name}" \
         --version "$chart_version" \
         --values "$tmp_values" \
-        --namespace test > "${EXPANDED_DIR}/helm/${chart_name}.yaml"; then
+        --namespace test > "$output_file"; then
         echo "  $chart_name"
       else
         echo "  $chart_name failed to template"
@@ -73,7 +74,7 @@ for chart_name in $(echo "$charts_json" | jq -r '.[].name'); do
       if helm template "$chart_name" "$repo_name/$chart_helm_name" \
         --version "$chart_version" \
         --values "$tmp_values" \
-        --namespace test > "${EXPANDED_DIR}/helm/${chart_name}.yaml"; then
+        --namespace test > "$output_file"; then
         echo "  $chart_name"
       else
         echo "  $chart_name failed to template"
@@ -81,6 +82,12 @@ for chart_name in $(echo "$charts_json" | jq -r '.[].name'); do
       fi
       ;;
   esac
+
+  # Strip null values from rendered output. Some charts use per-field template
+  # expressions (e.g. `cpu: {{ .Values.resources.limits.cpu }}`) instead of toYaml,
+  # which renders `cpu: ` (YAML null) when a value is explicitly nulled. The K8s API
+  # server ignores null fields, but kubeconform rejects them as invalid Quantity types.
+  yq --inplace 'del(.. | select(. == null))' "$output_file"
 done
 
 echo ""

--- a/kubernetes/platform/charts/prometheus-ipmi-exporter.yaml
+++ b/kubernetes/platform/charts/prometheus-ipmi-exporter.yaml
@@ -13,6 +13,7 @@ resources:
     cpu: 100m
     memory: 64Mi
   limits:
-    # No CPU limit — ipmitool subprocess forks cause brief spikes incompatible
+    # Explicitly null — ipmitool subprocess forks cause brief CPU spikes incompatible
     # with CFS rate limiting. Removed twice before (8acbb894, d052a162).
+    cpu: null
     memory: 128Mi


### PR DESCRIPTION
## Summary
- PR #359 did not actually remove the IPMI exporter CPU limit because omitting the field from values still allows the chart's default (100m) to be applied via Helm value merging
- Explicitly set `cpu: null` to override the chart default, preventing CFS throttling on bursty ipmitool subprocess forks
- Add null-value stripping to the chart templating script so kubeconform validation accepts the rendered output (the Kubernetes API server already ignores null fields)

## Test plan
- [x] Verified chart renders `cpu: 100m` with current (broken) values via `helm template`
- [x] Verified chart renders `cpu: null` with fixed values, which the K8s API strips
- [x] Confirmed `yq 'del(.. | select(. == null))'` cleanly removes the null field from rendered YAML
- [x] `task k8s:validate` passes with 0 invalid resources (421 valid, previously 420 valid + 1 invalid)