### PR TITLE
docs(platform): enforce zero-alert-tolerance policy

### DIFF
--- a/.claude/agents/troubleshooter.md
+++ b/.claude/agents/troubleshooter.md
@@ -101,6 +101,15 @@ Present findings as a structured investigation report:
 3. [Nuclear option] — Risk: High
 ```
 
+# Alert Response Policy
+
+**Every firing alert demands immediate action.** When investigating, check for firing alerts early — they are critical signals, not background noise.
+
+- If you discover firing alerts during investigation, **always flag them to the user** — even if they appear unrelated to the current incident
+- An alert that is firing without a corresponding Silence CR is an operational gap that must be resolved
+- Recommend either **fixing the root cause** or **creating a declarative Silence CR** (last resort, requires justification)
+- Every cluster must maintain a **zero firing alerts baseline** (excluding Watchdog)
+
 # Boundaries
 
 - **NEVER** modify cluster resources (no `kubectl apply`, `kubectl delete`, `kubectl patch`)

--- a/.claude/skills/monitoring-authoring/SKILL.md
+++ b/.claude/skills/monitoring-authoring/SKILL.md
@@ -511,7 +511,8 @@ spec:
 
 - **Always include a comment** explaining why the silence exists (architectural limitation, expected behavior, etc.)
 - Every cluster must maintain a **zero firing alerts baseline** (excluding Watchdog)
-- Silences are a last resort -- prefer fixing the root cause over silencing
+- **Silences are a LAST RESORT** — every effort must be made to fix the root cause before resorting to a silence. Only silence when the alert genuinely cannot be fixed: architectural limitations (e.g., single-node Spegel), expected environmental behavior, or confirmed upstream bugs
+- **Never leave alerts firing without action** — either fix the cause or create a Silence CR. An ignored alert degrades trust in the entire monitoring system and leads to alert fatigue where real incidents get missed
 
 ### Adding a Silence to a Cluster
 

--- a/.claude/skills/sre/SKILL.md
+++ b/.claude/skills/sre/SKILL.md
@@ -28,6 +28,7 @@ user-invocable: false
 - **Read-Only Investigation** - Observe and analyze, never modify resources
 - **Multi-Source Correlation** - Combine logs, events, metrics for complete picture
 - **Research Unknown Services** - Check documentation before deep investigation
+- **Zero Alert Tolerance** - Every firing alert must be addressed immediately: fix the root cause, or as a last resort, create a declarative Silence CR with justification. Never ignore, defer, or dismiss a firing alert.
 
 ## The 5 Whys Analysis (CRITICAL)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,6 +307,29 @@ For dev cluster permissions, pre-flight checks, and safety procedures, see [.tas
 - **NEVER** apply changes directly to the cluster - always use the GitOps approach through Flux
 - **NEVER** hallucinate YAML fields - use `kubectl explain`, official docs, or YAML schema validation
 
+## Alert Response
+
+**Every firing alert demands immediate action. Ignored alerts are unacceptable.**
+
+A firing alert means something is wrong — either with the system or with the alert definition. Both require resolution:
+
+- **NEVER** ignore a firing alert — it erodes trust in the entire monitoring system
+- **NEVER** leave alerts firing "for now" or defer them as follow-up work
+- **NEVER** treat alerts as informational noise — if an alert isn't actionable, it's misconfigured
+- **ALWAYS** either **fix the root cause** or **create a declarative Silence CR** with a comment explaining why
+
+**Response priority:**
+1. **Fix the root cause** — this is always the correct first response
+2. **Create a declarative Silence CR** — LAST RESORT, only when the alert genuinely cannot be fixed (architectural limitation, expected behavior in this environment, upstream bug). The Silence must include a comment explaining the justification
+
+**Every cluster must maintain a zero firing alerts baseline** (excluding Watchdog, which validates Alertmanager health). If an alert is firing, the work is not done.
+
+**Invalid reasons to ignore an alert:**
+- "It's a known issue" — then silence it declaratively with a comment
+- "It doesn't affect anything" — then the alert is misconfigured; fix or silence it
+- "We'll fix it later" — fix it now, or silence it now with a tracked justification
+- "It's not related to my change" — it's still firing; investigate or flag it
+
 ## Verification
 
 - **NEVER** guess resource names, strings, IPs, or values - VERIFY against source files


### PR DESCRIPTION
## Summary

- Codifies the expectation that every firing alert must be immediately resolved or declaratively silenced — ignoring alerts is never acceptable
- Adds the policy at four layers (root CLAUDE.md, troubleshooter agent, SRE skill, monitoring-authoring skill) so every agent encounters it regardless of entry point

## Test plan

- [ ] Verify CI passes (documentation-only change)
- [ ] Confirm the troubleshooter agent references alert response policy when investigating incidents
- [ ] Confirm the implementer agent references alert response expectations when deploying apps