### PR TITLE
fix(platform): resolve Authelia startup failures

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -10,10 +10,14 @@ pod:
     - name: oidc-jwk
       mountPath: /secrets/oidc-jwk
       readOnly: true
+    - name: notification
+      mountPath: /config
   extraVolumes:
     - name: oidc-jwk
       secret:
         secretName: authelia-oidc-jwk
+    - name: notification
+      emptyDir: { }
   securityContext:
     pod:
       runAsNonRoot: true
@@ -100,7 +104,7 @@ configMap:
     ldap:
       enabled: true
       implementation: custom
-      address: ldap://lldap-app.authelia.svc.cluster.local:3890
+      address: ldap://lldap.authelia.svc.cluster.local:3890
       base_dn: dc=homelab,dc=local
       additional_users_dn: ou=people
       users_filter: "(&(|({username_attribute}={input})({email_attribute}={input}))(objectClass=person))"

--- a/kubernetes/clusters/live/config/authelia/lldap-route.yaml
+++ b/kubernetes/clusters/live/config/authelia/lldap-route.yaml
@@ -13,5 +13,5 @@ spec:
     - "lldap.${internal_domain}"
   rules:
     - backendRefs:
-        - name: lldap-app
+        - name: lldap
           port: 17170

--- a/kubernetes/platform/config/database/pooler.yaml
+++ b/kubernetes/platform/config/database/pooler.yaml
@@ -13,5 +13,6 @@ spec:
     parameters:
       max_client_conn: "1000"
       default_pool_size: "25"
+      ignore_startup_parameters: search_path
   monitoring:
     enablePodMonitor: true


### PR DESCRIPTION
## Summary
- PgBouncer rejects pgx driver's `search_path` startup parameter in transaction pooling mode — add `ignore_startup_parameters` to Pooler spec
- Authelia LDAP config referenced `lldap-app` but app-template v3 names the service `lldap` — fix service references in chart values and HTTPRoute
- Filesystem notifier needs writable `/config` but container enforces `readOnlyRootFilesystem` — mount emptyDir

## Test plan
- [ ] Authelia pod exits CrashLoopBackOff and reaches Running state
- [ ] LDAP authentication works (login to Authelia)
- [ ] LLDAP admin UI accessible via internal gateway route
- [ ] OIDC flow with Grafana works