### PR TITLE
docs(platform): update skills for OAuth2 Proxy

### DIFF
--- a/.claude/skills/k8s/SKILL.md
+++ b/.claude/skills/k8s/SKILL.md
@@ -40,59 +40,55 @@ export KUBECONFIG=~/.kube/<cluster>.yaml && kubectl get pods
 KUBECONFIG=~/.kube/<cluster>.yaml kubectl <command>
 ```
 
-## Accessing Internal Services via DNS (Preferred)
+## Accessing Internal Services
 
-Platform services are exposed through the internal ingress gateway over HTTPS. **Always use DNS-based access instead of port-forwarding** when querying Prometheus, Grafana, Alertmanager, and other internal services.
+Platform services are exposed through the internal ingress gateway over HTTPS. DNS URLs are useful for **browser-based access** (Grafana, Hubble UI, Longhorn UI).
 
-| Service | Live | Integration | Dev |
-|---------|------|-------------|-----|
-| Prometheus | `https://prometheus.internal.tomnowak.work` | `https://prometheus.internal.integration.tomnowak.work` | `https://prometheus.internal.dev.tomnowak.work` |
-| Grafana | `https://grafana.internal.tomnowak.work` | `https://grafana.internal.integration.tomnowak.work` | `https://grafana.internal.dev.tomnowak.work` |
-| Alertmanager | `https://alertmanager.internal.tomnowak.work` | `https://alertmanager.internal.integration.tomnowak.work` | `https://alertmanager.internal.dev.tomnowak.work` |
-| Hubble UI | `https://hubble.internal.tomnowak.work` | `https://hubble.internal.integration.tomnowak.work` | `https://hubble.internal.dev.tomnowak.work` |
-| Longhorn UI | `https://longhorn.internal.tomnowak.work` | `https://longhorn.internal.integration.tomnowak.work` | `https://longhorn.internal.dev.tomnowak.work` |
-| Garage Admin | `https://garage.internal.tomnowak.work` | `https://garage.internal.integration.tomnowak.work` | `https://garage.internal.dev.tomnowak.work` |
+**OAuth2 Proxy caveat:** Prometheus, Alertmanager, and some other services are behind OAuth2 Proxy. DNS URLs redirect to an OAuth login page and **cannot be used for API queries via curl**. Use `kubectl exec` or port-forward instead for programmatic access.
+
+| Service | Live | Auth | API Access |
+|---------|------|------|------------|
+| Prometheus | `https://prometheus.internal.tomnowak.work` | OAuth2 Proxy | `kubectl exec` or port-forward |
+| Alertmanager | `https://alertmanager.internal.tomnowak.work` | OAuth2 Proxy | `kubectl exec` or port-forward |
+| Grafana | `https://grafana.internal.tomnowak.work` | Built-in auth | Browser only |
+| Hubble UI | `https://hubble.internal.tomnowak.work` | None | Browser |
+| Longhorn UI | `https://longhorn.internal.tomnowak.work` | None | Browser |
+| Garage Admin | `https://garage.internal.tomnowak.work` | None | Browser |
 
 **Domain pattern:** `<service>.internal.<cluster-suffix>.tomnowak.work`
 - live: `internal.tomnowak.work`
 - integration: `internal.integration.tomnowak.work`
 - dev: `internal.dev.tomnowak.work`
 
-**Usage with curl (use `-k` for self-signed TLS):**
+### Querying Prometheus/Alertmanager API
 
 ```bash
-# Query Prometheus API
-curl -sk "https://prometheus.internal.tomnowak.work/api/v1/query?query=up" | jq '.data.result'
+# Option 1: kubectl exec (quick, no setup)
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=up' | jq '.data.result'
 
-# Check firing alerts
-curl -sk "https://prometheus.internal.tomnowak.work/api/v1/alerts" | jq '.data.alerts[] | select(.state == "firing")'
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/alerts' | jq '.data.alerts[] | select(.state == "firing")'
 
-# Query Alertmanager
-curl -sk "https://alertmanager.internal.tomnowak.work/api/v2/alerts" | jq .
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl exec -n monitoring alertmanager-kube-prometheus-stack-0 -c alertmanager -- \
+  wget -qO- 'http://localhost:9093/api/v2/alerts' | jq .
+
+# Option 2: Port-forward (for scripts and repeated queries)
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090 &
+curl -s "http://localhost:9090/api/v1/query?query=up" | jq '.data.result'
 ```
 
