### PR TITLE
fix(platform): use SNMPv1 auth for CyberPower UPS SNMP scrape

### DIFF
--- a/kubernetes/platform/config/monitoring/ups-monitoring-scrape.yaml
+++ b/kubernetes/platform/config/monitoring/ups-monitoring-scrape.yaml
@@ -10,7 +10,7 @@ spec:
   metricsPath: /snmp
   params:
     module: ["cyberpower"]
-    auth: ["public_v2"]
+    auth: ["public_v1"]
   staticConfigs:
     - targets: ["ups.citadel.tomnowak.work"]
   relabelings:


### PR DESCRIPTION
## Summary
- CyberPower UPS only supports SNMPv1, but the SNMP exporter ScrapeConfig was configured with `public_v2` (SNMPv2c) auth, causing scrape failures
- Switch to `public_v1` auth which uses the correct SNMP version for this device

## Test plan
- [ ] Validated with `task k8s:validate`
- [ ] After merge, verify SNMP exporter targets show UP in Prometheus (`up{job="snmp-exporter-ups-targets"}`)
- [ ] Verify UPS metrics are being collected (`cyberpower_*` metrics present)