### PR TITLE
fix(apps): use process check for Satisfactory startup probe

### DIFF
--- a/kubernetes/clusters/live/charts/satisfactory.yaml
+++ b/kubernetes/clusters/live/charts/satisfactory.yaml
@@ -36,9 +36,9 @@ controllers:
             spec:
               exec:
                 command:
-                  - /bin/sh
-                  - -c
-                  - test -f /config/gamefiles/FactoryGame.exe
+                  - pgrep
+                  - -f
+                  - FactoryServer
               initialDelaySeconds: 30
               periodSeconds: 15
               failureThreshold: 60


### PR DESCRIPTION
## Summary
- The startup probe checked for `FactoryGame.exe` (a Windows binary) which does not exist in the Linux container `wolveix/satisfactory-server`, causing the pod to be killed every 15 minutes (97+ restarts)
- Switch to `pgrep -f FactoryServer` which detects actual server startup and matches the existing liveness probe pattern

## Test plan
- [ ] Validated with `task k8s:validate`
- [ ] Pod stops crash-looping after deployment
- [ ] Startup probe passes once FactoryServer process is running
- [ ] Liveness probe continues to work as before