### PR TITLE
feat(platform): add descheduler defaultConstraints for topology spread

### DIFF
--- a/kubernetes/platform/charts/descheduler.yaml
+++ b/kubernetes/platform/charts/descheduler.yaml
@@ -25,6 +25,10 @@ deschedulerPolicy:
             constraints:
               - DoNotSchedule
               - ScheduleAnyway
+            defaultConstraints:
+              - maxSkew: 1
+                topologyKey: kubernetes.io/hostname
+                whenUnsatisfiable: ScheduleAnyway
         - name: RemoveFailedPods
           args:
             excludeOwnerKinds:


### PR DESCRIPTION
## Summary
- The descheduler cannot read the kube-scheduler's cluster-level default topology spread constraints ([upstream limitation](https://github.com/kubernetes-sigs/descheduler/issues/1502)). Adding `defaultConstraints` mirrors the scheduler config so the descheduler can detect and rebalance pods that violate the cluster-wide `maxSkew:1` hostname spread, even when pods lack explicit `topologySpreadConstraints` in their spec.
- Complements #426 (scheduler plugin weight increase) -- together they form a self-correcting system: the scheduler places new pods correctly, and the descheduler gradually rebalances existing concentrated pods.

## Test plan
- [x] Validated with `task k8s:validate`
- [ ] Descheduler pods restart cleanly after merge
- [ ] Verify descheduler logs show topology spread evaluation for pods without explicit constraints