-**Using the helper scripts with internal DNS:**
+**Using the helper scripts:**
 
 ```bash
-# Prometheus (live cluster)
-export PROMETHEUS_URL=https://prometheus.internal.tomnowak.work
+# Prometheus (start port-forward first; script defaults to http://localhost:9090)
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090 &
 .claude/skills/prometheus/scripts/promql.sh alerts --firing
 
-# Loki (no HTTPRoute - requires port-forward, see fallback below)
+# Loki (no HTTPRoute — always requires port-forward)
 KUBECONFIG=~/.kube/<cluster>.yaml kubectl port-forward -n monitoring svc/loki-headless 3100:3100 &
 export LOKI_URL=http://localhost:3100
 .claude/skills/loki/scripts/logql.sh tail '{namespace="monitoring"}' --since 15m
-```
-
-**Note:** Loki does not have an HTTPRoute on the internal gateway. Use port-forward for Loki access.
-
-### Fallback: Port-Forward Access
-
-Use port-forwarding only when DNS-based access is unavailable (e.g., network issues, local development without VPN):
-
-```bash
-KUBECONFIG=~/.kube/<cluster>.yaml kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090 &
-KUBECONFIG=~/.kube/<cluster>.yaml kubectl port-forward -n monitoring svc/loki-headless 3100:3100 &
 ```
 
 # Common kubectl Patterns

--- a/.claude/skills/monitoring-authoring/SKILL.md
+++ b/.claude/skills/monitoring-authoring/SKILL.md
@@ -640,17 +640,21 @@ task k8s:validate
 
 ### Step 6: Verify After Deployment
 
+Prometheus is behind OAuth2 Proxy — use `kubectl exec` or port-forward for API queries:
+
 ```bash
 # Check ServiceMonitor is discovered
-curl -sk "https://prometheus.internal.tomnowak.work/api/v1/targets" | \
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/targets' | \
   jq '.data.activeTargets[] | select(.labels.job | contains("<component>"))'
 
 # Check alert rules are loaded
-curl -sk "https://prometheus.internal.tomnowak.work/api/v1/rules" | \
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/rules' | \
   jq '.data.groups[] | select(.name | contains("<component>"))'
 
 # Check canary status
-kubectl get canaries -A | grep <component>
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl get canaries -A | grep <component>
 ```
 
 ---

--- a/.claude/skills/prometheus/SKILL.md
+++ b/.claude/skills/prometheus/SKILL.md
@@ -8,37 +8,38 @@ user-invocable: false
 
 ## Setup
 
-Prometheus is accessible via the internal ingress gateway over HTTPS. **Always use DNS-based access as the default approach.**
+Prometheus and Alertmanager are behind **OAuth2 Proxy** on the internal gateway. DNS URLs (`https://prometheus.internal.tomnowak.work`) redirect to an OAuth login page and **cannot be used for API queries via curl**.
 
-| Cluster | URL |
-|---------|-----|
-| live | `https://prometheus.internal.tomnowak.work` |
-| integration | `https://prometheus.internal.integration.tomnowak.work` |
-| dev | `https://prometheus.internal.dev.tomnowak.work` |
+### Access Methods
+
+**Option 1: kubectl exec (quick, no setup)**
 
 ```bash
-# Set URL to the appropriate cluster (live example)
-export PROMETHEUS_URL=https://prometheus.internal.tomnowak.work
+# Query Prometheus API directly inside the pod
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=up' | jq '.data.result'
+
+# Query Alertmanager API
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl exec -n monitoring alertmanager-kube-prometheus-stack-0 -c alertmanager -- \
+  wget -qO- 'http://localhost:9093/api/v2/alerts' | jq .
 ```
 
-**Note:** The internal gateway uses a homelab CA certificate. Use `-k` with curl to skip TLS verification, or configure the CA trust. The `promql.sh` script uses `curl -f` internally, so set `CURL_INSECURE=true` or use the `--insecure` flag if needed.
-
-### Fallback: Port-Forward Access
-
-Use port-forwarding only when DNS-based access is unavailable:
+**Option 2: Port-forward (for scripts and repeated queries)**
 
 ```bash
-KUBECONFIG=~/.kube/<cluster>.yaml kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090 &
 export PROMETHEUS_URL=http://localhost:9090
 ```
