### PR TITLE
fix(platform): symlink Claude settings into worktrees

### DIFF
--- a/.taskfiles/worktree/taskfile.yaml
+++ b/.taskfiles/worktree/taskfile.yaml
@@ -11,6 +11,7 @@ tasks:
       WORKTREE_PATH: "{{.ROOT_DIR}}/../{{.REPO_NAME}}-{{.NAME}}"
     cmds:
       - git worktree add "{{.WORKTREE_PATH}}" -b "{{.NAME}}"
+      - test ! -f "{{.ROOT_DIR}}/.claude/settings.local.json" || ln -sf "{{.ROOT_DIR}}/.claude/settings.local.json" "{{.WORKTREE_PATH}}/.claude/settings.local.json"
       - echo "Worktree created at {{.WORKTREE_PATH}}"
       - echo "Starting Claude Code..."
       - cmd: claude


### PR DESCRIPTION
## Summary
- Worktree sessions were reprompting for every Claude Code permission because `settings.local.json` (where accumulated grants live) is per-checkout and not tracked in git
- `task wt:new` now symlinks the main checkout's local settings into new worktrees so permissions carry over immediately

## Test plan
- [ ] Run `task wt:new -- test-branch` and verify `.claude/settings.local.json` is a symlink pointing to the main checkout
- [ ] Confirm Claude Code session in the worktree inherits existing permissions without reprompting
- [ ] Run `task wt:new` on a fresh clone without `settings.local.json` — verify it doesn't error