### PR TITLE
fix(k8s): switch qbittorrent VPN from OpenVPN to WireGuard

### DIFF
--- a/.github/workflows/check-version-holds.yaml
+++ b/.github/workflows/check-version-holds.yaml
@@ -4,7 +4,7 @@ name: Check Version Holds
 
 on:
   schedule:
-    - cron: "0 13 * * 1" # Monday 8am ET (13:00 UTC)
+    - cron: "0 13 * * 1"  # Monday 8am ET (13:00 UTC)
   push:
     branches: [main]
     paths: [".github/version-holds.yaml"]

--- a/kubernetes/clusters/live/charts/qbittorrent.yaml
+++ b/kubernetes/clusters/live/charts/qbittorrent.yaml
@@ -22,21 +22,15 @@ controllers:
           tag: "${gluetun_version}"
         env:
           VPN_SERVICE_PROVIDER: nordvpn
-          VPN_TYPE: openvpn
-          OPENVPN_USER:
+          VPN_TYPE: wireguard
+          WIREGUARD_PRIVATE_KEY:
             valueFrom:
               secretKeyRef:
-                name: nordvpn-credentials
-                key: OPENVPN_USER
-          OPENVPN_PASSWORD:
-            valueFrom:
-              secretKeyRef:
-                name: nordvpn-credentials
-                key: OPENVPN_PASSWORD
+                name: nordvpn-wireguard-credentials
+                key: WIREGUARD_PRIVATE_KEY
           SERVER_COUNTRIES: United States
           SERVER_CATEGORIES: P2P
           DNS_KEEP_NAMESERVER: "on"
-          DOT: "off"
           FIREWALL_OUTBOUND_SUBNETS: "172.18.0.0/16,172.19.0.0/16,192.168.10.0/24"
           HEALTH_SERVER_ADDRESS: "0.0.0.0:9999"
         securityContext:

--- a/kubernetes/clusters/live/config/media-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - secrets.yaml
   - network-policy.yaml
   - nordvpn-credentials.yaml
+  - nordvpn-wireguard-credentials.yaml

--- a/kubernetes/clusters/live/config/media-prereqs/nordvpn-wireguard-credentials.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/nordvpn-wireguard-credentials.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# NordVPN WireGuard credentials for Gluetun VPN sidecar.
+# Stored in AWS SSM with WIREGUARD_PRIVATE_KEY property.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nordvpn-wireguard-credentials
+  namespace: media
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: nordvpn-wireguard-credentials
+  data:
+    - secretKey: WIREGUARD_PRIVATE_KEY
+      remoteRef:
+        key: /homelab/kubernetes/live/nordvpn-wireguard-credentials
+        property: WIREGUARD_PRIVATE_KEY


### PR DESCRIPTION
## Summary
- Switches gluetun VPN sidecar from OpenVPN to WireGuard protocol for NordVPN
- NordVPN OpenVPN auth is failing server-wide (gluetun#3132); WireGuard uses cryptographic key auth which is unaffected
- Adds new ExternalSecret for WireGuard private key from AWS SSM

## Test plan
- [ ] `task k8s:validate` passes
- [ ] After merge, verify qbittorrent pod starts and gluetun connects via WireGuard
- [ ] Verify VPN tunnel is active (external IP should be NordVPN, not home IP)