### PR TITLE
feat(platform): add GitHub OAuth for platform UIs via ext_authz

### DIFF
--- a/kubernetes/platform/charts/grafana.yaml
+++ b/kubernetes/platform/charts/grafana.yaml
@@ -13,35 +13,22 @@ env:
   GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: natel-discrete-panel,pr0ps-trackmap-panel,panodata-map-panel
   GF_SECURITY_ANGULAR_SUPPORT_ENABLED: true
   GF_SERVER_ROOT_URL: https://grafana.${internal_domain}
-envValueFrom:
-  GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET:
-    secretKeyRef:
-      name: grafana-oidc-client-secret
-      key: client-secret
-      optional: true
 grafana.ini:
   analytics:
     check_for_updates: false
     check_for_plugin_updates: false
     reporting_enabled: false
   auth:
-    signout_redirect_url: https://auth.${internal_domain}/logout
-  auth.generic_oauth:
+    disable_login_form: true
+  auth.anonymous:
     enabled: true
-    name: Authelia
-    icon: signin
-    client_id: grafana
-    scopes: openid profile email groups
-    empty_scopes: false
-    auth_url: https://auth.${internal_domain}/api/oidc/authorization
-    token_url: https://auth.${internal_domain}/api/oidc/token
-    api_url: https://auth.${internal_domain}/api/oidc/userinfo
-    login_attribute_path: preferred_username
-    groups_attribute_path: groups
-    name_attribute_path: name
-    use_pkce: true
-    auto_login: false
-    role_attribute_path: contains(groups[*], 'admin') && 'Admin' || 'Viewer'
+    org_role: Admin
+  auth.proxy:
+    enabled: true
+    header_name: X-Auth-Request-User
+    header_property: username
+    auto_sign_up: true
+    headers: "Email:X-Auth-Request-Email"
   news:
     news_feed_enabled: false
 datasources:

--- a/kubernetes/platform/charts/istiod.yaml
+++ b/kubernetes/platform/charts/istiod.yaml
@@ -3,6 +3,26 @@
 # yaml-language-server: $schema=https://json.schemastore.org/helm-values.json
 profile: ambient
 
+meshConfig:
+  extensionProviders:
+    - name: oauth2-proxy
+      envoyExtAuthz:
+        service: oauth2-proxy.oauth2-proxy.svc.cluster.local
+        port: 4180
+        headersToDownstreamOnDeny:
+          - content-type
+          - set-cookie
+        headersToUpstreamOnAllow:
+          - authorization
+          - cookie
+          - x-auth-request-user
+          - x-auth-request-email
+        headersToDownstreamOnAllow:
+          - set-cookie
+        includeRequestHeadersInCheck:
+          - authorization
+          - cookie
+
 # Disable built-in CA - certificates are issued by istio-csr via cert-manager
 pilot:
   env:

--- a/kubernetes/platform/charts/oauth2-proxy.yaml
+++ b/kubernetes/platform/charts/oauth2-proxy.yaml
@@ -1,0 +1,74 @@
+---
+# https://github.com/oauth2-proxy/manifests/blob/main/helm/oauth2-proxy/values.yaml
+priorityClassName: platform
+
+podAnnotations:
+  reloader.stakater.com/auto: "true"
+
+config:
+  clientID: "override-me"
+  clientSecret: "override-me"
+  cookieSecret: "override-me"
+  configFile: |
+    provider = "github"
+    github_user = "ionfury"
+    cookie_domains = [".${internal_domain}"]
+    cookie_expire = "168h"
+    cookie_secure = true
+    cookie_samesite = "lax"
+    upstreams = ["static://202"]
+    set_xauthrequest = true
+    skip_provider_button = true
+    email_domain = ["*"]
+    redirect_url = "https://oauth2-proxy.${internal_domain}/oauth2/callback"
+    whitelist_domain = [".${internal_domain}"]
+
+extraEnv:
+  - name: OAUTH2_PROXY_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: github-oauth-credentials
+        key: client-id
+  - name: OAUTH2_PROXY_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: github-oauth-credentials
+        key: client-secret
+  - name: OAUTH2_PROXY_COOKIE_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: oauth2-proxy-cookie-secret
+        key: cookie-secret
+
+service:
+  type: ClusterIP
+  portNumber: 4180
+
+metrics:
+  enabled: true
+  port: 44180
+  servicemonitor:
+    enabled: true
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 2000
+  runAsGroup: 2000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop:
+      - ALL
+
+podSecurityContext:
+  fsGroup: 2000
+  fsGroupChangePolicy: OnRootMismatch
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    memory: 64Mi

--- a/kubernetes/platform/config.yaml
+++ b/kubernetes/platform/config.yaml
@@ -39,6 +39,10 @@ spec:
       namespace: istio-gateway
       path: kubernetes/platform/config/gateway
       dependsOn: [istiod]
