### PR TITLE
fix(platform): enable oauth2-proxy redirect after authentication

### DIFF
--- a/kubernetes/platform/charts/istiod.yaml
+++ b/kubernetes/platform/charts/istiod.yaml
@@ -12,6 +12,7 @@ meshConfig:
         headersToDownstreamOnDeny:
           - content-type
           - set-cookie
+          - location
         headersToUpstreamOnAllow:
           - authorization
           - cookie
@@ -27,6 +28,7 @@ meshConfig:
           - x-forwarded-for
         includeAdditionalHeadersInCheck:
           x-forwarded-proto: "https"
+          X-Auth-Request-Redirect: "https://%REQ(:authority)%%REQ(:path)%"
 
 # Disable built-in CA - certificates are issued by istio-csr via cert-manager
 pilot:


### PR DESCRIPTION
## Summary
- Fix oauth2-proxy ext_authz redirect flow so users are sent back to the original service after authenticating with GitHub, instead of getting stuck on the oauth2-proxy "Authenticated" page
- Forward the `Location` header on deny responses so Envoy passes the 302 redirect to GitHub through to the browser
- Inject `X-Auth-Request-Redirect` with the original URL via Envoy variable substitution so oauth2-proxy knows where to redirect after authentication

## Test plan
- [ ] `task k8s:validate` passes (verified locally)
- [ ] After deployment, access a protected internal service (e.g. Grafana) while unauthenticated
- [ ] Verify redirect to GitHub OAuth flow occurs (not blocked)
- [ ] After GitHub authentication, verify redirect back to the original service URL (not stuck on oauth2-proxy page)