### PR TITLE
fix(apps): disable gluetun DNS_KEEP_NAMESERVER to fix healthcheck

### DIFF
--- a/kubernetes/clusters/live/charts/qbittorrent.yaml
+++ b/kubernetes/clusters/live/charts/qbittorrent.yaml
@@ -30,7 +30,7 @@ controllers:
                 key: WIREGUARD_PRIVATE_KEY
           SERVER_COUNTRIES: United States
           SERVER_CATEGORIES: P2P
-          DNS_KEEP_NAMESERVER: "on"
+          DNS_KEEP_NAMESERVER: "off"
           FIREWALL_OUTBOUND_SUBNETS: "172.18.0.0/16,172.19.0.0/16,192.168.10.0/24"
           HEALTH_SERVER_ADDRESS: "0.0.0.0:9999"
         securityContext:


### PR DESCRIPTION
## Summary
- Gluetun's internal iptables firewall blocks UDP DNS packets to kube-dns even when the subnet is in `FIREWALL_OUTBOUND_SUBNETS`, causing the healthcheck to fail with `write: operation not permitted`
- Setting `DNS_KEEP_NAMESERVER=off` tells gluetun to use only VPN-provided DNS instead of trying to reach kube-dns, bypassing the firewall conflict
- This is the final piece of the qbittorrent VPN fix (WireGuard switch in #414, gluetun downgrade in #412)

## Test plan
- [ ] PR passes validation
- [ ] After merge + promotion, suspend/resume qbittorrent HelmRelease on live
- [ ] Verify gluetun healthcheck passes (no `operation not permitted` errors)
- [ ] Verify qbittorrent pod reaches Running state
- [ ] Verify VPN tunnel is active (gluetun logs show WireGuard connected)