### PR TITLE
fix(apps): align gluetun with community Kubernetes VPN patterns

### DIFF
--- a/.claude/skills/app-template/SKILL.md
+++ b/.claude/skills/app-template/SKILL.md
@@ -378,6 +378,25 @@ controllers:
             enabled: false
 ```
 
+## Resource Limits
+
+Resource limits exist to prevent runaway processes, not to optimize bin-packing. The homelab hardware is heavily over-provisioned — **be generous with limits** rather than running tight to avoid OOMKills and CrashLoopBackOff.
+
+**Guidelines:**
+- **Limits should be 2-4x the expected working set** — leave room for spikes, GC pressure, and startup allocations
+- **Requests should reflect steady-state usage** — this is what the scheduler uses for placement
+- **Never set CPU limits** unless the workload is genuinely CPU-abusive — CPU throttling causes latency spikes and is harder to debug than memory OOMKills
+- **When in doubt, go higher** — an OOMKill costs more in debugging time than 128Mi of unused RAM
+
+**Typical ranges for common workloads:**
+
+| Workload Type | Memory Request | Memory Limit |
+|--------------|----------------|--------------|
+| Lightweight sidecar (gluetun, oauth2-proxy) | 64Mi | 256Mi |
+| Web application | 128-256Mi | 512Mi-1Gi |
+| Media application (qbittorrent, jellyfin) | 512Mi | 2-4Gi |
+| Database (CNPG) | 256Mi | 1-2Gi |
+
 ## StatefulSet with VolumeClaimTemplates
 
 ```yaml

--- a/kubernetes/clusters/live/charts/qbittorrent.yaml
+++ b/kubernetes/clusters/live/charts/qbittorrent.yaml
@@ -30,7 +30,8 @@ controllers:
                 key: WIREGUARD_PRIVATE_KEY
           SERVER_COUNTRIES: United States
           SERVER_CATEGORIES: P2P
-          DNS_KEEP_NAMESERVER: "off"
+          DNS_KEEP_NAMESERVER: "on"
+          DOT: "off"
           FIREWALL_OUTBOUND_SUBNETS: "172.18.0.0/16,172.19.0.0/16,192.168.10.0/24"
           HEALTH_SERVER_ADDRESS: "0.0.0.0:9999"
         securityContext:
@@ -38,13 +39,13 @@ controllers:
           runAsGroup: 0
           runAsNonRoot: false
           capabilities:
-            add: [NET_ADMIN]
+            add: [NET_ADMIN, NET_RAW]
         resources:
           requests:
             cpu: 10m
             memory: 64Mi
           limits:
-            memory: 128Mi
+            memory: 256Mi
         probes:
           startup:
             enabled: true


### PR DESCRIPTION
## Summary
- The community-proven gluetun+WireGuard pattern uses `DNS_KEEP_NAMESERVER=on` with `DOT=off` — keeping kube-dns as the resolver while disabling DNS-over-TLS (which tries to reach 1.1.1.1:853 before the tunnel is up, blocked by gluetun's own firewall)
- Adds `NET_RAW` capability needed by WireGuard and bumps memory to 256Mi to prevent OOMKill during kernel module setup
- Also documents resource limit philosophy in app-template skill — be generous with limits on over-provisioned hardware

## Test plan
- [ ] PR passes validation
- [ ] After merge + promotion, suspend/resume qbittorrent HelmRelease on live
- [ ] Verify gluetun starts without OOMKill
- [ ] Verify WireGuard tunnel establishes (gluetun logs show connected)
- [ ] Verify healthcheck passes (no `operation not permitted` errors)
- [ ] Verify qbittorrent pod reaches Running 2/2 state