+    - name: oauth2-proxy-config
+      namespace: oauth2-proxy
+      path: kubernetes/platform/config/oauth2-proxy
+      dependsOn: [oauth2-proxy, external-secrets-stores, canary-checker]
     - name: monitoring-config
       namespace: monitoring
       path: kubernetes/platform/config/monitoring

--- a/kubernetes/platform/config/gateway/kustomization.yaml
+++ b/kubernetes/platform/config/gateway/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - coraza-wasm-plugin.yaml
   - coraza-config.yaml
   - coraza-waf-rules.yaml
+  - platform-auth-policy.yaml

--- a/kubernetes/platform/config/gateway/platform-auth-policy.yaml
+++ b/kubernetes/platform/config/gateway/platform-auth-policy.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/security.istio.io/authorizationpolicy_v1.json
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: platform-ui-auth
+  namespace: istio-gateway
+spec:
+  targetRefs:
+    - kind: Gateway
+      group: gateway.networking.k8s.io
+      name: internal
+  action: CUSTOM
+  provider:
+    name: oauth2-proxy
+  rules:
+    - to:
+        - operation:
+            hosts:
+              - "prometheus.${internal_domain}"
+              - "alertmanager.${internal_domain}"
+              - "longhorn.${internal_domain}"
+              - "hubble.${internal_domain}"
+              - "garage.${internal_domain}"
+              - "grafana.${internal_domain}"

--- a/kubernetes/platform/config/monitoring/grafana-oidc-secret-replication.yaml
+++ b/kubernetes/platform/config/monitoring/grafana-oidc-secret-replication.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: grafana-oidc-client-secret
-  annotations:
-    replicator.v1.mittwald.de/replicate-from: authelia/grafana-oidc-client-secret
-data: { }

--- a/kubernetes/platform/config/monitoring/kustomization.yaml
+++ b/kubernetes/platform/config/monitoring/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
   - alertmanager-route.yaml
   - alertmanager-canary.yaml
   - grafana-admin-secret.yaml
-  - grafana-oidc-secret-replication.yaml
   - grafana-route.yaml
   - grafana-canary.yaml
   - prometheus-route.yaml

--- a/kubernetes/platform/config/network-policy/platform/kustomization.yaml
+++ b/kubernetes/platform/config/network-policy/platform/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
   - kromgo.yaml
   - longhorn-system.yaml
   - monitoring.yaml
+  - oauth2-proxy.yaml
   - system-upgrade.yaml

--- a/kubernetes/platform/config/network-policy/platform/oauth2-proxy.yaml
+++ b/kubernetes/platform/config/network-policy/platform/oauth2-proxy.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: oauth2-proxy-default
+  namespace: oauth2-proxy
+spec:
+  description: "Allow OAuth2 Proxy: ingress from gateway, egress to GitHub for OAuth"
+  endpointSelector: { }
+  ingress:
+    # Allow traffic from gateway (ext_authz requests)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: istio-gateway
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+    # Allow Prometheus scraping
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "44180"
+              protocol: TCP
+  egress:
+    # To GitHub (OAuth token exchange + user validation)
+    - toFQDNs:
+        - matchName: github.com
+        - matchName: api.github.com
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # To istiod (xDS for ambient mesh)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: istio-system
+      toPorts:
+        - ports:
+            - port: "15012"
+              protocol: TCP

--- a/kubernetes/platform/config/oauth2-proxy/cookie-secret.yaml
+++ b/kubernetes/platform/config/oauth2-proxy/cookie-secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oauth2-proxy-cookie-secret
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: cookie-secret
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+stringData: { }

--- a/kubernetes/platform/config/oauth2-proxy/github-oauth-credentials.yaml
+++ b/kubernetes/platform/config/oauth2-proxy/github-oauth-credentials.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-oauth-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: github-oauth-credentials
+  data:
+    - secretKey: client-id
+      remoteRef:
+        key: /homelab/kubernetes/shared/github-oauth-proxy
+        property: client-id
+    - secretKey: client-secret
+      remoteRef:
+        key: /homelab/kubernetes/shared/github-oauth-proxy
+        property: client-secret

--- a/kubernetes/platform/config/oauth2-proxy/kustomization.yaml
+++ b/kubernetes/platform/config/oauth2-proxy/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - github-oauth-credentials.yaml
+  - cookie-secret.yaml
+  - oauth2-proxy-route.yaml
+  - oauth2-proxy-canary.yaml

