### PR TITLE
fix(platform): correct Tuppr ServiceMonitor values nesting

### DIFF
--- a/kubernetes/platform/charts/tuppr.yaml
+++ b/kubernetes/platform/charts/tuppr.yaml
@@ -1,4 +1,5 @@
 ---
 # https://github.com/home-operations/tuppr
-serviceMonitor:
-  enabled: true
+monitoring:
+  serviceMonitor:
+    enabled: true


### PR DESCRIPTION
## Summary
- The Tuppr chart expects `monitoring.serviceMonitor.enabled` but the values file had `serviceMonitor.enabled` at the top level, so Helm never created the ServiceMonitor
- Corrects the YAML nesting to match the chart's expected values structure

## Test plan
- [ ] `task k8s:validate` passes
- [ ] After merge, verify ServiceMonitor: `kubectl -n system-upgrade get servicemonitor`
- [ ] Confirm Prometheus target is up for tuppr