### PR TITLE
feat(platform): add backup health alerting and dashboard

### DIFF
--- a/kubernetes/platform/config/database/prometheus-rules.yaml
+++ b/kubernetes/platform/config/database/prometheus-rules.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -33,3 +34,58 @@ spec:
             severity: critical
           annotations:
             summary: "CNPG replica {{ $labels.pod }} WAL receiver down"
+
+        # WAL Archiving Lag - pending files above healthy threshold
+        - alert: CNPGWALArchivingLagHigh
+          expr: cnpg_collector_pg_wal_archive_status{value="ready"} > 10
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "CNPG cluster {{ $labels.cluster }} WAL archiving lagging"
+            description: >-
+              {{ $value }} WAL files pending archival for cluster {{ $labels.cluster }}.
+              WAL archive lag degrades RPO. Check Garage connectivity and barman health.
+
+        # WAL Archiving Stalled - critical backlog
+        - alert: CNPGWALArchivingStalled
+          expr: cnpg_collector_pg_wal_archive_status{value="ready"} > 100
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "CNPG cluster {{ $labels.cluster }} WAL archiving stalled"
+            description: >-
+              {{ $value }} WAL files pending archival for cluster {{ $labels.cluster }}.
+              Archiving appears stalled. RPO is severely degraded. Check Garage health
+              and barman object store connectivity immediately.
+
+        # Base Backup Staleness - no successful backup within 48h
+        - alert: CNPGBackupStale
+          expr: |
+            (time() - cnpg_collector_last_available_backup_timestamp) > 172800
+            and cnpg_collector_last_available_backup_timestamp > 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "CNPG cluster {{ $labels.cluster }} backup older than 48h"
+            description: >-
+              Last available backup for cluster {{ $labels.cluster }} is
+              {{ $value | humanizeDuration }} old (threshold: 48h). Check
+              ScheduledBackup resource and barman object store connectivity.
+
+        # Backup Failed - most recent attempt was a failure
+        - alert: CNPGBackupFailed
+          expr: |
+            cnpg_collector_last_failed_backup_timestamp
+            > cnpg_collector_last_available_backup_timestamp
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "CNPG cluster {{ $labels.cluster }} latest backup failed"
+            description: >-
+              The most recent backup attempt for cluster {{ $labels.cluster }} failed.
+              A failed backup is more recent than the last successful one.
+              Check CNPG operator logs and barman backup connectivity to Garage.

--- a/kubernetes/platform/config/longhorn/prometheus-rules.yaml
+++ b/kubernetes/platform/config/longhorn/prometheus-rules.yaml
@@ -130,3 +130,33 @@ spec:
           annotations:
             summary: "Longhorn replica rebuild stalled on {{ $labels.volume }}"
             description: "Volume {{ $labels.volume }} has been rebuilding for over 30 minutes at {{ $value }}%. This may indicate disk I/O issues or network problems."
+
+        # Backup Staleness - volume has backup but no recent success
+        - alert: LonghornBackupStale
+          expr: |
+            (time() - longhorn_volume_last_backup_at) > 129600
+            and longhorn_volume_last_backup_at > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} backup is stale"
+            description: >-
+              Volume {{ $labels.volume }} (PVC {{ $labels.pvc }}, ns {{ $labels.pvc_namespace }})
+              last successful backup was {{ $value | humanizeDuration }} ago (threshold: 36h).
+              Check recurring backup job status and backup target connectivity.
+
+        # Backup Never Completed - volume exists but has never been backed up
+        - alert: LonghornBackupNeverCompleted
+          expr: |
+            longhorn_volume_last_backup_at == 0
+            and longhorn_volume_robustness >= 0
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} has never been backed up"
+            description: >-
+              Volume {{ $labels.volume }} reports a last backup timestamp of 0,
+              meaning no backup has ever completed. Verify recurring job configuration
+              and backup target availability.

