### PR TITLE
refactor(k8s): separate operators into dedicated namespaces

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -129,7 +129,7 @@ configMap:
         subdomain: auth
     redis:
       enabled: true
-      host: platform.database.svc.cluster.local
+      host: dragonfly.cache.svc.cluster.local
       port: 6379
       password:
         secret_name: dragonfly-password

--- a/kubernetes/clusters/live/charts/immich.yaml
+++ b/kubernetes/clusters/live/charts/immich.yaml
@@ -20,7 +20,7 @@ controllers:
               secretKeyRef:
                 name: cnpg-immich-database-app
                 key: password
-          REDIS_HOSTNAME: dragonfly.database.svc.cluster.local
+          REDIS_HOSTNAME: dragonfly.cache.svc.cluster.local
           REDIS_PORT: "6379"
           REDIS_PASSWORD:
             valueFrom:

--- a/kubernetes/clusters/live/config/authelia-prereqs/dragonfly-secret-replication.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/dragonfly-secret-replication.yaml
@@ -5,5 +5,5 @@ metadata:
   name: dragonfly-password
   namespace: authelia
   annotations:
-    replicator.v1.mittwald.de/replicate-from: database/dragonfly-password
+    replicator.v1.mittwald.de/replicate-from: cache/dragonfly-password
 data: { }

--- a/kubernetes/clusters/live/config/immich/dragonfly-secret-replication.yaml
+++ b/kubernetes/clusters/live/config/immich/dragonfly-secret-replication.yaml
@@ -5,5 +5,5 @@ metadata:
   name: dragonfly-password
   namespace: immich
   annotations:
-    replicator.v1.mittwald.de/replicate-from: database/dragonfly-password
+    replicator.v1.mittwald.de/replicate-from: cache/dragonfly-password
 data: { }

