### PR TITLE
fix(apps): disable gluetun firewall for Talos kernel 6.18 compat

### DIFF
--- a/kubernetes/clusters/live/charts/qbittorrent.yaml
+++ b/kubernetes/clusters/live/charts/qbittorrent.yaml
@@ -32,6 +32,10 @@ controllers:
           SERVER_CATEGORIES: P2P
           DNS_KEEP_NAMESERVER: "on"
           DOT: "off"
+          # Talos v1.12 kernel 6.18 disables CONFIG_NETFILTER_XTABLES_LEGACY,
+          # breaking gluetun's iptables test rule cleanup. Cilium network
+          # policies provide egress enforcement at the cluster level.
+          FIREWALL: "off"
           FIREWALL_OUTBOUND_SUBNETS: "172.18.0.0/16,172.19.0.0/16,192.168.10.0/24"
           HEALTH_SERVER_ADDRESS: "0.0.0.0:9999"
         securityContext:


### PR DESCRIPTION
## Summary
- Gluetun v3.40.0 crashes on Talos v1.12 (kernel 6.18) because `CONFIG_NETFILTER_XTABLES_LEGACY` is disabled, breaking iptables test rule cleanup
- Cannot upgrade to v3.41.x due to healthcheck regression (upstream #3132, held in version-holds.yaml)
- Disable gluetun's built-in iptables firewall (`FIREWALL=off`) to bypass the incompatibility; Cilium network policies provide egress enforcement at the cluster level

## Test plan
- [x] Validated with `task k8s:validate`
- [ ] Verify qbittorrent pod starts without gluetun iptables errors on live cluster after merge
- [ ] Verify VPN tunnel establishes successfully (gluetun healthcheck passes)