--- a/kubernetes/platform/config/monitoring/backup-health-dashboard.yaml
+++ b/kubernetes/platform/config/monitoring/backup-health-dashboard.yaml
@@ -1,0 +1,301 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-backup-health
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "true"
+  annotations:
+    grafana_folder: "Backup"
+data:
+  backup-health.json: |
+    {
+      "annotations": { "list": [] },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+          "id": 10,
+          "title": "Longhorn Backups",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 86400 },
+                  { "color": "red", "value": 129600 }
+                ]
+              },
+              "unit": "s",
+              "mappings": [
+                {
+                  "type": "value",
+                  "options": {
+                    "0": { "text": "Never", "color": "red" }
+                  }
+                }
+              ]
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 1 },
+          "id": 1,
+          "options": {
+            "cellHeight": "sm",
+            "footer": { "enablePagination": false, "show": false },
+            "showHeader": true,
+            "sortBy": [
+              { "desc": true, "displayName": "Backup Age" }
+            ]
+          },
+          "pluginVersion": "11.4.0",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "time() - longhorn_volume_last_backup_at",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Longhorn Volume Backup Age",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "__name__": true,
+                  "instance": true,
+                  "job": true
+                },
+                "renameByName": {
+                  "Value": "Backup Age",
+                  "volume": "Volume",
+                  "pvc": "PVC",
+                  "pvc_namespace": "Namespace",
+                  "node": "Node"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+          "id": 11,
+          "title": "CNPG PostgreSQL Backups",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 86400 },
+                  { "color": "red", "value": 172800 }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 6, "w": 12, "x": 0, "y": 10 },
+          "id": 2,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": ["lastNotNull"],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "11.4.0",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "time() - cnpg_collector_last_available_backup_timestamp",
+              "legendFormat": "{{ cluster }}",
+              "refId": "A"
+            }
+          ],
+          "title": "CNPG Last Backup Age",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 10 },
+                  { "color": "red", "value": 100 }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 6, "w": 12, "x": 12, "y": 10 },
+          "id": 3,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": ["lastNotNull"],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "11.4.0",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "cnpg_collector_pg_wal_archive_status{value=\"ready\"}",
+              "legendFormat": "{{ cluster }}",
+              "refId": "A"
+            }
+          ],
+          "title": "CNPG WAL Files Pending Archival",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 86400 },
+                  { "color": "red", "value": 172800 }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 6, "w": 12, "x": 0, "y": 16 },
+          "id": 4,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": ["lastNotNull"],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "11.4.0",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "time() - cnpg_collector_first_recoverability_point",
+              "legendFormat": "{{ cluster }}",
+              "refId": "A"
+            }
+          ],
+          "title": "CNPG First Recoverability Point Age",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": { "type": "linear" },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": {
+                  "mode": "dashed",
+                  "dashes": { "values": [10, 100] }
+                }
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 10 },
+                  { "color": "red", "value": 100 }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+          "id": 5,
+          "options": {
+            "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" },
+            "tooltip": { "mode": "multi", "sort": "none" }
+          },
+          "pluginVersion": "11.4.0",
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "cnpg_collector_pg_wal_archive_status{value=\"ready\"}",
+              "legendFormat": "{{ cluster }}",
+              "refId": "A"
+            }
+          ],
+          "title": "CNPG WAL Archiving Lag Over Time",
+          "type": "timeseries"
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": ["backup", "longhorn", "cnpg", "data-protection"],
+      "templating": { "list": [] },
+      "time": { "from": "now-24h", "to": "now" },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Backup Health",
+      "uid": "backup-health",
+      "version": 1
+    }

--- a/kubernetes/platform/config/monitoring/kustomization.yaml
+++ b/kubernetes/platform/config/monitoring/kustomization.yaml
@@ -32,3 +32,4 @@ resources:
   - ups-monitoring-config.yaml
   - ups-monitoring-scrape.yaml
   - ups-monitoring-alerts.yaml
+  - backup-health-dashboard.yaml


### PR DESCRIPTION
## Summary

- Adds staleness and failure alerts for Longhorn S3 backups and CNPG PostgreSQL backups (WAL archiving + base backups) to catch silent backup failures before they become data loss events
- Creates a unified Grafana "Backup Health" dashboard with per-volume backup age, WAL archiving lag, and recoverability point panels
- Adds schema comment to CNPG PrometheusRule for IDE validation

Closes #317

## Test plan

- [ ] `task k8s:validate` passes (verified locally)
- [ ] After deployment, verify new alert rules are loaded in Prometheus: check `/api/v1/rules` for `LonghornBackupStale`, `CNPGWALArchivingLagHigh`, `CNPGBackupStale`, `CNPGBackupFailed`
- [ ] Verify "Backup Health" dashboard appears in Grafana under the "Backup" folder
- [ ] Confirm no alerts are spuriously firing (volumes should have recent backups)
- [ ] Verify `cnpg_collector_last_available_backup_timestamp` returns non-zero values (known CNPG metric reliability concern per cloudnative-pg/cloudnative-pg#7812)