### PR TITLE
fix(k8s): deploy metrics-server and increase Flux source-controller cache

### DIFF
--- a/infrastructure/modules/bootstrap/resources/instance-oci.yaml.tftpl
+++ b/infrastructure/modules/bootstrap/resources/instance-oci.yaml.tftpl
@@ -25,5 +25,12 @@ instance:
             path: /spec/ref
             value:
               semver: "${oci_semver}"
+      - target:
+          kind: Deployment
+          name: source-controller
+        patch: |
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --helm-cache-max-size=16
 healthcheck:
   enabled: true

--- a/infrastructure/modules/bootstrap/resources/instance.yaml.tftpl
+++ b/infrastructure/modules/bootstrap/resources/instance.yaml.tftpl
@@ -18,6 +18,15 @@ instance:
     ref: refs/heads/main
     provider: generic
     pullSecret: flux-system
+  kustomize:
+    patches:
+      - target:
+          kind: Deployment
+          name: source-controller
+        patch: |
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --helm-cache-max-size=16
 healthcheck:
   enabled: true
 

--- a/kubernetes/platform/charts/metrics-server.yaml
+++ b/kubernetes/platform/charts/metrics-server.yaml
@@ -1,0 +1,9 @@
+---
+# https://raw.githubusercontent.com/kubernetes-sigs/metrics-server/master/charts/metrics-server/values.yaml
+priorityClassName: system-cluster-critical
+replicas: 2
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+serviceMonitor:
+  enabled: true

--- a/kubernetes/platform/helm-charts.yaml
+++ b/kubernetes/platform/helm-charts.yaml
@@ -42,6 +42,13 @@ spec:
         version: "${descheduler_version}"
         url: "https://kubernetes-sigs.github.io/descheduler"
       dependsOn: [cilium]
+    - name: "metrics-server"
+      namespace: "kube-system"
+      chart:
+        name: "metrics-server"
+        version: "${metrics_server_version}"
+        url: "https://kubernetes-sigs.github.io/metrics-server"
+      dependsOn: [cilium]
     - name: longhorn
       namespace: longhorn-system
       chart:

--- a/kubernetes/platform/kustomization.yaml
+++ b/kubernetes/platform/kustomization.yaml
@@ -30,6 +30,7 @@ configMapGenerator:
       - kube-prometheus-stack-crds.yaml=charts/kube-prometheus-stack-crds.yaml
       - kube-prometheus-stack.yaml=charts/kube-prometheus-stack.yaml
       - longhorn.yaml=charts/longhorn.yaml
+      - metrics-server.yaml=charts/metrics-server.yaml
       - alloy.yaml=charts/alloy.yaml
       - reloader.yaml=charts/reloader.yaml
       - replicator.yaml=charts/replicator.yaml

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -25,6 +25,8 @@ cert_manager_version=1.19.3
 external_secrets_version=2.0.0
 # renovate: datasource=helm depName=descheduler registryUrl=https://kubernetes-sigs.github.io/descheduler
 descheduler_version=0.34.0
+# renovate: datasource=helm depName=metrics-server registryUrl=https://kubernetes-sigs.github.io/metrics-server
+metrics_server_version=3.13.0
 # renovate: datasource=helm depName=longhorn registryUrl=https://charts.longhorn.io
 longhorn_version=1.11.0
 # renovate: datasource=helm depName=reloader registryUrl=https://stakater.github.io/stakater-charts


### PR DESCRIPTION
## Summary
- Deploy metrics-server to register the `metrics.k8s.io` API, unblocking HPA for istiod and Longhorn resource metrics
- Increase Flux source-controller `--helm-cache-max-size` from 10 (small profile default) to 16, eliminating repeated "Cache is full" log warnings across 13 unique HTTP HelmRepositories

## Test plan
- [ ] `task k8s:validate` passes
- [ ] After merge, verify metrics-server pods are running: `kubectl get pods -n kube-system -l app.kubernetes.io/name=metrics-server`
- [ ] Verify `kubectl top nodes` returns metrics
- [ ] Verify istiod HPA shows CPU values instead of `<unknown>`
- [ ] Flux source-controller cache: requires `task tg:apply-<stack>` to update the FluxInstance on each cluster
- [ ] After FluxInstance update, verify no more "Cache is full" log entries: `kubectl logs -n flux-system deploy/source-controller | grep "Cache is full"`