### PR TITLE
feat(platform): add internal gateway and CNI PodMonitors

### DIFF
--- a/kubernetes/platform/config/monitoring/istio-servicemonitors.yaml
+++ b/kubernetes/platform/config/monitoring/istio-servicemonitors.yaml
@@ -58,3 +58,43 @@ spec:
     - port: http-envoy-prom
       path: /stats/prometheus
       interval: 30s
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: internal-istio-gateway
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - istio-gateway
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: internal
+  podMetricsEndpoints:
+    - port: http-envoy-prom
+      path: /stats/prometheus
+      interval: 30s
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: istio-cni
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - istio-system
+  selector:
+    matchLabels:
+      k8s-app: istio-cni-node
+  podMetricsEndpoints:
+    - port: "15014"
+      path: /metrics
+      interval: 30s


### PR DESCRIPTION
## Summary
- The internal Istio gateway and istio-cni-node both expose Prometheus metrics but had no PodMonitors, creating observability gaps in the mesh data plane
- Mirrors the existing external gateway PodMonitor pattern for the internal gateway and adds CNI node metrics collection

## Test plan
- [ ] `task k8s:validate` passes
- [ ] After merge, verify PodMonitors: `kubectl -n monitoring get podmonitor internal-istio-gateway istio-cni`
- [ ] Confirm targets appear in Prometheus