+
+The `promql.sh` script defaults to `http://localhost:9090` and works with port-forward out of the box.
 
 ## Quick Queries
 
 Use the bundled script at `.claude/skills/prometheus/scripts/promql.sh`:
 
 ```bash
-# Set URL (default uses internal gateway for live cluster)
-export PROMETHEUS_URL=https://prometheus.internal.tomnowak.work
+# Start port-forward first (script defaults to http://localhost:9090)
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090 &
 
 # Instant query
 ./scripts/promql.sh query 'up'
@@ -87,14 +88,16 @@ export PROMETHEUS_URL=https://prometheus.internal.tomnowak.work
 ./scripts/promql.sh alerts --verbose
 ```
 
-### Direct curl (alternative)
+### Direct kubectl exec (alternative)
 
 ```bash
-# Instant query (use -k for self-signed TLS)
-curl -sk "https://prometheus.internal.tomnowak.work/api/v1/query?query=up" | jq '.data.result'
+# Instant query via kubectl exec (no port-forward needed)
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=up' | jq '.data.result'
 
 # Alerts
-curl -sk "https://prometheus.internal.tomnowak.work/api/v1/alerts" | jq '.data.alerts'
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/alerts' | jq '.data.alerts'
 ```
 
 ## Reference

--- a/.claude/skills/prometheus/scripts/promql.sh
+++ b/.claude/skills/prometheus/scripts/promql.sh
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-PROMETHEUS_URL="${PROMETHEUS_URL:-https://prometheus.internal.tomnowak.work}"
+PROMETHEUS_URL="${PROMETHEUS_URL:-http://localhost:9090}"
 
 usage() {
     cat <<EOF
@@ -46,7 +46,7 @@ Output Options:
   --verbose          Show full response including status
 
 Environment:
-  PROMETHEUS_URL     Prometheus base URL [default: https://prometheus.internal.tomnowak.work]
+  PROMETHEUS_URL     Prometheus base URL [default: http://localhost:9090]
 
 Examples:
   # Current CPU usage across all nodes

--- a/.claude/skills/sre/SKILL.md
+++ b/.claude/skills/sre/SKILL.md
@@ -102,14 +102,16 @@ kubectl get events -n <namespace> --sort-by='.lastTimestamp'
 kubectl top pods -n <namespace>
 ```
 
-**Metrics and alerts via internal gateway (preferred over port-forward):**
+**Metrics and alerts via kubectl exec (Prometheus is behind OAuth2 Proxy — DNS URLs won't work for API queries):**
 
 ```bash
 # Check firing alerts
-curl -sk "https://prometheus.internal.tomnowak.work/api/v1/alerts" | jq '.data.alerts[] | select(.state == "firing")'
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/alerts' | jq '.data.alerts[] | select(.state == "firing")'
 
 # Pod restart metrics
-curl -sk "https://prometheus.internal.tomnowak.work/api/v1/query?query=increase(kube_pod_container_status_restarts_total[1h])>0" | jq '.data.result'
+KUBECONFIG=~/.kube/<cluster>.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=increase(kube_pod_container_status_restarts_total[1h])>0' | jq '.data.result'
 ```
 
 ### Phase 3: Correlation


### PR DESCRIPTION
## Summary
- PR #402 placed Prometheus and Alertmanager behind OAuth2 Proxy, which breaks `curl -sk` API access via DNS URLs (they now redirect to an OAuth login page)
- Update skill files (prometheus, k8s, sre, monitoring-authoring) to use `kubectl exec` + `wget` or port-forward as the primary API access method
- Change `promql.sh` default URL from DNS to `http://localhost:9090` (port-forward)

## Test plan
- [ ] Verify `promql.sh` works with port-forward: `kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090 & && .claude/skills/prometheus/scripts/promql.sh alerts --firing`
- [ ] Verify `kubectl exec` pattern works: `kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- wget -qO- 'http://localhost:9090/api/v1/query?query=up'`