### PR TITLE
fix(platform): correct OAuth2 Proxy ServiceMonitor key casing

### DIFF
--- a/kubernetes/platform/charts/oauth2-proxy.yaml
+++ b/kubernetes/platform/charts/oauth2-proxy.yaml
@@ -48,7 +48,7 @@ service:
 metrics:
   enabled: true
   port: 44180
-  servicemonitor:
+  serviceMonitor:
     enabled: true
 
 securityContext:


### PR DESCRIPTION
## Summary
- The OAuth2 Proxy chart expects camelCase `serviceMonitor` but the values file used lowercase `servicemonitor`, causing Helm to silently ignore the configuration
- This one-character casing fix enables the ServiceMonitor that was always intended

## Test plan
- [ ] `task k8s:validate` passes
- [ ] After merge, verify ServiceMonitor: `kubectl -n monitoring get servicemonitor -l app.kubernetes.io/name=oauth2-proxy`
- [ ] Confirm Prometheus target is up for oauth2-proxy