### PR TITLE
feat(platform): establish dev cluster as sandbox for rapid iteration

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -129,7 +129,8 @@ PR format:
 - **NEVER** create resources with PLACEHOLDER values
 - **NEVER** defer dependencies as "manual operational tasks"
 - **NEVER** commit secrets or generated artifacts
-- **NEVER** apply changes directly to clusters — always GitOps through Flux
+- **NEVER** apply changes directly to integration or live clusters — always GitOps through Flux
+- **Dev cluster exception**: Direct `kubectl apply`, `helm install/upgrade/uninstall`, and Flux suspend/resume are permitted on dev for rapid iteration. Always write changes as proper manifests first — apply from written files, not ad-hoc commands. Resume Flux and validate convergence before opening a PR
 - **NEVER** use `--force`, `--no-verify`, or `--auto-approve`
 - **ALWAYS** research chart configs (via kubesearch) before writing Helm values
 - **ALWAYS** set network-policy labels on new namespaces

--- a/.claude/agents/troubleshooter.md
+++ b/.claude/agents/troubleshooter.md
@@ -112,11 +112,10 @@ Present findings as a structured investigation report:
 
 # Boundaries
 
-- **NEVER** modify cluster resources (no `kubectl apply`, `kubectl delete`, `kubectl patch`)
-- **NEVER** run destructive commands (no `kubectl drain`, no force operations)
-- **NEVER** suggest manual fixes — all remediations should be GitOps-compatible
-- **Read-only operations only**: `kubectl get`, `kubectl describe`, `kubectl logs`, `kubectl top`, `flux get`, Hubble queries
-- For applying fixes, direct the user: **"To implement this fix, use the `/implement` command"**
+- **Integration/live clusters**: Read-only operations only — `kubectl get`, `kubectl describe`, `kubectl logs`, `kubectl top`, `flux get`, Hubble queries. Never modify resources. For applying fixes, direct the user: **"To implement this fix, use the `/implement` command"**
+- **Dev cluster exception**: Direct mutations (`kubectl apply`, `kubectl delete`, `kubectl patch`, Flux suspend/resume) are permitted on dev for debugging and remediation. Always use `KUBECONFIG=~/.kube/dev.yaml` to ensure you're targeting dev
+- **NEVER** run destructive commands on any cluster (no `kubectl drain`, no force operations)
+- **NEVER** suggest manual fixes for integration/live — all remediations should be GitOps-compatible
 
 # User Interaction
 

--- a/.claude/skills/deploy-app/SKILL.md
+++ b/.claude/skills/deploy-app/SKILL.md
@@ -385,34 +385,50 @@ Fix any errors before proceeding.
 
 ## Phase 5: Test on Dev
 
-### 5.1 Direct Helm Install
+The dev cluster is a sandbox — iterate freely until the deployment works.
 
-Bypass Flux to test immediately on dev cluster:
+### 5.1 Suspend Flux (if needed)
+
+If Flux would reconcile over your changes, suspend the relevant Kustomization:
 
 ```bash
-# Get values from rendered kustomization
+task k8s:flux-suspend -- <kustomization-name>
+```
+
+### 5.2 Deploy Directly
+
+Install or upgrade the chart directly on dev:
+
+```bash
+# Standard Helm repo
 KUBECONFIG=~/.kube/dev.yaml helm install <app-name> <repo>/<chart> \
   -n <namespace> --create-namespace \
   -f kubernetes/platform/charts/<app-name>.yaml \
   --version <version>
-```
 
-For OCI charts:
-```bash
+# OCI chart
 KUBECONFIG=~/.kube/dev.yaml helm install <app-name> oci://registry/<path>/<chart> \
   -n <namespace> --create-namespace \
   -f kubernetes/platform/charts/<app-name>.yaml \
   --version <version>
 ```
 
-### 5.2 Wait for Pods
+For iterating on values, use `helm upgrade`:
+```bash
+KUBECONFIG=~/.kube/dev.yaml helm upgrade <app-name> <repo>/<chart> \
+  -n <namespace> \
+  -f kubernetes/platform/charts/<app-name>.yaml \
+  --version <version>
+```
+
+### 5.3 Wait for Pods
 
 ```bash
 KUBECONFIG=~/.kube/dev.yaml kubectl -n <namespace> \
   wait --for=condition=Ready pod -l app.kubernetes.io/name=<app-name> --timeout=300s
 ```
 
-### 5.3 Verify Network Connectivity
+### 5.4 Verify Network Connectivity
 
 **CRITICAL**: Network policies are enforced - verify traffic flows correctly:
 
