### PR TITLE
fix(platform): remove duplicate SNMP auth causing CrashLoopBackOff

### DIFF
--- a/kubernetes/platform/charts/prometheus-snmp-exporter.yaml
+++ b/kubernetes/platform/charts/prometheus-snmp-exporter.yaml
@@ -3,14 +3,18 @@
 priorityClassName: platform
 serviceMonitor:
   enabled: false  # Using standalone ScrapeConfig for Flux variable substitution
-# Load all SNMP configs via glob: the built-in /etc/snmp_exporter/snmp.yml
-# (provides if_mib, etc.) plus the custom cyberpower module mounted alongside it.
+# Load both the built-in /etc/snmp_exporter/snmp.yml (provides default auths
+# and modules like if_mib) and the custom cyberpower module mounted alongside
+# it. The custom file contains ONLY the cyberpower module definition; the
+# public_v2 auth it needs already exists in the default config. Using a glob
+# lets snmp_exporter merge maps from both files via sequential UnmarshalStrict
+# calls -- duplicate map keys across files cause startup failures.
 extraArgs:
   - "--config.file=/etc/snmp_exporter/*.yml"
 extraConfigmapMounts:
   - name: cyberpower-snmp-config
     mountPath: /etc/snmp_exporter/cyberpower.yml
-    subPath: snmp.yml
+    subPath: cyberpower.yml
     configMap: snmp-exporter-cyberpower-config
     readOnly: true
     defaultMode: 420

--- a/kubernetes/platform/config/monitoring/ups-monitoring-config.yaml
+++ b/kubernetes/platform/config/monitoring/ups-monitoring-config.yaml
@@ -7,14 +7,7 @@ kind: ConfigMap
 metadata:
   name: snmp-exporter-cyberpower-config
 data:
-  snmp.yml: |
-    auths:
-      public_v2:
-        community: public
-        security_level: noAuthNoPriv
-        auth_protocol: MD5
-        priv_protocol: DES
-        version: 2
+  cyberpower.yml: |
     modules:
       cyberpower:
         walk:


### PR DESCRIPTION
## Summary
- The prometheus-snmp-exporter pod is in CrashLoopBackOff because the custom CyberPower SNMP config duplicates the `auths.public_v2` key from the default `snmp.yml`, and the exporter's `yaml.UnmarshalStrict` rejects duplicate map keys when loading multiple files via glob
- Removed the redundant `auths` block from the custom config so it only contains the `cyberpower` module definition -- the `public_v2` auth already exists in the default config

## Test plan
- [x] `task k8s:validate` passes
- [ ] SNMP exporter pod starts without CrashLoopBackOff after merge
- [ ] UPS metrics (`upsAdvanceBatteryCapacity`, `upsAdvanceOutputLoad`) are scraped by Prometheus