### PR TITLE
fix(apps): opt qbittorrent out of Istio ambient mesh

### DIFF
--- a/kubernetes/clusters/live/charts/qbittorrent.yaml
+++ b/kubernetes/clusters/live/charts/qbittorrent.yaml
@@ -8,6 +8,11 @@ controllers:
       reloader.stakater.com/auto: "true"
 
     pod:
+      annotations:
+        # Gluetun's iptables OUTPUT DROP policy conflicts with ztunnel's
+        # DNS redirect (UDP:53 -> 15053). The VPN sidecar doesn't benefit
+        # from mesh features, so opt the pod out of ambient interception.
+        ambient.istio.io/redirection: disabled
       securityContext:
         fsGroup: 568
         fsGroupChangePolicy: OnRootMismatch


### PR DESCRIPTION
## Summary
- Disable Istio ambient traffic interception for the qbittorrent pod via pod annotation
- Gluetun's iptables OUTPUT DROP policy conflicts with ztunnel's DNS redirect (UDP:53 to port 15053), preventing DNS resolution inside the VPN sidecar

## Test plan
- [x] Validated with `task k8s:validate`
- [ ] Pod starts successfully and gluetun resolves DNS without ztunnel interference
- [ ] VPN tunnel establishes and qbittorrent WebUI is accessible