### PR TITLE
fix(platform): load both default and custom SNMP exporter modules

### DIFF
--- a/kubernetes/platform/charts/prometheus-snmp-exporter.yaml
+++ b/kubernetes/platform/charts/prometheus-snmp-exporter.yaml
@@ -3,12 +3,13 @@
 priorityClassName: platform
 serviceMonitor:
   enabled: false  # Using standalone ScrapeConfig for Flux variable substitution
-# Mount CyberPower SNMP module config alongside the default snmp.yml
+# Load all SNMP configs via glob: the built-in /etc/snmp_exporter/snmp.yml
+# (provides if_mib, etc.) plus the custom cyberpower module mounted alongside it.
 extraArgs:
-  - "--config.file=/etc/snmp_exporter_custom/snmp.yml"
+  - "--config.file=/etc/snmp_exporter/*.yml"
 extraConfigmapMounts:
   - name: cyberpower-snmp-config
-    mountPath: /etc/snmp_exporter_custom/snmp.yml
+    mountPath: /etc/snmp_exporter/cyberpower.yml
     subPath: snmp.yml
     configMap: snmp-exporter-cyberpower-config
     readOnly: true


### PR DESCRIPTION
## Summary
- The SNMP exporter's `--config.file` was overridden to point only to the custom CyberPower config, which dropped the built-in `if_mib` module required by IPMI hardware monitoring scrape targets
- Uses the snmp_exporter's glob pattern support (`*.yml`) to load both the default config and the custom CyberPower module from the same directory

## Test plan
- [x] `task k8s:validate` passes
- [ ] After merge, verify `if_mib` scrape targets return metrics in Prometheus (`up{job="snmp-exporter-targets"}`)
- [ ] Verify `cyberpower` UPS scrape targets still return metrics (`up{job="snmp-exporter-ups-targets"}`)