### PR TITLE
feat(platform): add PDBs for Istio gateways and Alertmanager

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -5,6 +5,9 @@ crds:
 cleanPrometheusOperatorObjectNames: true
 alertmanager:
   enabled: true
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 1
   alertmanagerSpec:
     priorityClassName: platform
     podMetadata:

--- a/kubernetes/platform/config/gateway/gateway-deployment-defaults.yaml
+++ b/kubernetes/platform/config/gateway/gateway-deployment-defaults.yaml
@@ -7,3 +7,6 @@ data:
   deployment: |
     spec:
       replicas: ${default_replica_count}
+  podDisruptionBudget: |
+    spec:
+      maxUnavailable: 1


### PR DESCRIPTION
## Summary
- Istio gateway pods (internal + external) and Alertmanager had no PodDisruptionBudgets, allowing all replicas to be evicted simultaneously during node drains
- Adds `podDisruptionBudget` to gateway deployment defaults ConfigMap (used by Istio's gateway controller via `parametersRef`) with `maxUnavailable: 1`
- Enables the built-in Alertmanager PDB in kube-prometheus-stack with `maxUnavailable: 1`

## Test plan
- [ ] Verify gateway PDBs exist: `kubectl -n istio-gateway get pdb`
- [ ] Verify Alertmanager PDB exists: `kubectl -n monitoring get pdb`
- [ ] Confirm gateways continue serving traffic during a node drain test