### PR TITLE
fix(platform): exclude cert-manager and istio-system from ambient mesh

### DIFF
--- a/kubernetes/platform/namespaces.yaml
+++ b/kubernetes/platform/namespaces.yaml
@@ -11,7 +11,7 @@ spec:
   inputs:
     # --- restricted: standard controllers with no privileged requirements ---
     - name: cert-manager
-      dataplane: ambient
+      dataplane: standard
       security: restricted
       networkPolicy: false
     - name: external-secrets
@@ -65,7 +65,7 @@ spec:
       security: privileged
       networkPolicy: false
     - name: istio-system
-      dataplane: ambient
+      dataplane: standard
       security: privileged
       networkPolicy: false
     - name: monitoring


### PR DESCRIPTION
## Summary
- Break the bootstrap deadlock on fresh cluster rebuilds where ztunnel intercepts cert-manager and istio-system traffic before it has SPIFFE certificates, preventing the certificate chain from initializing
- Both namespaces are part of the certificate bootstrap path and fundamentally cannot be behind the mesh they bootstrap
- L3/L4 security is maintained by existing dedicated CiliumNetworkPolicies (`cert-manager-default`, `istio-system-default`)

## Test plan
- [ ] `task k8s:validate` passes
- [ ] Fresh dev cluster rebuild completes without manual intervention
- [ ] ztunnel obtains SPIFFE certs from istio-csr during bootstrap
- [ ] cert-manager webhook responds to CertificateRequests without deadlock
- [ ] Existing ambient mesh workloads in other namespaces unaffected