### PR TITLE
feat(platform): enable Dragonfly operator ServiceMonitor

### DIFF
--- a/kubernetes/platform/charts/dragonfly-operator.yaml
+++ b/kubernetes/platform/charts/dragonfly-operator.yaml
@@ -16,7 +16,7 @@ resources:
     memory: 256Mi
 
 serviceMonitor:
-  enabled: false
+  enabled: true
   interval: 60s
 
 grafanaDashboard:


### PR DESCRIPTION
## Summary
- The Dragonfly operator exposes metrics but had `serviceMonitor.enabled: false`, preventing visibility into operator reconciliation health

## Test plan
- [ ] `task k8s:validate` passes
- [ ] After merge, verify ServiceMonitor: `kubectl -n dragonfly-system get servicemonitor`
- [ ] Confirm Prometheus target is up for dragonfly-operator