### PR TITLE
feat(platform): add standalone Loki ServiceMonitor

### DIFF
--- a/kubernetes/platform/config/monitoring/kustomization.yaml
+++ b/kubernetes/platform/config/monitoring/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
   - grafana-alerts.yaml
   - loki-mixin-alerts.yaml
   - loki-mixin-recording-rules.yaml
+  - loki-servicemonitor.yaml
   - flux-podmonitor.yaml
   - alloy-alerts.yaml
   - hardware-monitoring-secrets.yaml

--- a/kubernetes/platform/config/monitoring/loki-servicemonitor.yaml
+++ b/kubernetes/platform/config/monitoring/loki-servicemonitor.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: loki
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - monitoring
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  endpoints:
+    - port: http-metrics
+      path: /metrics
+      interval: 30s


### PR DESCRIPTION
## Summary
- Loki's chart `serviceMonitor.enabled: true` does not generate a ServiceMonitor in single-binary mode, leaving Loki metrics unscraped by Prometheus
- Adds a standalone ServiceMonitor targeting `grafana-loki-single-binary` service on port `http-metrics`

## Test plan
- [ ] `task k8s:validate` passes
- [ ] After merge, verify ServiceMonitor appears: `kubectl -n monitoring get servicemonitor loki`
- [ ] Confirm Prometheus target is up: check `prometheus/targets` for `serviceMonitor/monitoring/loki`