@@ -435,7 +451,7 @@ hubble observe --from-namespace <namespace> --to-namespace database --since 2m
 - Missing access label → database/S3 traffic blocked
 - Wrong profile → external API calls blocked (use `internal-egress` or `standard`)
 
-### 5.4 Verify Monitoring
+### 5.5 Verify Monitoring
 
 Use the helper scripts:
 
@@ -453,26 +469,27 @@ Use the helper scripts:
 .claude/skills/deploy-app/scripts/check-canary.sh <app-name>
 ```
 
-### 5.5 User Confirmation
+### 5.6 Iterate
 
-Use AskUserQuestion to report:
-- Pod status (Ready/NotReady)
-- Network connectivity (Hubble drops)
-- ServiceMonitor discovery status
-- Alert status
-- Canary status (if applicable)
-
-Ask whether to proceed with PR creation.
+If something isn't right, fix the manifests/values and re-apply. This is the dev sandbox — iterate until it works. Update Helm values, ResourceSet configs, network policy labels, etc. and re-deploy.
 
 ---
 
-## Phase 6: Cleanup & PR
+## Phase 6: Validate GitOps & PR
 
-### 6.1 Uninstall from Dev
+### 6.1 Reconcile and Validate
+
+Before opening a PR, prove the manifests work through the GitOps path:
 
 ```bash
+# Uninstall the direct helm install
 KUBECONFIG=~/.kube/dev.yaml helm uninstall <app-name> -n <namespace>
+
+# Resume Flux and validate clean convergence
+task k8s:reconcile-validate
 ```
+
+If reconciliation fails, fix the manifests and try again. The goal is a clean state where Flux can deploy everything from git.
 
 ### 6.2 Commit Changes
 

--- a/.claude/skills/network-policy/SKILL.md
+++ b/.claude/skills/network-policy/SKILL.md
@@ -258,7 +258,8 @@ After creating, add to `kubernetes/platform/config/network-policy/platform/kusto
 - **NEVER** hardcode IP addresses — use endpoint selectors and entities
 - **NEVER** allow `any` port — always specify explicit port lists
 - **NEVER** disable enforcement without following the escape hatch runbook
-- **NEVER** apply network policy changes via `kubectl` — always through GitOps
+- **NEVER** apply network policy changes via `kubectl` on integration/live — always through GitOps
+- **Dev cluster exception**: Direct `kubectl apply` of network policies is permitted on dev for testing
 
 ---
 

--- a/.claude/skills/sre/SKILL.md
+++ b/.claude/skills/sre/SKILL.md
@@ -25,7 +25,7 @@ user-invocable: false
 ## Core Principles
 
 - **5 Whys Analysis** - NEVER stop at symptoms. Ask "why" until you reach the root cause.
-- **Read-Only Investigation** - Observe and analyze, never modify resources
+- **Read-Only Investigation** - Observe and analyze, never modify resources on integration/live. Dev cluster permits direct mutations for debugging (see troubleshooter agent boundaries)
 - **Multi-Source Correlation** - Combine logs, events, metrics for complete picture
 - **Research Unknown Services** - Check documentation before deep investigation
 - **Zero Alert Tolerance** - Every firing alert must be addressed immediately: fix the root cause, or as a last resort, create a declarative Silence CR with justification. Never ignore, defer, or dismiss a firing alert.

--- a/.taskfiles/CLAUDE.md
+++ b/.taskfiles/CLAUDE.md
@@ -21,13 +21,20 @@ For detailed Taskfile syntax and patterns, invoke the `taskfiles` skill.
 
 ## Quick Reference
 
-### Kubernetes Validation (k8s:)
+### Kubernetes Validation & Dev Workflow (k8s:)
 
 ```bash
+# Validation
 task k8s:validate              # Full validation (lint, ResourceSets, charts, kubeconform, deprecations)
 task k8s:deprecations          # Show all deprecated APIs (informational - doesn't fail)
+
+# Dev cluster operations (autonomous)
 task k8s:dry-run-dev           # Server-side dry-run against dev cluster
-task k8s:apply-dev             # Apply to dev cluster (with confirmation)
+task k8s:apply-dev             # Apply expanded ResourceSets to dev cluster
+task k8s:flux-suspend -- <ks>  # Suspend a Flux Kustomization on dev
+task k8s:flux-resume -- <ks>   # Resume a Flux Kustomization on dev
+task k8s:flux-status           # Show Flux Kustomization status on dev
+task k8s:reconcile-validate    # Resume all Flux, reconcile, validate clean state
 ```
 
 ### Infrastructure Validation (tg:)
