### PR TITLE
fix(apps): resolve gluetun OOMKill and WireGuard IPv6 rule conflict

### DIFF
--- a/kubernetes/clusters/live/charts/qbittorrent.yaml
+++ b/kubernetes/clusters/live/charts/qbittorrent.yaml
@@ -4,6 +4,7 @@
 controllers:
   qbittorrent:
     type: deployment
+    strategy: Recreate
     annotations:
       reloader.stakater.com/auto: "true"
 
@@ -33,6 +34,13 @@ controllers:
           DNS_KEEP_NAMESERVER: "off"
           FIREWALL_OUTBOUND_SUBNETS: "172.18.0.0/16,172.19.0.0/16,192.168.10.0/24"
           HEALTH_SERVER_ADDRESS: "0.0.0.0:9999"
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - (ip rule del table 51820; ip -6 rule del table 51820) || true
         securityContext:
           runAsUser: 0
           runAsGroup: 0
@@ -44,7 +52,7 @@ controllers:
             cpu: 10m
             memory: 64Mi
           limits:
-            memory: 128Mi
+            memory: 256Mi
         probes:
           startup:
             enabled: true


### PR DESCRIPTION
## Summary
- Gluetun OOMKills at 128Mi during WireGuard kernel module setup, leaving stale IP routing rules (table 51820) in the pod's network namespace
- On restart, WireGuard fails with "ip rule: file exists", preventing tunnel establishment — gluetun's firewall then blocks all outbound traffic including DNS
- Adds `postStart` lifecycle hook (per [gluetun wiki](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/kubernetes.md#adding-ipv6-rule--file-exists)) to clean stale rules, bumps memory to 256Mi, and sets Recreate strategy

## Test plan
- [ ] PR passes validation
- [ ] After merge + promotion, suspend/resume qbittorrent HelmRelease on live
- [ ] Verify gluetun container starts without OOMKill
- [ ] Verify no "ip rule: file exists" errors in gluetun logs
- [ ] Verify WireGuard tunnel establishes and healthcheck passes
- [ ] Verify qbittorrent pod reaches Running 2/2 state