### PR TITLE
fix(platform): use plural config keys for oauth2-proxy v7

### DIFF
--- a/kubernetes/platform/charts/oauth2-proxy.yaml
+++ b/kubernetes/platform/charts/oauth2-proxy.yaml
@@ -11,7 +11,7 @@ config:
   cookieSecret: "override-me"
   configFile: |
     provider = "github"
-    github_user = "ionfury"
+    github_users = ["ionfury"]
     cookie_domains = [".${internal_domain}"]
     cookie_expire = "168h"
     cookie_secure = true
@@ -19,9 +19,9 @@ config:
     upstreams = ["static://202"]
     set_xauthrequest = true
     skip_provider_button = true
-    email_domain = ["*"]
+    email_domains = ["*"]
     redirect_url = "https://oauth2-proxy.${internal_domain}/oauth2/callback"
-    whitelist_domain = [".${internal_domain}"]
+    whitelist_domains = [".${internal_domain}"]
 
 extraEnv:
   - name: OAUTH2_PROXY_CLIENT_ID


### PR DESCRIPTION
## Summary
- oauth2-proxy pod CrashLoopBackOff because config file used singular key names (`github_user`, `email_domain`, `whitelist_domain`) which v7's strict validation rejects — requires plural forms for list-type options

## Test plan
- [ ] `task k8s:validate` passes
- [ ] oauth2-proxy pod starts successfully on dev
- [ ] Platform UIs return 302 redirect to GitHub OAuth (not 403)
- [ ] Canary check alerts resolve