--- a/kubernetes/platform/config/oauth2-proxy/oauth2-proxy-canary.yaml
+++ b/kubernetes/platform/config/oauth2-proxy/oauth2-proxy-canary.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/canaries.flanksource.com/canary_v1.json
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: http-check-oauth2-proxy
+spec:
+  schedule: "@every 1m"
+  http:
+    - name: oauth2-proxy-gateway-health
+      url: https://oauth2-proxy.${internal_domain}/ping
+      responseCodes: [200]
+      maxSSLExpiry: 7
+      thresholdMillis: 5000

--- a/kubernetes/platform/config/oauth2-proxy/oauth2-proxy-route.yaml
+++ b/kubernetes/platform/config/oauth2-proxy/oauth2-proxy-route.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: oauth2-proxy
+spec:
+  parentRefs:
+    - name: internal
+      namespace: istio-gateway
+  hostnames:
+    - "oauth2-proxy.${internal_domain}"
+  rules:
+    - backendRefs:
+        - name: oauth2-proxy
+          port: 4180

--- a/kubernetes/platform/helm-charts.yaml
+++ b/kubernetes/platform/helm-charts.yaml
@@ -189,6 +189,13 @@ spec:
         version: "${spegel_version}"
         url: oci://ghcr.io/spegel-org/helm-charts
       dependsOn: [cilium]
+    - name: oauth2-proxy
+      namespace: oauth2-proxy
+      chart:
+        name: oauth2-proxy
+        version: "${oauth2_proxy_version}"
+        url: https://oauth2-proxy.github.io/manifests
+      dependsOn: [istiod, external-secrets]
     - name: tuppr
       namespace: system-upgrade
       chart:

--- a/kubernetes/platform/kustomization.yaml
+++ b/kubernetes/platform/kustomization.yaml
@@ -31,6 +31,7 @@ configMapGenerator:
       - kube-prometheus-stack.yaml=charts/kube-prometheus-stack.yaml
       - longhorn.yaml=charts/longhorn.yaml
       - metrics-server.yaml=charts/metrics-server.yaml
+      - oauth2-proxy.yaml=charts/oauth2-proxy.yaml
       - alloy.yaml=charts/alloy.yaml
       - reloader.yaml=charts/reloader.yaml
       - replicator.yaml=charts/replicator.yaml

--- a/kubernetes/platform/namespaces.yaml
+++ b/kubernetes/platform/namespaces.yaml
@@ -38,6 +38,10 @@ spec:
       dataplane: ambient
       security: restricted
       networkPolicy: false
+    - name: oauth2-proxy
+      dataplane: ambient
+      security: restricted
+      networkPolicy: false
     # --- baseline: require some elevated capabilities (e.g. NET_BIND_SERVICE) ---
     - name: cache
       dataplane: ambient

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -75,6 +75,8 @@ immich_version=0.10.3
 vectorchord_version=18.1-1.0.0
 # renovate: datasource=helm depName=authelia registryUrl=https://charts.authelia.com
 authelia_version=0.10.49
+# renovate: datasource=helm depName=oauth2-proxy registryUrl=https://oauth2-proxy.github.io/manifests
+oauth2_proxy_version=10.1.3
 # renovate: datasource=docker depName=lldap packageName=ghcr.io/lldap/lldap
 lldap_version=v0.6.2
 # renovate: datasource=docker depName=satisfactory-server packageName=wolveix/satisfactory-server


### PR DESCRIPTION
## Summary
- Adds OAuth2 Proxy as an Istio ext_authz provider, protecting all 6 platform UIs (Prometheus, Alertmanager, Longhorn, Hubble, Garage Admin, Grafana) behind GitHub OAuth with a single SSO cookie
- Replaces Grafana's per-app Authelia OIDC with gateway-level enforcement — auth.proxy trusts headers from OAuth2 Proxy, anonymous fallback for port-forward access
- Agent and automation access (kubectl port-forward, pod-to-pod) is unaffected — the AuthorizationPolicy only targets browser traffic through the internal gateway

## Test plan
- [ ] Create GitHub OAuth App (callback: `https://oauth2-proxy.internal.tomnowak.work/oauth2/callback`) and store `client-id` + `client-secret` in SSM at `/homelab/kubernetes/shared/github-oauth-proxy`
- [ ] Deploy to dev cluster and verify `curl -kI https://prometheus.internal.dev.tomnowak.work/` returns 302 redirect to GitHub
- [ ] After GitHub login, verify all 6 platform UIs load with a single SSO cookie
- [ ] Verify `kubectl port-forward svc/prometheus-operated 9090:9090 -n monitoring` still works (bypasses gateway)
- [ ] Verify `kubectl port-forward svc/grafana 3000:80 -n monitoring` loads Grafana with anonymous Admin access
- [ ] Verify `hubble observe --verdict DROPPED --namespace oauth2-proxy` shows no unexpected drops
- [ ] Emergency disable: `kubectl delete authorizationpolicy platform-ui-auth -n istio-gateway` restores unauthenticated access