### PR TITLE
fix(platform): break circular dependency in oauth2-proxy config

### DIFF
--- a/kubernetes/platform/config.yaml
+++ b/kubernetes/platform/config.yaml
@@ -42,7 +42,7 @@ spec:
     - name: oauth2-proxy-config
       namespace: oauth2-proxy
       path: kubernetes/platform/config/oauth2-proxy
-      dependsOn: [oauth2-proxy, external-secrets-stores, canary-checker]
+      dependsOn: [external-secrets-stores, canary-checker]
     - name: monitoring-config
       namespace: monitoring
       path: kubernetes/platform/config/monitoring


### PR DESCRIPTION
## Summary
- The `oauth2-proxy-config` Kustomization had a circular dependency: it waited for the `oauth2-proxy` HelmRelease, but the HelmRelease needs secrets from that config to start
- Removes `oauth2-proxy` from `dependsOn` — the config only uses ExternalSecret (from `external-secrets`) and Canary CRDs (from `canary-checker`), not oauth2-proxy CRDs
- This unblocks the deadlocked deployment on dev where oauth2-proxy is stuck in `CreateContainerConfigError` and all platform UIs return 403

## Test plan
- [ ] Merge and verify oauth2-proxy pod starts successfully on dev
- [ ] Verify `curl -kI https://prometheus.internal.dev.tomnowak.work/` returns 302 (not 403)
- [ ] Verify canary check alerts resolve within ~2 minutes