### PR TITLE
docs(platform): standardize on Mermaid diagrams

### DIFF
--- a/.claude/skills/self-improvement/SKILL.md
+++ b/.claude/skills/self-improvement/SKILL.md
@@ -161,6 +161,8 @@ Match the existing style:
 - Use bullet points for lists
 - Use code blocks for examples
 - Keep entries concise - this is reference material
+- Use Mermaid diagrams for flows, architectures, and decision trees — never create new ASCII art diagrams
+- See root CLAUDE.md "Diagram Standards" section for Mermaid type selection and formatting rules
 
 ### For skill additions
 

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -26,50 +26,42 @@ The promotion pipeline uses OCI artifacts for immutable, auditable deployments.
 
 ### Pipeline Flow
 
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                         PR merged to main                           │
-└─────────────────────────────────┬───────────────────────────────────┘
-                                  │
-                                  ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│  build-platform-artifact.yaml                                       │
-│  ├─ Discovers latest stable tag, bumps patch for next version       │
-│  ├─ flux push artifact → ghcr.io/.../platform:X.Y.Z-rc.N           │
-│  ├─ flux tag artifact → sha-<short-sha>                            │
-│  └─ flux tag artifact → integration-<short-sha>                    │
-└─────────────────────────────────┬───────────────────────────────────┘
-                                  │
-                                  ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│  Integration Cluster                                                │
-│  ├─ OCIRepository polls for semver ">= 0.0.0-0" (includes RCs)     │
-│  ├─ Detects new X.Y.Z-rc.N artifact (higher than last stable)      │
-│  └─ Flux reconciles platform                                        │
-└─────────────────────────────────┬───────────────────────────────────┘
-                                  │
-                                  ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│  Flux Alert (validation-success)                                     │
-│  ├─ Watches platform Kustomization for "Reconciliation finished"     │
-│  ├─ Provider posts commit status (context: kustomization/platform/*) │
-│  └─ Workflow has idempotency guard for repeated reconciliation events │
-└─────────────────────────────────┬───────────────────────────────────┘
-                                  │
-                                  ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│  tag-validated-artifact.yaml                                        │
-│  ├─ flux tag artifact → validated-<short-sha> (traceability)       │
-│  └─ flux tag artifact → X.Y.Z (stable semver, RC suffix stripped)  │
-└─────────────────────────────────┬───────────────────────────────────┘
-                                  │
-                                  ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│  Live Cluster                                                       │
-│  ├─ OCIRepository polls for semver ">= 0.0.0" (stable only)        │
-│  ├─ Detects new 0.1.N stable semver tag                            │
-│  └─ Flux reconciles platform (production deployment)                │
-└─────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    PR[PR merged to main] --> build
+
+    subgraph build["build-platform-artifact.yaml"]
+        B1["Discovers latest stable tag, bumps patch"] --> B2["flux push artifact → ghcr.io/.../platform:X.Y.Z-rc.N"]
+        B2 --> B3["flux tag artifact → sha-‹short-sha›"]
+        B3 --> B4["flux tag artifact → integration-‹short-sha›"]
+    end
+
+    build --> integ
+
+    subgraph integ["Integration Cluster"]
+        I1["OCIRepository polls for semver ≥ 0.0.0-0 (includes RCs)"] --> I2["Detects new X.Y.Z-rc.N artifact"]
+        I2 --> I3["Flux reconciles platform"]
+    end
+
+    integ --> alert
+
+    subgraph alert["Flux Alert (validation-success)"]
+        A1["Watches platform Kustomization for 'Reconciliation finished'"] --> A2["Provider posts commit status\n(context: kustomization/platform/*)"]
+        A2 --> A3["Idempotency guard for repeated events"]
+    end
+
+    alert --> tag
+
+    subgraph tag["tag-validated-artifact.yaml"]
+        T1["flux tag artifact → validated-‹short-sha›"] --> T2["flux tag artifact → X.Y.Z\n(stable semver, RC suffix stripped)"]
+    end
+
+    tag --> livecluster
+
+    subgraph livecluster["Live Cluster"]
+        L1["OCIRepository polls for semver ≥ 0.0.0 (stable only)"] --> L2["Detects new stable semver tag"]
+        L2 --> L3["Flux reconciles platform\n(production deployment)"]
+    end
 ```
 
 ### Artifact Tagging Strategy
@@ -115,19 +107,18 @@ higher than the previous stable release in semver ordering.
 
 ### Artifact Stuck in Integration?
 
-```
-Is the artifact in GHCR?
-│
-├─ NO → Check build-platform-artifact.yaml run
-│       └─ Did the workflow trigger?
-│           ├─ NO → Was kubernetes/ modified?
-│           └─ YES → Check workflow logs for push errors
-│
-└─ YES → Is OCIRepository seeing it?
-         └─ kubectl get ocirepository -n flux-system
-             ├─ NO match → Check semver constraint
-             └─ Match found → Check Kustomization status
-                 └─ kubectl get kustomization -n flux-system
+```mermaid
+flowchart TD
+    A{Is the artifact in GHCR?}
+
+    A -->|NO| B[Check build-platform-artifact.yaml run]
+    B --> C{Did the workflow trigger?}
+    C -->|NO| D[Was kubernetes/ modified?]
+    C -->|YES| E[Check workflow logs for push errors]
+
+    A -->|YES| F{"Is OCIRepository seeing it?\nkubectl get ocirepository -n flux-system"}
+    F -->|NO match| G[Check semver constraint]
+    F -->|Match found| H{"Check Kustomization status\nkubectl get kustomization -n flux-system"}
 ```
 
 ### Validation Not Triggering Promotion?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,22 +207,13 @@ All changes flow through pull requests using **worktree-based isolation**:
 
 The `main` branch represents the desired state for production. Merging to `main` triggers OCI artifact-based promotion:
 
-```
-PR merged to main
-       ↓
-  GHA builds OCI artifact
-  (packages kubernetes/)
-       ↓
-  integration cluster
-  (auto-deploys via ImagePolicy)
-       ↓
-  canary-checker validation
-  (Flux health + platform checks)
-       ↓
-  GHA tags artifact as validated
-       ↓
-  live cluster
-  (auto-deploys via ImagePolicy)
+```mermaid
+flowchart TD
+    A[PR merged to main] --> B["GHA builds OCI artifact\n(packages kubernetes/)"]
+    B --> C["integration cluster\n(auto-deploys via ImagePolicy)"]
+    C --> D["canary-checker validation\n(Flux health + platform checks)"]
+    D --> E[GHA tags artifact as validated]
+    E --> F["live cluster\n(auto-deploys via ImagePolicy)"]
 ```
 
 1. **Artifact build**: GHA packages `kubernetes/` directory as OCI artifact, tags as `integration-<sha>`
@@ -467,17 +458,12 @@ See [kubernetes/platform/CLAUDE.md](kubernetes/platform/CLAUDE.md) for detailed 
 
 ### Data Flow
 
-```
-kubernetes/platform/versions.env  ─────────────────────────────┐
-    │                                                          │
-    ├──→ infrastructure/stacks/*/  (Terragrunt reads versions) │
-    │         │                                                │
-    │         └──→ generates .cluster-vars.env per cluster     │
-    │                    │                                     │
-    │                    ▼                                     │
-    │    kubernetes/clusters/<cluster>/.cluster-vars.env       │
-    │                                                          │
-    └──→ kubernetes/platform/ (Flux substitutes versions) ◄────┘
+```mermaid
+flowchart LR
+    V["kubernetes/platform/versions.env"] --> S["infrastructure/stacks/*\n(Terragrunt reads versions)"]
+    S --> G["generates .cluster-vars.env\nper cluster"]
+    G --> C["kubernetes/clusters/‹cluster›/\n.cluster-vars.env"]
+    V --> F["kubernetes/platform/\n(Flux substitutes versions)"]
 ```
 
 ---
@@ -554,6 +540,31 @@ Code should be self-documenting. Comments and messages explain the WHY, not the 
 - **Comments explain reasoning**: Why this approach? Why not the obvious alternative?
 - **Omit the obvious**: Don't comment what the code clearly does
 - **No redundancy**: If the code says it, don't repeat it in a comment
+
+## Diagram Standards
+
+**Use Mermaid for all flow, architecture, decision tree, sequence, and topology diagrams.** GitHub renders Mermaid natively in markdown — zero tooling required, version-control-friendly, and richer output than ASCII art.
+
+**ASCII remains acceptable for:** directory trees and terminal output mockups (these render better as monospace text).
+
+### Diagram Type Selection
+
+| Content | Mermaid Type | Direction |
+|---------|-------------|-----------|
+| Deployment pipelines, promotion flows | `flowchart TD` | Top-down |
+| Network topologies, data flows | `flowchart LR` | Left-right |
+| Decision trees | `flowchart TD` | Top-down, use `{}` for decisions |
+| Temporal interactions between components | `sequenceDiagram` | — |
+| System architecture with boundaries | `flowchart` + `subgraph` | TD or LR |
+
+### Formatting Rules
+
+- Use `flowchart` (not the deprecated `graph` keyword)
+- Use `TD` (top-down) for pipelines and decision trees, `LR` (left-right) for topologies and data flows
+- Use `subgraph` to visually group related components (clusters, tiers, namespaces)
+- Use `{}` for decision diamonds, `[]` for process nodes, `([])` for rounded nodes
+- Keep node labels concise — use `\n` for line breaks within labels
+- Use quoted edge labels for clarity: `-->|"label"|`
 
 ## Commits
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -80,43 +80,19 @@ Resolve "partial state" errors during `terragrunt validate`. Usually caused by m
 
 Use this decision tree to determine where documentation belongs:
 
-```
-Is this knowledge...
+```mermaid
+flowchart TD
+    A{Is this knowledge...}
 
-├─ An emergency/incident procedure?
-│  └─ RUNBOOK (docs/runbooks/)
-│     - Step-by-step recovery actions
-│     - Time-sensitive operations
-│     - Procedures with potential data loss risk
-│     Examples: Disaster recovery, emergency policy bypass
-│
-├─ A living description of current system design?
-│  └─ ARCHITECTURE (docs/architecture/)
-│     - How the system works today and why
-│     - Conscious tradeoffs and their rationale
-│     - Updated as the system evolves
-│     Examples: Backup strategy, network segmentation, secret management
-│
-├─ Declarative knowledge about the system?
-│  └─ CLAUDE.md (appropriate directory)
-│     - How the system works (for AI agents)
-│     - Constraints and anti-patterns
-│     - Quick reference tables
-│     Examples: ResourceSet patterns, testing philosophy
-│
-├─ A multi-step workflow for normal operations?
-│  └─ SKILL (.claude/skills/)
-│     - Procedural how-to guides
-│     - Repeatable development workflows
-│     - Task automation guidance
-│     Examples: Adding a Helm release, debugging Flux
-│
-└─ A pre-implementation design proposal?
-    └─ PLAN (docs/plans/)
-       - Design documents before implementation
-       - Implementation proposals
-       - Moved to .archive/ once implemented
-       Examples: Network policy architecture, promotion pipeline
+    A -->|"Emergency/incident procedure?"| RB["**RUNBOOK** — docs/runbooks/\nStep-by-step recovery actions\nTime-sensitive operations\nProcedures with potential data loss risk"]
+
+    A -->|"Living description of current design?"| ARCH["**ARCHITECTURE** — docs/architecture/\nHow the system works today and why\nConscious tradeoffs and their rationale\nUpdated as the system evolves"]
+
+    A -->|"Declarative knowledge about system?"| CMD["**CLAUDE.md** — appropriate directory\nHow the system works (for AI agents)\nConstraints and anti-patterns\nQuick reference tables"]
+
+    A -->|"Multi-step workflow for normal ops?"| SKILL["**SKILL** — .claude/skills/\nProcedural how-to guides\nRepeatable development workflows\nTask automation guidance"]
+
+    A -->|"Pre-implementation design proposal?"| PLAN["**PLAN** — docs/plans/\nDesign documents before implementation\nMoved to .archive/ once implemented"]
 ```
 
 ---

--- a/docs/plans/network-policy-architecture.md
+++ b/docs/plans/network-policy-architecture.md
@@ -28,25 +28,21 @@ This document defines the architectural approach for implementing network segmen
 
 Network policy is split into two tiers with different management approaches:
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                        PLATFORM TIER                            │
-│  Hand-crafted CiliumNetworkPolicy per component                 │
-│  High-touch, PR-reviewed, specific to each service              │
-│                                                                 │
-│  flux-system, prometheus, grafana, alertmanager, loki,          │
-│  cert-manager, external-secrets, ingress-nginx, longhorn-system │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              │ (well-defined interfaces)
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                      APPLICATION TIER                           │
-│  Namespace-profile-based CiliumClusterwideNetworkPolicy         │
-│  Low-touch, labels/annotations, composable                      │
-│                                                                 │
-│  All off-the-shelf apps, user workloads                         │
-└─────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    subgraph platform["PLATFORM TIER"]
+        direction LR
+        P1["Hand-crafted CiliumNetworkPolicy per component\nHigh-touch, PR-reviewed, specific to each service"]
+        P2["flux-system, prometheus, grafana, alertmanager, loki,\ncert-manager, external-secrets, ingress-nginx, longhorn-system"]
+    end
+
+    subgraph application["APPLICATION TIER"]
+        direction LR
+        A1["Namespace-profile-based CiliumClusterwideNetworkPolicy\nLow-touch, labels/annotations, composable"]
+        A2["All off-the-shelf apps, user workloads"]
+    end
+
+    platform -->|"well-defined interfaces"| application
 ```
 
 ### Platform Tier

--- a/docs/runbooks/unifi-bgp-configuration.md
+++ b/docs/runbooks/unifi-bgp-configuration.md
@@ -11,24 +11,29 @@ Configure BGP peering between UniFi Dream Machine and Kubernetes clusters runnin
 
 ## Architecture Overview
 
-```
-UniFi Router (ASN 64512)          Kubernetes Clusters
-192.168.10.1                      ┌─────────────────────────┐
-       │                          │ live (ASN 64513)        │
-       │◄─── BGP eBGP ───────────►│ node41: 192.168.10.253  │
-       │                          │ node42: 192.168.10.203  │
-       │                          │ node43: 192.168.10.201  │
-       │                          └─────────────────────────┘
-       │                          ┌─────────────────────────┐
-       │◄─── BGP eBGP ───────────►│ integration (ASN 64514) │
-       │                          │ node46: 192.168.10.233  │
-       │                          │ node47: 192.168.10.247  │
-       │                          │ node48: 192.168.10.151  │
-       │                          └─────────────────────────┘
-       │                          ┌─────────────────────────┐
-       │◄─── BGP eBGP ───────────►│ dev (ASN 64515)         │
-       │                          │ node45: 192.168.10.252  │
-       │                          └─────────────────────────┘
+```mermaid
+flowchart LR
+    R["UniFi Router\nASN 64512\n192.168.10.1"]
+
+    subgraph live["live (ASN 64513)"]
+        L1["node41: 192.168.10.253"]
+        L2["node42: 192.168.10.203"]
+        L3["node43: 192.168.10.201"]
+    end
+
+    subgraph integration["integration (ASN 64514)"]
+        I1["node46: 192.168.10.233"]
+        I2["node47: 192.168.10.247"]
+        I3["node48: 192.168.10.151"]
+    end
+
+    subgraph dev["dev (ASN 64515)"]
+        D1["node45: 192.168.10.252"]
+    end
+
+    R <-->|"BGP eBGP"| live
+    R <-->|"BGP eBGP"| integration
+    R <-->|"BGP eBGP"| dev
 ```
 
 ## Configuration Steps

--- a/kubernetes/platform/CLAUDE.md
+++ b/kubernetes/platform/CLAUDE.md
@@ -274,15 +274,20 @@ app_template_version=3.7.3
 
 Terragrunt and Tuppr both read from `versions.env`, ensuring no drift:
 
-```
-Scenario: Version Upgrade via PR
-──────────────────────────────────
-1. PR updates versions.env → talos_version=v1.12.2
-2. PR merges, Flux syncs new ConfigMap to cluster
-3. Tuppr sees mismatch → executes upgrade to v1.12.2
-4. Node now at v1.12.2
-5. Next Terragrunt run reads versions.env → v1.12.2
-6. Terragrunt sees node already at v1.12.2 → NO-OP
+```mermaid
+sequenceDiagram
+    participant PR as PR / versions.env
+    participant Flux
+    participant Tuppr
+    participant Node
+    participant TG as Terragrunt
+
+    PR->>Flux: Merge updates talos_version=v1.12.2
+    Flux->>Flux: Syncs new ConfigMap to cluster
+    Tuppr->>Node: Sees mismatch → executes upgrade to v1.12.2
+    Note over Node: Now at v1.12.2
+    TG->>PR: Reads versions.env → v1.12.2
+    TG->>Node: Sees node already at v1.12.2 → NO-OP
 ```
 
 ### Adding/Updating Versions
@@ -446,33 +451,25 @@ Istio mesh mTLS certificates are issued by cert-manager via [istio-csr](https://
 
 ### Architecture
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│  AWS SSM Parameter Store                                    │
-│  /homelab/kubernetes/shared/istio-mesh-ca                   │
-└──────────────────────┬──────────────────────────────────────┘
-                       │ ExternalSecret pulls on bootstrap
-                       ▼
-┌─────────────────────────────────────────────────────────────┐
-│  Cluster (dev / integration / live)                         │
-│  ┌─────────────────────────────────────────────────────┐   │
-│  │  Secret: istio-mesh-root-ca (cert-manager ns)       │   │
-│  └──────────────────────┬──────────────────────────────┘   │
-│                         │                                   │
-│                         ▼                                   │
-│  ┌─────────────────────────────────────────────────────┐   │
-│  │  CA ClusterIssuer (istio-mesh-ca)                   │   │
-│  └──────────────────────┬──────────────────────────────┘   │
-│                         │                                   │
-│                         ▼                                   │
-│  ┌─────────────────────────────────────────────────────┐   │
-│  │  istio-csr (cert-manager namespace)                 │   │
-│  │         │                                           │   │
-│  │    ┌────┴────┐                                      │   │
-│  │    ▼         ▼                                      │   │
-│  │  istiod   ztunnel ──► workload SPIFFE identities    │   │
-│  └─────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    subgraph ssm["AWS SSM Parameter Store"]
+        S["/homelab/kubernetes/shared/istio-mesh-ca"]
+    end
+
+    ssm -->|"ExternalSecret pulls on bootstrap"| SEC
+
+    subgraph cluster["Cluster (dev / integration / live)"]
+        SEC["Secret: istio-mesh-root-ca\n(cert-manager ns)"]
+        CA["CA ClusterIssuer\n(istio-mesh-ca)"]
+
+        subgraph csr["istio-csr (cert-manager namespace)"]
+            ISTIOD["istiod"]
+            ZTUNNEL["ztunnel"] --> SPIFFE["workload SPIFFE identities"]
+        end
+
+        SEC --> CA --> csr
+    end
 ```
 
 ### Key Configuration


### PR DESCRIPTION
## Summary
- ASCII art diagrams render inconsistently and produce noisy diffs — Mermaid is rendered natively by GitHub as interactive SVGs with zero tooling requirements
- Establishes Mermaid as the mandatory diagram format for flows, architectures, decision trees, sequences, and topologies (ASCII remains for directory trees)
- Converts all 9 existing ASCII diagrams across 7 files to Mermaid

## Test plan
- [ ] View each changed file in the PR Files tab — confirm Mermaid diagrams render correctly
- [ ] Verify every node/edge from original ASCII art is present in each Mermaid diagram
- [ ] Confirm directory trees in `kubernetes/clusters/CLAUDE.md` and `kubernetes/platform/config/network-policy/CLAUDE.md` are unchanged
- [ ] `task k8s:validate` passes (docs-only, trivially passes)