### PR TITLE
feat(apps): scale Authelia to 2 replicas for HA

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -3,7 +3,7 @@
 # Chart docs: https://www.authelia.com/integration/kubernetes/introduction/
 pod:
   kind: Deployment
-  replicas: 1
+  replicas: 2
   annotations:
     reloader.stakater.com/auto: "true"
   extraVolumeMounts:


### PR DESCRIPTION
## Summary
- Single-replica Authelia is a SPOF for the entire authentication chain (Authelia + LLDAP + OAuth2 Proxy)
- Sessions are stored in Dragonfly (shared Redis), so scaling to 2 replicas is safe without session loss

## Test plan
- [ ] Verify both Authelia pods are running: `kubectl -n authelia get pods`
- [ ] Verify authentication still works through both OAuth2 flow and direct Authelia login
- [ ] Verify sessions persist across pod restarts