--- a/kubernetes/platform/CLAUDE.md
+++ b/kubernetes/platform/CLAUDE.md
@@ -118,8 +118,8 @@ Namespaces use PodSecurity admission to enforce security profiles. The `namespac
 
 | Level | Namespaces | Implications |
 |-------|-----------|--------------|
-| `restricted` | cert-manager, external-secrets, system, database, kromgo | Strictest: requires full security context on all pods |
-| `baseline` | istio-gateway, garage | Moderate: allows some elevated capabilities (e.g., `NET_BIND_SERVICE`) |
+| `restricted` | cert-manager, cnpg-system, dragonfly-system, external-secrets, system, database, kromgo | Strictest: requires full security context on all pods |
+| `baseline` | istio-gateway, cache, garage, garage-system | Moderate: allows some elevated capabilities (e.g., `NET_BIND_SERVICE`) |
 | `privileged` | kube-system, longhorn-system, istio-system, monitoring, spegel, system-upgrade | Unrestricted: host access, BPF, privileged containers |
 
 ### Required Security Context for `restricted` Namespaces

--- a/kubernetes/platform/config.yaml
+++ b/kubernetes/platform/config.yaml
@@ -47,7 +47,7 @@ spec:
       path: kubernetes/platform/config/database
       dependsOn: [cloudnative-pg, garage-config, canary-checker]
     - name: dragonfly-config
-      namespace: database
+      namespace: cache
       path: kubernetes/platform/config/dragonfly
       dependsOn: [dragonfly-operator, garage-config, canary-checker]
     - name: kromgo-config

--- a/kubernetes/platform/config/CLAUDE.md
+++ b/kubernetes/platform/config/CLAUDE.md
@@ -14,7 +14,7 @@ For Flux patterns and version management, see [kubernetes/platform/CLAUDE.md](..
 | `certs/` | TLS certificates for gateways | Certificate |
 | `cilium/` | Load balancer config, L2 announcements | CiliumLoadBalancerIPPool, CiliumL2AnnouncementPolicy |
 | `database/` | Shared PostgreSQL cluster | Cluster, Pooler (CNPG) |
-| `dragonfly/` | Shared Dragonfly (Redis) instance | Dragonfly, Secret, CiliumNetworkPolicy, PrometheusRule |
+| `dragonfly/` | Shared Dragonfly (Redis) cache (deployed to `cache` namespace) | Dragonfly, Secret, PrometheusRule |
 | `flux-notifications/` | Flux alert providers and routing | Provider, Alert |
 | `garage/` | S3-compatible object storage | GarageCluster |
 | `gateway/` | Gateway API resources and WAF | Gateway, HTTPRoute, WasmPlugin |
@@ -252,6 +252,8 @@ Multiple namespaces enforce the PodSecurity `restricted` profile, which requires
 | Namespace | Why Restricted |
 |-----------|---------------|
 | `cert-manager` | Standard controller, no privileged requirements |
+| `cnpg-system` | CNPG operator, no privileged requirements |
+| `dragonfly-system` | Dragonfly operator, no privileged requirements |
 | `external-secrets` | Standard controller, no privileged requirements |
 | `system` | Standard controller workloads |
 | `database` | CNPG PostgreSQL pods run as non-root |

--- a/kubernetes/platform/config/canary-checker/platform-health.yaml
+++ b/kubernetes/platform/config/canary-checker/platform-health.yaml
@@ -78,7 +78,7 @@ spec:
     - name: cnpg-operator-healthy
       kind: Pod
       namespaceSelector:
-        name: database
+        name: cnpg-system
       resource:
         labelSelector: app.kubernetes.io/name=cloudnative-pg
       test:

--- a/kubernetes/platform/config/dragonfly/prometheus-rules.yaml
+++ b/kubernetes/platform/config/dragonfly/prometheus-rules.yaml
@@ -11,7 +11,7 @@ spec:
     - name: dragonfly.rules
       rules:
         - alert: DragonflyDown
-          expr: up{app="dragonfly", namespace="database"} == 0
+          expr: up{app="dragonfly", namespace="cache"} == 0
           for: 2m
           labels:
             severity: critical
@@ -20,8 +20,8 @@ spec:
 
         - alert: DragonflyHighMemoryUsage
           expr: |
-            (dragonfly_used_memory_bytes{namespace="database"}
-            / dragonfly_maxmemory_bytes{namespace="database"}) > 0.9
+            (dragonfly_used_memory_bytes{namespace="cache"}
+            / dragonfly_maxmemory_bytes{namespace="cache"}) > 0.9
           for: 5m
           labels:
             severity: warning
@@ -30,8 +30,8 @@ spec:
 
         - alert: DragonflyHighMemoryUsageCritical
           expr: |
-            (dragonfly_used_memory_bytes{namespace="database"}
-            / dragonfly_maxmemory_bytes{namespace="database"}) > 0.95
+            (dragonfly_used_memory_bytes{namespace="cache"}
+            / dragonfly_maxmemory_bytes{namespace="cache"}) > 0.95
           for: 2m
           labels:
             severity: critical
@@ -40,8 +40,8 @@ spec:
 
         - alert: DragonflyReplicationBroken
           expr: |
-            dragonfly_connected_replicas{namespace="database"}
-            < (dragonfly_total_replicas{namespace="database"} - 1)
+            dragonfly_connected_replicas{namespace="cache"}
+            < (dragonfly_total_replicas{namespace="cache"} - 1)
           for: 5m
           labels:
             severity: critical

--- a/kubernetes/platform/config/garage/dragonfly-key.yaml
+++ b/kubernetes/platform/config/garage/dragonfly-key.yaml
@@ -12,4 +12,4 @@ spec:
       write: true
   secretTemplate:
     name: dragonfly-s3-credentials
-    namespace: database
+    namespace: cache

--- a/kubernetes/platform/config/infrastructure-policies/cnpg-system.yaml
+++ b/kubernetes/platform/config/infrastructure-policies/cnpg-system.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cnpg-system-default
+  namespace: cnpg-system
+spec:
+  description: "Allow CNPG operator: K8s API access, webhook ingress, Prometheus scraping"
+  endpointSelector: { }
+  ingress:
+    # Allow Prometheus scraping
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # Allow webhooks from K8s API server (CNPG operator admission webhooks)
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "9443"
+              protocol: TCP
+  egress:
+    # Allow Kubernetes API access (6443 for node IPs, 443 for ClusterIP service)
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/platform/config/infrastructure-policies/dragonfly-system.yaml
+++ b/kubernetes/platform/config/infrastructure-policies/dragonfly-system.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: dragonfly-system-default
+  namespace: dragonfly-system
+spec:
+  description: "Allow Dragonfly operator: K8s API access, Prometheus scraping"
+  endpointSelector: { }
+  ingress:
+    # Allow Prometheus scraping
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # Allow Kubernetes API access (6443 for node IPs, 443 for ClusterIP service)
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/platform/config/infrastructure-policies/garage-system.yaml
+++ b/kubernetes/platform/config/infrastructure-policies/garage-system.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: garage-system-default
+  namespace: garage-system
+spec:
+  description: "Allow Garage operator: K8s API access, Prometheus scraping, admin API to garage namespace"
+  endpointSelector: { }
+  ingress:
+    # Allow Prometheus scraping
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # Allow Kubernetes API access (6443 for node IPs, 443 for ClusterIP service)
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+    # Allow admin API calls to Garage instances in garage namespace
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: garage
+      toPorts:
+        - ports:
+            - port: "3903"
+              protocol: TCP

--- a/kubernetes/platform/config/infrastructure-policies/kustomization.yaml
+++ b/kubernetes/platform/config/infrastructure-policies/kustomization.yaml
@@ -4,8 +4,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cert-manager.yaml
+  - cnpg-system.yaml
+  - dragonfly-system.yaml
   - external-secrets.yaml
   - flux-system.yaml
+  - garage-system.yaml
   - istio-system.yaml
   - kube-system.yaml
   - spegel.yaml

--- a/kubernetes/platform/config/network-policy/CLAUDE.md
+++ b/kubernetes/platform/config/network-policy/CLAUDE.md
@@ -50,8 +50,8 @@ network-policy/
 │   ├── profile-internal-egress.yaml  # Internal gateway + HTTPS egress
 │   └── profile-standard.yaml      # Both gateways + HTTPS egress
 ├── platform/            # Hand-crafted CNPs for platform namespaces
-│   ├── database.yaml              # CloudNative-PG operator + clusters
-│   ├── database-dragonfly.yaml    # Dragonfly (Redis) instances
+│   ├── cache.yaml                 # Dragonfly (Redis) cache instances
+│   ├── database.yaml              # CloudNative-PG data plane (clusters + poolers)
 │   ├── garage.yaml                # Garage S3 storage
 │   ├── istio-gateway.yaml         # Istio ingress gateways
 │   ├── kromgo.yaml                # Kromgo status badges
@@ -59,6 +59,7 @@ network-policy/
 │   ├── monitoring.yaml            # Prometheus, Grafana, Alertmanager, Loki
 │   └── system-upgrade.yaml        # Tuppr upgrade controller
 ├── shared-resources/    # Opt-in access to shared services
+│   ├── access-dragonfly.yaml      # Dragonfly (Redis) access
 │   ├── access-postgres.yaml       # Database access
 │   └── access-garage-s3.yaml      # Object storage access
 └── kustomization.yaml
@@ -97,7 +98,7 @@ Namespaces can opt-in to additional capabilities via labels:
 | Label | Capability |
 |-------|------------|
 | `access.network-policy.homelab/kube-api=true` | Egress to Kubernetes API (port 6443) |
-| `access.network-policy.homelab/dragonfly=true` | Egress to Dragonfly in database namespace (port 6379) |
+| `access.network-policy.homelab/dragonfly=true` | Egress to Dragonfly in cache namespace (port 6379) |
 | `access.network-policy.homelab/postgres=true` | Egress to PostgreSQL in database namespace (port 5432) |
 | `access.network-policy.homelab/garage-s3=true` | Egress to Garage S3 in garage namespace (port 3900) |
 

--- a/kubernetes/platform/config/network-policy/platform/cache.yaml
+++ b/kubernetes/platform/config/network-policy/platform/cache.yaml
@@ -3,14 +3,11 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: database-dragonfly
-  namespace: database
+  name: cache-default
+  namespace: cache
 spec:
-  description: "Allow Dragonfly: Redis connections from labeled namespaces, replication, metrics, S3 backup"
-  endpointSelector:
-    matchLabels:
-      app: dragonfly
-      app.kubernetes.io/name: dragonfly
+  description: "Allow Dragonfly cache: Redis connections from labeled namespaces, replication, S3 snapshots"
+  endpointSelector: { }
   ingress:
     # Redis connections from namespaces with dragonfly access label
     - fromEndpoints:
@@ -22,21 +19,30 @@ spec:
         - ports:
             - port: "6379"
               protocol: TCP
-    # Intra-namespace (master <-> replicas, operator management)
+    # Intra-namespace (master <-> replicas)
     - fromEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: database
+            io.kubernetes.pod.namespace: cache
       toPorts:
         - ports:
             - port: "6379"
               protocol: TCP
             - port: "9999"
               protocol: TCP
+    # Allow Prometheus scraping
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "9999"
+              protocol: TCP
   egress:
     # Intra-namespace (replication)
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: database
+            io.kubernetes.pod.namespace: cache
       toPorts:
         - ports:
             - port: "6379"

--- a/kubernetes/platform/config/network-policy/platform/database.yaml
+++ b/kubernetes/platform/config/network-policy/platform/database.yaml
@@ -6,7 +6,7 @@ metadata:
   name: database-default
   namespace: database
 spec:
-  description: "Allow CloudNative-PG: PostgreSQL connections from labeled namespaces, S3 backup, replication"
+  description: "Allow CloudNative-PG data plane: PostgreSQL connections from labeled namespaces, S3 backup, replication"
   endpointSelector: { }
   ingress:
     # Allow PostgreSQL connections from namespaces with postgres access label
@@ -19,7 +19,7 @@ spec:
         - ports:
             - port: "5432"
               protocol: TCP
-    # Allow intra-namespace communication (primary <-> replicas, operator)
+    # Allow intra-namespace communication (primary <-> replicas)
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: database
@@ -38,23 +38,7 @@ spec:
         - ports:
             - port: "9187"
               protocol: TCP
-    # Allow webhooks from K8s API server (CNPG operator)
-    - fromEntities:
-        - kube-apiserver
-      toPorts:
-        - ports:
-            - port: "9443"
-              protocol: TCP
   egress:
-    # Allow Kubernetes API access (operator) - 6443 for node IPs, 443 for ClusterIP service
-    - toEntities:
-        - kube-apiserver
-      toPorts:
-        - ports:
-            - port: "6443"
-              protocol: TCP
-            - port: "443"
-              protocol: TCP
     # Allow S3 backup to Garage
     - toEndpoints:
         - matchLabels:

--- a/kubernetes/platform/config/network-policy/platform/garage.yaml
+++ b/kubernetes/platform/config/network-policy/platform/garage.yaml
@@ -6,7 +6,7 @@ metadata:
   name: garage-default
   namespace: garage
 spec:
-  description: "Allow Garage S3: API from labeled namespaces, inter-node replication, admin API"
+  description: "Allow Garage S3 data plane: API from labeled namespaces, inter-node replication, admin API"
   endpointSelector: { }
   ingress:
     # Allow S3 API from namespaces with garage-s3 access label
@@ -19,12 +19,14 @@ spec:
         - ports:
             - port: "3900"
               protocol: TCP
-    # Allow S3 API from platform namespaces that need backups (longhorn, database)
+    # Allow S3 API from platform namespaces that need backups (longhorn, database, cache)
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: longhorn-system
         - matchLabels:
             io.kubernetes.pod.namespace: database
+        - matchLabels:
+            io.kubernetes.pod.namespace: cache
       toPorts:
         - ports:
             - port: "3900"
@@ -37,13 +39,15 @@ spec:
         - ports:
             - port: "3901"
               protocol: TCP
-    # Allow Prometheus scraping and operator admin API access
+    # Allow Prometheus scraping, operator admin API access, and intra-namespace admin
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: monitoring
             app.kubernetes.io/name: prometheus
         - matchLabels:
             io.kubernetes.pod.namespace: garage
+        - matchLabels:
+            io.kubernetes.pod.namespace: garage-system
       toPorts:
         - ports:
             - port: "3903"
@@ -57,7 +61,7 @@ spec:
             - port: "3903"
               protocol: TCP
   egress:
-    # Allow inter-node RPC replication and operator admin API calls
+    # Allow inter-node RPC replication and intra-namespace admin API calls
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: garage
@@ -66,13 +70,4 @@ spec:
             - port: "3901"
               protocol: TCP
             - port: "3903"
-              protocol: TCP
-    # Allow Kubernetes API access (6443 for node IPs, 443 for ClusterIP service)
-    - toEntities:
-        - kube-apiserver
-      toPorts:
-        - ports:
-            - port: "6443"
-              protocol: TCP
-            - port: "443"
               protocol: TCP

--- a/kubernetes/platform/config/network-policy/platform/kustomization.yaml
+++ b/kubernetes/platform/config/network-policy/platform/kustomization.yaml
@@ -3,8 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - cache.yaml
   - database.yaml
-  - database-dragonfly.yaml
   - garage.yaml
   - istio-gateway.yaml
   - kromgo.yaml

--- a/kubernetes/platform/config/network-policy/shared-resources/access-dragonfly.yaml
+++ b/kubernetes/platform/config/network-policy/shared-resources/access-dragonfly.yaml
@@ -6,8 +6,8 @@ metadata:
   name: access-dragonfly-egress
 spec:
   description: >-
-    Allow namespaces with dragonfly access label to egress to Dragonfly in database namespace.
-    Corresponding ingress rule is in the database namespace CNP.
+    Allow namespaces with dragonfly access label to egress to Dragonfly in cache namespace.
+    Corresponding ingress rule is in the cache namespace CNP.
     Usage: Add label access.network-policy.homelab/dragonfly=true to namespace.
   endpointSelector:
     matchExpressions:
@@ -17,7 +17,7 @@ spec:
   egress:
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: database
+            io.kubernetes.pod.namespace: cache
       toPorts:
         - ports:
             - port: "6379"

--- a/kubernetes/platform/config/tuppr/kubernetes-upgrade.yaml
+++ b/kubernetes/platform/config/tuppr/kubernetes-upgrade.yaml
@@ -43,7 +43,7 @@ spec:
     - apiVersion: dragonflydb.io/v1alpha1
       kind: Dragonfly
       name: dragonfly
-      namespace: database
+      namespace: cache
       description: Dragonfly must be ready and not in a rolling update
       expr: |
         status.phase == 'ready' &&

--- a/kubernetes/platform/config/tuppr/talos-upgrade.yaml
+++ b/kubernetes/platform/config/tuppr/talos-upgrade.yaml
@@ -46,7 +46,7 @@ spec:
     - apiVersion: dragonflydb.io/v1alpha1
       kind: Dragonfly
       name: dragonfly
-      namespace: database
+      namespace: cache
       description: Dragonfly must be ready and not in a rolling update
       expr: |
         status.phase == 'ready' &&

--- a/kubernetes/platform/helm-charts.yaml
+++ b/kubernetes/platform/helm-charts.yaml
@@ -148,21 +148,21 @@ spec:
         url: https://istio-release.storage.googleapis.com/charts
       dependsOn: [istio-base, istiod, istio-cni]
     - name: garage-operator
-      namespace: garage
+      namespace: garage-system
       chart:
         name: garage-operator
         version: "${garage_operator_version}"
         url: oci://ghcr.io/rajsinghtech/charts
       dependsOn: [cilium]
     - name: cloudnative-pg
-      namespace: database
+      namespace: cnpg-system
       chart:
         name: cloudnative-pg
         version: "${cloudnative_pg_version}"
         url: https://cloudnative-pg.github.io/charts
       dependsOn: [cilium, longhorn, kube-prometheus-stack-crds, secret-generator]
     - name: dragonfly-operator
-      namespace: database
+      namespace: dragonfly-system
       chart:
         name: dragonfly-operator
         version: "${dragonfly_operator_version}"

--- a/kubernetes/platform/namespaces.yaml
+++ b/kubernetes/platform/namespaces.yaml
@@ -22,7 +22,15 @@ spec:
       dataplane: ambient
       security: restricted
       networkPolicy: false
+    - name: cnpg-system
+      dataplane: ambient
+      security: restricted
+      networkPolicy: false
     - name: database
+      dataplane: ambient
+      security: restricted
+      networkPolicy: false
+    - name: dragonfly-system
       dataplane: ambient
       security: restricted
       networkPolicy: false
@@ -31,11 +39,19 @@ spec:
       security: restricted
       networkPolicy: false
     # --- baseline: require some elevated capabilities (e.g. NET_BIND_SERVICE) ---
+    - name: cache
+      dataplane: ambient
+      security: baseline
+      networkPolicy: false
     - name: istio-gateway
       dataplane: ambient
       security: baseline
       networkPolicy: false
     - name: garage
+      dataplane: ambient
+      security: baseline
+      networkPolicy: false
+    - name: garage-system
       dataplane: ambient
       security: baseline
       networkPolicy: false


### PR DESCRIPTION
## Summary
- Separate CNPG, Dragonfly, and Garage operators into dedicated `-system` namespaces (`cnpg-system`, `dragonfly-system`, `garage-system`) so network policies can enforce precise control-plane vs data-plane boundaries
- Move Dragonfly data plane from `database` to a new `cache` namespace, giving it a clean network identity and independent policy surface
- Fix Authelia redis host which was incorrectly pointing to the CNPG pooler service name instead of Dragonfly

## Test plan
- [x] `task k8s:validate` passes (YAML lint, ResourceSet expansion, Helm templating, kubeconform schema validation, API deprecation check)
- [ ] Integration cluster deploys successfully after merge
- [ ] Verify operator pods are running in new `-system` namespaces
- [ ] Verify Dragonfly instance is running in `cache` namespace
- [ ] Verify cross-namespace secret replication works (dragonfly-password replicated from `cache`)
- [ ] Verify Authelia and Immich can connect to Dragonfly at new address
- [ ] Verify Prometheus scraping works for all operator and data-plane namespaces
- [ ] Verify network policies allow expected traffic and block unexpected traffic via Hubble