### PR TITLE
fix(k8s): add restricted-compliant security context to Dragonfly instance

### DIFF
--- a/kubernetes/platform/config/dragonfly/dragonfly-instance.yaml
+++ b/kubernetes/platform/config/dragonfly/dragonfly-instance.yaml
@@ -6,6 +6,21 @@ metadata:
 spec:
   replicas: ${default_replica_count}
 
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+    fsGroup: 999
+    fsGroupChangePolicy: OnRootMismatch
+    seccompProfile:
+      type: RuntimeDefault
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
+
   authentication:
     passwordFromSecret:
       name: dragonfly-password


### PR DESCRIPTION
## Summary
- Dragonfly pods are rejected by PodSecurity `restricted:latest` on the `database` namespace because the operator's default pod spec lacks required security context fields
- The Dragonfly CRD natively supports `podSecurityContext` and `containerSecurityContext` fields, so the fix configures them directly on the Dragonfly CR rather than requiring namespace-level PSA exemptions

## Test plan
- [x] `task k8s:validate` passes
- [ ] Dragonfly pods schedule successfully on dev cluster after Flux reconciles
- [ ] No PodSecurity violation events in the `database` namespace
- [ ] Dragonfly clients (Authelia, Immich) can connect and operate normally