### PR TITLE
fix(monitoring): add Dragonfly cache PodMonitor to kustomization

### DIFF
--- a/kubernetes/platform/config/dragonfly/kustomization.yaml
+++ b/kubernetes/platform/config/dragonfly/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - password-secret.yaml
   - dragonfly-instance.yaml
+  - podmonitor.yaml
   - prometheus-rules.yaml

--- a/kubernetes/platform/config/dragonfly/podmonitor.yaml
+++ b/kubernetes/platform/config/dragonfly/podmonitor.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dragonfly
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - cache
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dragonfly
+  podMetricsEndpoints:
+    - port: admin
+      path: /metrics
+      interval: 30s


### PR DESCRIPTION
## Summary
- The Dragonfly cache PodMonitor existed as an untracked file but was never committed to git and was missing from `kustomization.yaml`, so Flux never deployed it to the cluster
- This caused a gap in metrics coverage for the Dragonfly cache instances in the `cache` namespace

## Test plan
- [x] `task k8s:validate` passes
- [ ] After merge, verify PodMonitor appears in cluster: `kubectl get podmonitor dragonfly -n monitoring`
- [ ] Verify Prometheus discovers new target: check `cache/dragonfly` scrape pool in Prometheus targets