### PR TITLE
fix(apps): correct container image tags for pxe-boot and valheim

### DIFF
--- a/kubernetes/clusters/live/charts/pxe-boot.yaml
+++ b/kubernetes/clusters/live/charts/pxe-boot.yaml
@@ -9,7 +9,7 @@ controllers:
     containers:
       app:
         image:
-          repository: ghcr.io/netbootxyz/netbootxyz
+          repository: netbootxyz/netbootxyz
           tag: "${netbootxyz_version}"
         env:
           # Keep all TFTP traffic on port 69 (essential for LoadBalancer compatibility)

--- a/kubernetes/clusters/live/charts/valheim.yaml
+++ b/kubernetes/clusters/live/charts/valheim.yaml
@@ -19,7 +19,7 @@ controllers:
         image:
           repository: ghcr.io/lloesche/valheim-server
           # renovate: datasource=docker depName=ghcr.io/lloesche/valheim-server
-          tag: latest@sha256:0ceab2ad3a524a76e9a3edfc0e1e7ddab2cbdbc7ef7ae93ccc62e5ad65da8e09
+          tag: latest
         env:
           # Server configuration
           SERVER_NAME: "Valheim Dedicated"

--- a/kubernetes/clusters/live/config/valheim/namespace.yaml
+++ b/kubernetes/clusters/live/config/valheim/namespace.yaml
@@ -8,3 +8,4 @@ metadata:
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/warn: restricted
+    network-policy.homelab/profile: internal-egress

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -79,8 +79,8 @@ authelia_version=0.10.49
 lldap_version=v0.6.2
 # renovate: datasource=docker depName=satisfactory-server packageName=wolveix/satisfactory-server
 satisfactory_server_version=v1.9.10
-# renovate: datasource=docker depName=netbootxyz packageName=ghcr.io/netbootxyz/netbootxyz
-netbootxyz_version=3.0.0
+# renovate: datasource=docker depName=netbootxyz packageName=netbootxyz/netbootxyz
+netbootxyz_version=0.7.6-nbxyz10
 
 # Talos Image Factory schematic ID for PXE boot (iscsi-tools + util-linux-tools)
 # Content-addressed hash — only changes when extensions change, not on version bumps


### PR DESCRIPTION
## Summary
- netbootxyz GHCR repo only publishes PR-based tags, not semver — switch to Docker Hub (`netbootxyz/netbootxyz`) which has proper releases (`0.7.6-nbxyz10`)
- Valheim `latest@sha256:0ceab2ad...` digest was garbage-collected — remove stale pin, Renovate will re-pin on next run
- Valheim namespace was missing `network-policy.homelab/profile` label — add `internal-egress` for Steam auth/update egress

## Test plan
- [ ] pxe-boot pod pulls `netbootxyz/netbootxyz:0.7.6-nbxyz10` successfully
- [ ] Valheim pod pulls `ghcr.io/lloesche/valheim-server:latest` and starts
- [ ] Renovate auto-creates PR to pin valheim digest on next scan
- [ ] `task renovate:validate` passes (verify annotation is correct)