### PR TITLE
fix(storage): add explicit Longhorn backup Setting CRDs

### DIFF
--- a/kubernetes/platform/config/longhorn/backup/backup-target-credential-secret.yaml
+++ b/kubernetes/platform/config/longhorn/backup/backup-target-credential-secret.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/longhorn.io/setting_v1beta2.json
+apiVersion: longhorn.io/v1beta2
+kind: Setting
+metadata:
+  name: backup-target-credential-secret
+  namespace: longhorn-system
+value: longhorn-s3-backup-credentials

--- a/kubernetes/platform/config/longhorn/backup/backup-target.yaml
+++ b/kubernetes/platform/config/longhorn/backup/backup-target.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/longhorn.io/setting_v1beta2.json
+apiVersion: longhorn.io/v1beta2
+kind: Setting
+metadata:
+  name: backup-target
+  namespace: longhorn-system
+value: s3://homelab-longhorn-backup-${cluster_name}@us-east-2/

--- a/kubernetes/platform/config/longhorn/backup/kustomization.yaml
+++ b/kubernetes/platform/config/longhorn/backup/kustomization.yaml
@@ -5,3 +5,5 @@ kind: Kustomization
 
 resources:
   - external-secret.yaml
+  - backup-target.yaml
+  - backup-target-credential-secret.yaml


### PR DESCRIPTION
## Summary
- Fixes HA audit finding #1 (P0 CRITICAL): Longhorn BackupTarget URL is empty, causing all 6 recurring backup jobs to silently fail with zero backups
- Root cause: `defaultSettings.backupTarget` Helm value only applies on initial chart install — it does not propagate to the BackupTarget CRD on existing clusters
- Adds explicit `Setting` CRDs (`backup-target` and `backup-target-credential-secret`) that Flux will reconcile, ensuring the backup target converges on both new and existing clusters

## Test plan
- [x] `task k8s:validate` passes
- [ ] After merge and promotion to integration, verify Setting CRs exist: `kubectl -n longhorn-system get settings backup-target -o yaml`
- [ ] Verify BackupTarget URL is populated: `kubectl -n longhorn-system get backuptargets -o yaml`
- [ ] Verify recurring backup jobs start producing backups within 6 hours