### PR TITLE
fix(platform): remove invalid region key from CNPG S3 credentials

### DIFF
--- a/kubernetes/clusters/live/config/immich/immich-cluster.yaml
+++ b/kubernetes/clusters/live/config/immich/immich-cluster.yaml
@@ -45,9 +45,6 @@ spec:
         secretAccessKey:
           name: cnpg-immich-s3-credentials
           key: secret-access-key
-        region:
-          name: cnpg-immich-s3-credentials
-          key: region
       wal:
         compression: gzip
       data:

--- a/kubernetes/platform/config/database/cluster.yaml
+++ b/kubernetes/platform/config/database/cluster.yaml
@@ -39,9 +39,6 @@ spec:
         secretAccessKey:
           name: cnpg-platform-s3-credentials
           key: secret-access-key
-        region:
-          name: cnpg-platform-s3-credentials
-          key: region
       wal:
         compression: gzip
       data:


### PR DESCRIPTION
## Summary
- CNPG WAL archiving was failing on both the platform shared cluster and immich dedicated cluster because the `barmanObjectStore.s3Credentials.region` field referenced a key (`region`) that garage-operator does not generate in S3 credential secrets
- Removes the optional `region` SecretKeySelector from both CNPG cluster definitions — the region field is not required for garage S3 endpoints

## Test plan
- [ ] Verify CNPG WAL archiving resumes on the platform shared cluster (`database` namespace)
- [ ] Verify CNPG WAL archiving resumes on the immich dedicated cluster (`live` cluster)
- [ ] Check `kubectl -n database describe cluster platform` shows healthy backup status