### PR TITLE
feat(platform): add CoreDNS topology spread and PDB

### DIFF
--- a/kubernetes/platform/config.yaml
+++ b/kubernetes/platform/config.yaml
@@ -75,6 +75,10 @@ spec:
       namespace: ""
       path: kubernetes/platform/config/network-policy
       dependsOn: [cilium]
+    - name: coredns-ha
+      namespace: kube-system
+      path: kubernetes/platform/config/coredns
+      dependsOn: []  # PDB and Deployment are built-in resources (no CRDs needed)
     - name: priority-classes-config
       namespace: ""
       path: kubernetes/platform/config/priority-classes

--- a/kubernetes/platform/config/coredns/kustomization.yaml
+++ b/kubernetes/platform/config/coredns/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pdb.yaml
+  - topology-spread-patch.yaml

--- a/kubernetes/platform/config/coredns/pdb.yaml
+++ b/kubernetes/platform/config/coredns/pdb.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/poddisruptionbudget-policy-v1.json
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: coredns
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns

--- a/kubernetes/platform/config/coredns/topology-spread-patch.yaml
+++ b/kubernetes/platform/config/coredns/topology-spread-patch.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              k8s-app: kube-dns


### PR DESCRIPTION
## Summary
- Both CoreDNS replicas were observed running on the same node (node2), creating a single point of failure for cluster DNS resolution
- Adds a new `coredns` config subsystem with a hard topology spread constraint (`DoNotSchedule`) ensuring replicas land on different nodes, plus a PodDisruptionBudget guaranteeing at least 1 replica during maintenance
- Talos uses additive-only management for CoreDNS — once Flux applies these resources, Talos won't revert them

## Test plan
- [ ] Verify CoreDNS pods are distributed across different nodes: `kubectl -n kube-system get pods -l k8s-app=kube-dns -o wide`
- [ ] Verify PDB exists: `kubectl -n kube-system get pdb coredns`
- [ ] Verify DNS resolution works during a rolling restart: `kubectl -n kube-system rollout restart deployment coredns`