### PR TITLE
fix(platform): revert Cilium bpf.masquerade and ambient namespace workaround

### DIFF
--- a/kubernetes/platform/charts/cilium.yaml
+++ b/kubernetes/platform/charts/cilium.yaml
@@ -68,10 +68,6 @@ rollOutCiliumPods: true
 # Return ICMP "Destination Unreachable" instead of silently dropping denied traffic.
 # Provides faster client-side failure detection with our implicit default-deny model.
 policyDenyResponse: icmp
-bpf:
-  masquerade: true
-egressGateway:
-  enabled: true
 routingMode: native
 securityContext:
   capabilities:

--- a/kubernetes/platform/namespaces.yaml
+++ b/kubernetes/platform/namespaces.yaml
@@ -11,7 +11,7 @@ spec:
   inputs:
     # --- restricted: standard controllers with no privileged requirements ---
     - name: cert-manager
-      dataplane: standard
+      dataplane: ambient
       security: restricted
       networkPolicy: false
     - name: external-secrets
@@ -65,7 +65,7 @@ spec:
       security: privileged
       networkPolicy: false
     - name: istio-system
-      dataplane: standard
+      dataplane: ambient
       security: privileged
       networkPolicy: false
     - name: monitoring


### PR DESCRIPTION
## Summary
- Revert `bpf.masquerade: true` and `egressGateway.enabled: true` from Cilium values (added in PR #368), which broke Istio ambient mesh bootstrap by altering eBPF packet handling before ztunnel could intercept traffic
- Restore `cert-manager` and `istio-system` namespaces to `dataplane: ambient` (reverting PR #388), which was a misdiagnosis of the bootstrap failure -- the root cause was the Cilium bpf.masquerade change, not ambient mesh enrollment

## Test plan
- [ ] `task k8s:validate` passes
- [ ] Dev cluster bootstraps successfully with ambient mesh on cert-manager and istio-system
- [ ] ztunnel can issue SPIFFE certs without circular dependency
- [ ] No Hubble drops on cert-manager or istio-system traffic after deployment