@@ -105,11 +112,17 @@ For infrastructure changes, always follow this sequence:
 
 ---
 
-## Dev Cluster Safety
+## Dev Cluster Operations
 
-The `dev` cluster is a sandbox environment for testing infrastructure changes. Claude has expanded permissions for dev cluster operations to facilitate testing workflows.
+The `dev` cluster is a **sandbox for rapid iteration**. Claude operates autonomously on dev — applying, debugging, and mutating directly. Integration and live remain strictly read-only.
 
-### Allowed Operations (dev cluster only)
+### Dev Sandbox Workflow
+
+```
+Suspend Kustomization → Experiment on dev → Write/refine manifests → Resume Flux → Validate convergence → Open PR
+```
+
+### Available Operations
 
 ```bash
 # Status checks (run freely)
@@ -124,7 +137,28 @@ task tg:plan-dev                   # Plan dev cluster changes
 task tg:apply-dev                  # Apply dev cluster changes
 task tg:gen-dev                    # Generate dev stack
 task tg:clean-dev                  # Clean dev stack cache
+
+# Kubernetes dev workflow (autonomous)
+task k8s:dry-run-dev               # Server-side dry-run against dev cluster
+task k8s:apply-dev                 # Apply expanded ResourceSets to dev
+task k8s:flux-suspend -- <name>    # Suspend a Flux Kustomization on dev
+task k8s:flux-resume -- <name>     # Resume a Flux Kustomization on dev
+task k8s:flux-status               # Show Flux Kustomization status on dev
+task k8s:reconcile-validate        # Resume all Flux, wait for convergence, validate clean state
+
+# Direct kubectl/helm on dev (autonomous)
+KUBECONFIG=~/.kube/dev.yaml kubectl apply -f <manifest>
+KUBECONFIG=~/.kube/dev.yaml helm install <name> <chart> -n <ns> -f <values>
+KUBECONFIG=~/.kube/dev.yaml helm upgrade <name> <chart> -n <ns> -f <values>
+KUBECONFIG=~/.kube/dev.yaml helm uninstall <name> -n <ns>
 ```
+
+### Key Principles
+
+- **Same manifest format**: Always write changes as proper manifests/values files — never use ad-hoc `kubectl edit` or `kubectl patch` as a substitute for writing the actual files
+- **Suspend, don't disable**: Use `task k8s:flux-suspend` for targeted Kustomization suspension rather than disabling Flux entirely
+- **Reconcile before PR**: Always run `task k8s:reconcile-validate` before opening a PR to prove manifests work through the GitOps path
+- **Destroy as last resort**: If the cluster is too dirty to reconcile, `task tg:apply-dev` can rebuild it (~10 min). This is a smell, not the happy path
 
 ### AWS Credentials
 
@@ -151,14 +185,14 @@ Before running infrastructure operations on dev, verify cluster readiness:
 
 **ALWAYS use AskUserQuestion before:**
 - `task tg:apply-dev` (creates/modifies infrastructure)
-- Any operation that destroys or recreates resources
+- Any operation that destroys or recreates the cluster
 
-This ensures the human operator is aware and approves state-changing operations, even on the dev cluster.
+Kubernetes-level operations (`kubectl apply`, `helm install`, Flux suspend/resume) are **autonomous** on dev and do not require confirmation.
 
 ### Scope Boundaries
 
 | Cluster | Claude Permissions |
 |---------|-------------------|
-| `dev` | Plan, apply, destroy (with confirmation) |
+| `dev` | **Autonomous**: kubectl apply/delete, helm install/uninstall, Flux suspend/resume. **With confirmation**: tg:apply-dev, cluster destroy/recreate |
 | `integration` | Read-only, validation only |
 | `live` | Read-only, validation only |

--- a/.taskfiles/kubernetes/taskfile.yaml
+++ b/.taskfiles/kubernetes/taskfile.yaml
@@ -112,9 +112,8 @@ tasks:
       - test -d {{.EXPANDED_DIR}}/resourcesets
 
   apply-dev:
-    desc: Apply manifests to dev cluster (REQUIRES CONFIRMATION)
+    desc: Apply manifests to dev cluster
     deps: [validate]
-    prompt: This will apply manifests to the dev cluster. Continue?
     cmds:
       - |
         echo "Applying to dev cluster..."
