### PR TITLE
fix(infra): guard control-plane-only Talos config from worker nodes

### DIFF
--- a/infrastructure/modules/config/resources/talos/talos_machine.yaml.tftpl
+++ b/infrastructure/modules/config/resources/talos/talos_machine.yaml.tftpl
@@ -39,7 +39,7 @@ cluster:
       "${arg.name}": "${arg.value}"
 %{ endfor ~}
 %{ endif ~}
-%{ if length(cluster_etcd_extraArgs) > 0 ~}
+%{ if machine_type == "controlplane" && length(cluster_etcd_extraArgs) > 0 ~}
   etcd:
     extraArgs:
 %{ for arg in cluster_etcd_extraArgs ~}
@@ -82,12 +82,14 @@ machine:
       enabled: true
       forwardKubeDNSToHost: true
       resolveMemberNames: true
+%{ if machine_type == "controlplane" ~}
     kubernetesTalosAPIAccess:
       enabled: true
       allowedRoles:
         - os:admin
       allowedKubernetesNamespaces:
         - system-upgrade
+%{ endif ~}
 %{ if length(machine_labels) > 0 ~}
   nodeLabels:
 %{ for item in machine_labels ~}


### PR DESCRIPTION
## Summary
- Talos machine config template applied `etcd` extraArgs and `kubernetesTalosAPIAccess` to all machines regardless of role, causing `terragrunt apply` to fail when a worker node (node2) was added to the live cluster
- Added `machine_type == "controlplane"` guards to both sections so they are only rendered for control plane nodes

## Test plan
- [x] `task tg:test-config` — all 121 tests pass
- [ ] Re-run `terragrunt apply` on live stack with the worker node