### PR TITLE
fix(k8s): prevent CNPG WAL archiving race with garage-config wait

### DIFF
--- a/kubernetes/platform/config.yaml
+++ b/kubernetes/platform/config.yaml
@@ -34,6 +34,7 @@ spec:
       namespace: garage
       path: kubernetes/platform/config/garage
       dependsOn: [garage-operator, canary-checker]
+      wait: true
     - name: gateway
       namespace: istio-gateway
       path: kubernetes/platform/config/gateway
@@ -93,6 +94,9 @@ spec:
       <<- end >>
       <<- end >>
       interval: 10m
+      <<- if (index inputs "wait") >>
+      wait: true
+      <<- end >>
       path: << inputs.path >>
       prune: true
       sourceRef:


### PR DESCRIPTION
## Summary

- CNPG WAL archiving permanently fails with "cache miss" because the instance manager's S3 credential cache is populated once at startup and never retried on failure (upstream bug cloudnative-pg/cloudnative-pg#6031)
- The root cause is a race condition: Flux marks `garage-config` as Ready when GarageKey CRs are applied, but the Garage operator takes ~2 minutes to create the actual S3 credentials secret -- by which time CNPG pods have already started with empty caches
- Adding `wait: true` to `garage-config` ensures Flux waits for GarageKey CRs to reach Ready status (secret created) before unblocking dependent Kustomizations like `database-config`

## Test plan

- [ ] `task k8s:validate` passes (verified locally)
- [ ] After merge and deploy, restart the CNPG `platform-1` pod on dev and live clusters to clear stale cache
- [ ] Verify WAL archiving resumes: `kubectl -n database get cluster platform -o jsonpath='{.status.conditions}'` shows ContinuousArchiving=True
- [ ] Verify scheduled backup completes successfully