@@ -129,6 +128,105 @@ tasks:
       - which kubectl
       - test -f {{.DEV_KUBECONFIG}}
       - test -d {{.EXPANDED_DIR}}/resourcesets
+
+  flux-suspend:
+    desc: Suspend a Flux Kustomization on dev cluster
+    cmds:
+      - |
+        KSNAME="{{.CLI_ARGS}}"
+        if [ -z "$KSNAME" ]; then
+          echo "Usage: task k8s:flux-suspend -- <kustomization-name>"
+          echo ""
+          echo "Available Kustomizations:"
+          KUBECONFIG={{.DEV_KUBECONFIG}} kubectl get kustomizations.kustomize.toolkit.fluxcd.io -n flux-system \
+            -o custom-columns='NAME:.metadata.name,SUSPENDED:.spec.suspend,READY:.status.conditions[?(@.type=="Ready")].status' \
+            --no-headers
+          exit 1
+        fi
+        echo "Suspending Kustomization: $KSNAME"
+        KUBECONFIG={{.DEV_KUBECONFIG}} flux suspend kustomization "$KSNAME" -n flux-system
+        echo "Suspended. Flux will not reconcile $KSNAME until resumed."
+    preconditions:
+      - which flux kubectl
+      - test -f {{.DEV_KUBECONFIG}}
+
+  flux-resume:
+    desc: Resume a suspended Flux Kustomization on dev cluster
+    cmds:
+      - |
+        KSNAME="{{.CLI_ARGS}}"
+        if [ -z "$KSNAME" ]; then
+          echo "Usage: task k8s:flux-resume -- <kustomization-name>"
+          echo ""
+          echo "Suspended Kustomizations:"
+          KUBECONFIG={{.DEV_KUBECONFIG}} kubectl get kustomizations.kustomize.toolkit.fluxcd.io -n flux-system \
+            -o custom-columns='NAME:.metadata.name,SUSPENDED:.spec.suspend' \
+            --no-headers | grep -i true || echo "  (none suspended)"
+          exit 1
+        fi
+        echo "Resuming Kustomization: $KSNAME"
+        KUBECONFIG={{.DEV_KUBECONFIG}} flux resume kustomization "$KSNAME" -n flux-system
+        echo "Resumed. Flux will reconcile $KSNAME on next interval."
+    preconditions:
+      - which flux kubectl
+      - test -f {{.DEV_KUBECONFIG}}
+
+  flux-status:
+    desc: Show Flux Kustomization status on dev cluster
+    cmds:
+      - |
+        echo "Flux Kustomizations on dev cluster:"
+        echo ""
+        KUBECONFIG={{.DEV_KUBECONFIG}} kubectl get kustomizations.kustomize.toolkit.fluxcd.io -n flux-system \
+          -o custom-columns='NAME:.metadata.name,READY:.status.conditions[?(@.type=="Ready")].status,SUSPENDED:.spec.suspend,MESSAGE:.status.conditions[?(@.type=="Ready")].message'
+    preconditions:
+      - which kubectl
+      - test -f {{.DEV_KUBECONFIG}}
+
+  reconcile-validate:
+    desc: Resume all Flux Kustomizations on dev, wait for reconciliation, validate clean state
+    cmds:
+      - |
+        echo "=== Resuming all suspended Kustomizations ==="
+        SUSPENDED=$(KUBECONFIG={{.DEV_KUBECONFIG}} kubectl get kustomizations.kustomize.toolkit.fluxcd.io -n flux-system \
+          -o jsonpath='{range .items[?(@.spec.suspend==true)]}{.metadata.name}{"\n"}{end}')
+        if [ -z "$SUSPENDED" ]; then
+          echo "No suspended Kustomizations found."
+        else
+          echo "$SUSPENDED" | while read -r ks; do
+            echo "  Resuming: $ks"
+            KUBECONFIG={{.DEV_KUBECONFIG}} flux resume kustomization "$ks" -n flux-system
+          done
+        fi
+        echo ""
+      - |
+        echo "=== Triggering reconciliation ==="
+        KUBECONFIG={{.DEV_KUBECONFIG}} flux reconcile source git flux-system -n flux-system
+        echo ""
+      - |
+        echo "=== Waiting for Kustomizations to reconcile (timeout: 5m) ==="
+        KUBECONFIG={{.DEV_KUBECONFIG}} kubectl wait kustomizations.kustomize.toolkit.fluxcd.io \
+          --all -n flux-system \
+          --for=condition=Ready \
+          --timeout=300s
+        echo ""
+      - |
+        echo "=== Checking HelmRelease status ==="
+        FAILED=$(KUBECONFIG={{.DEV_KUBECONFIG}} kubectl get helmreleases.helm.toolkit.fluxcd.io -A \
+          -o jsonpath='{range .items[?(@.status.conditions[0].status!="True")]}{.metadata.namespace}/{.metadata.name}: {.status.conditions[0].message}{"\n"}{end}')
+        if [ -n "$FAILED" ]; then
+          echo "WARNING: Failed HelmReleases detected:"
+          echo "$FAILED"
+          echo ""
+          echo "Investigate before opening a PR."
+          exit 1
+        fi
+        echo "All HelmReleases healthy."
+        echo ""
+        echo "=== Dev cluster reconciled and validated ==="
+    preconditions:
+      - which flux kubectl
+      - test -f {{.DEV_KUBECONFIG}}
 
   # =============================================================================
   # Internal Tasks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,11 +256,29 @@ task renovate:validate
 
 ## Dev Cluster Operations
 
