### PR TITLE
fix(infra): guard controlplane-only Talos config for worker nodes

### DIFF
--- a/infrastructure/modules/config/resources/talos/talos_machine.yaml.tftpl
+++ b/infrastructure/modules/config/resources/talos/talos_machine.yaml.tftpl
@@ -39,7 +39,7 @@ cluster:
       "${arg.name}": "${arg.value}"
 %{ endfor ~}
 %{ endif ~}
-%{ if length(cluster_etcd_extraArgs) > 0 ~}
+%{ if machine_type == "controlplane" && length(cluster_etcd_extraArgs) > 0 ~}
   etcd:
     extraArgs:
 %{ for arg in cluster_etcd_extraArgs ~}
@@ -82,12 +82,14 @@ machine:
       enabled: true
       forwardKubeDNSToHost: true
       resolveMemberNames: true
+%{ if machine_type == "controlplane" ~}
     kubernetesTalosAPIAccess:
       enabled: true
       allowedRoles:
         - os:admin
       allowedKubernetesNamespaces:
         - system-upgrade
+%{ endif ~}
 %{ if length(machine_labels) > 0 ~}
   nodeLabels:
 %{ for item in machine_labels ~}


### PR DESCRIPTION
## Summary
- Add `machine_type == "controlplane"` guards to etcd extraArgs and kubernetesTalosAPIAccess blocks in the Talos machine config template, preventing worker nodes from receiving controlplane-only settings
- Add investigation document for a Longhorn nsmounter PID resolution bug affecting RWX NFS mounts on Talos v1.12.4 / Longhorn v1.11.0 (node42 affected due to kubelet being the last numeric PID in lexicographic `/proc` order)

## Test plan
- [ ] `task tg:fmt` passes
- [ ] `task tg:test-config` passes (config module generates correct machine configs for both controlplane and worker types)
- [ ] `task tg:validate-live` passes
- [ ] Review `docs/investigations/longhorn-nsmounter-bug.md` for accuracy and completeness