### PR TITLE
fix(infra): increase scheduler spread plugin weights to improve HA distribution

### DIFF
--- a/infrastructure/modules/config/resources/talos/talos_machine.yaml.tftpl
+++ b/infrastructure/modules/config/resources/talos/talos_machine.yaml.tftpl
@@ -25,6 +25,13 @@ cluster:
       kind: KubeSchedulerConfiguration
       profiles:
         - schedulerName: default-scheduler
+          plugins:
+            score:
+              enabled:
+                - name: PodTopologySpread
+                  weight: 5
+                - name: InterPodAffinity
+                  weight: 5
           pluginConfig:
             - name: PodTopologySpread
               args:


### PR DESCRIPTION
## Summary
- HA audit found that soft anti-affinity and topology spread preferences were being consistently overruled by resource-based scoring (NodeResourcesFit, NodeResourcesBalancedAllocation) on the heterogeneous 4-node cluster
- This caused both CoreDNS replicas and other critical services to concentrate on node2 (the largest node), defeating the purpose of soft anti-affinity rules
- Increasing PodTopologySpread and InterPodAffinity plugin weights from 2 (default) to 5 makes spread score up to ~500 pts vs resource scoring max of ~200 pts, ensuring spread preferences reliably win without requiring hard constraints

## Test plan
- [x] `task tg:fmt` passes
- [x] `task tg:test-config` passes (121/121 tests)
- [ ] After merge, verify new pods spread across nodes instead of concentrating on node2
- [ ] Verify single-node dev cluster still schedules pods normally (ScheduleAnyway policy unchanged)