-For dev cluster permissions, pre-flight checks, and safety procedures, see [.taskfiles/CLAUDE.md](.taskfiles/CLAUDE.md#dev-cluster-safety).
+The dev cluster is a **sandbox for rapid iteration**. Claude operates autonomously on dev — applying, debugging, and mutating directly — using the same manifest format as production. Integration and live remain strictly GitOps.
+
+### Dev Sandbox Philosophy
+
+- **Experiment freely**: Apply manifests, install Helm charts, mutate resources directly on dev
+- **Same artifact format**: Always write changes as proper manifests/values files — the same format that will land in the PR. Never use ad-hoc `kubectl edit` or `kubectl patch` as a substitute for writing manifests
+- **Suspend, don't disable**: Use targeted Flux Kustomization suspension (`task k8s:flux-suspend`) to prevent reconciliation from reverting your work-in-progress. Keep the rest of the platform synced
+- **Reconcile before PR**: When experimentation is done, resume Flux and validate clean convergence (`task k8s:reconcile-validate`). This proves your manifests work through the GitOps path
+- **Destroy as last resort**: If the cluster is too dirty to reconcile cleanly, destroy and rebuild (~10 min). This is a smell, not the happy path
+
+### Dev Workflow
+
+```
+Suspend Kustomization → Experiment on dev → Write/refine manifests → Resume Flux → Validate convergence → Open PR
+```
+
+For dev cluster task commands and detailed procedures, see [.taskfiles/CLAUDE.md](.taskfiles/CLAUDE.md#dev-cluster-operations).
+
+### Cluster Permissions
 
 | Cluster | Claude Permissions |
 |---------|-------------------|
-| `dev` | Plan, apply, destroy (with confirmation) |
+| `dev` | **Autonomous**: plan, apply, destroy, kubectl apply/delete, helm install/uninstall, Flux suspend/resume |
 | `integration` | Read-only, validation only |
 | `live` | Read-only, validation only |
 
@@ -295,7 +313,8 @@ For dev cluster permissions, pre-flight checks, and safety procedures, see [.tas
 
 - **NEVER** use `kubectl --force --grace-period=0` or `--ignore-not-found` flags
 - **NEVER** modify CRD definitions without understanding operator compatibility
-- **NEVER** apply changes directly to the cluster - always use the GitOps approach through Flux
+- **NEVER** apply changes directly to integration or live clusters - always use the GitOps approach through Flux
+- **Dev cluster exception**: Direct `kubectl apply`, `helm install`, and Flux suspension are permitted on dev for experimentation (see Dev Cluster Operations above)
 - **NEVER** hallucinate YAML fields - use `kubectl explain`, official docs, or YAML schema validation
 
 ## Alert Response


### PR DESCRIPTION
## Summary
- Pivot dev cluster from "always GitOps" to sandbox-first workflow: suspend Flux, experiment directly, reconcile before PR
- Scope all direct-apply prohibitions to integration/live only — dev permits autonomous kubectl/helm/Flux operations
- Add 4 new Taskfile commands (`flux-suspend`, `flux-resume`, `flux-status`, `reconcile-validate`) to support the sandbox workflow

## Test plan
- [x] `task k8s:validate` passes
- [x] All new tasks registered (`task --list`)
- [x] No stale blanket "NEVER apply directly" prohibitions remain (grep verified)
- [ ] Smoke test `task k8s:flux-status` against dev cluster
- [ ] Smoke test `task k8s:flux-suspend` / `task k8s:flux-resume` against dev cluster
- [ ] Smoke test `task k8s:reconcile-validate` against dev cluster