### PR TITLE
fix(network): correct game server network policy profiles

### DIFF
--- a/kubernetes/clusters/live/config/factorio/namespace.yaml
+++ b/kubernetes/clusters/live/config/factorio/namespace.yaml
@@ -8,4 +8,4 @@ metadata:
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/warn: restricted
-    network-policy.homelab/profile: isolated
+    network-policy.homelab/profile: internal-egress

--- a/kubernetes/clusters/live/config/satisfactory/network-policy.yaml
+++ b/kubernetes/clusters/live/config/satisfactory/network-policy.yaml
@@ -6,7 +6,7 @@ metadata:
   name: satisfactory-game-server
   namespace: satisfactory
 spec:
-  description: "Allow Satisfactory: UDP/TCP 7777 ingress from internet"
+  description: "Satisfactory: game traffic ingress + HTTP egress for SteamCMD downloads"
   endpointSelector: { }
   ingress:
     - fromEntities:
@@ -16,4 +16,12 @@ spec:
             - port: "7777"
               protocol: UDP
             - port: "7777"
+              protocol: TCP
+  egress:
+    # SteamCMD requires HTTP (port 80) for game file downloads from Steam CDN
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "80"
               protocol: TCP


### PR DESCRIPTION
## Summary
- Factorio had `isolated` profile blocking HTTPS egress to `auth.factorio.com` — upgrade to `internal-egress`
- Satisfactory's SteamCMD needs HTTP/80 egress for CDN downloads but no profile allows it — add namespace-scoped CNP egress rule

## Test plan
- [ ] Factorio server authenticates with `auth.factorio.com` and stays running
- [ ] Satisfactory SteamCMD downloads game files without `SSL_ERROR_SYSCALL`
- [ ] `hubble observe --verdict DROPPED --namespace factorio` shows no auth-related drops
- [ ] `hubble observe --verdict DROPPED --namespace satisfactory` shows no HTTP/80 drops