### PR TITLE
fix(platform): resolve database outage and metrics-server failure

### DIFF
--- a/kubernetes/platform/charts/metrics-server.yaml
+++ b/kubernetes/platform/charts/metrics-server.yaml
@@ -2,6 +2,8 @@
 # https://raw.githubusercontent.com/kubernetes-sigs/metrics-server/master/charts/metrics-server/values.yaml
 priorityClassName: system-cluster-critical
 replicas: 2
+args:
+  - --kubelet-insecure-tls
 podDisruptionBudget:
   enabled: true
   minAvailable: 1

--- a/kubernetes/platform/config/network-policy/platform/database.yaml
+++ b/kubernetes/platform/config/network-policy/platform/database.yaml
@@ -39,6 +39,15 @@ spec:
             - port: "9187"
               protocol: TCP
   egress:
+    # Allow Kubernetes API access (CNPG upgrade jobs poll cluster status)
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
     # Allow S3 backup to Garage
     - toEndpoints:
         - matchLabels:


### PR DESCRIPTION
## Summary
- **P1**: Add kube-apiserver egress to the database namespace CNP so CNPG major upgrade jobs can poll cluster status -- without this, the PostgreSQL 17-to-18 upgrade job is blocked by Cilium and no database instance pods are running
- **P2**: Add `--kubelet-insecure-tls` to metrics-server args because Talos kubelet certificates do not include IP SANs, causing TLS verification failures and a Stalled HelmRelease

## Test plan
- [x] `task k8s:validate` passes
- [ ] After merge, verify CNPG upgrade job completes and PostgreSQL pods come up in integration
- [ ] After merge, verify metrics-server HelmRelease transitions from Stalled to Ready in integration