### PR TITLE
feat(platform): scale istiod and Cilium operator for HA

### DIFF
--- a/kubernetes/platform/charts/cilium.yaml
+++ b/kubernetes/platform/charts/cilium.yaml
@@ -48,7 +48,7 @@ socketLB:
   hostNamespaceOnly: true
 operator:
   rollOutPods: true
-  replicas: 1
+  replicas: 2
   prometheus:
     enabled: true
     serviceMonitor:

--- a/kubernetes/platform/charts/istiod.yaml
+++ b/kubernetes/platform/charts/istiod.yaml
@@ -32,6 +32,7 @@ meshConfig:
 
 # Disable built-in CA - certificates are issued by istio-csr via cert-manager
 pilot:
+  autoscaleMin: 2
   env:
     ENABLE_CA_SERVER: "false"
 


### PR DESCRIPTION
## Summary
- istiod and Cilium operator were running as single replicas, creating SPOFs for service mesh config distribution and CNI policy management
- Sets istiod HPA minimum to 2 (the HPA is already enabled by default) and Cilium operator replicas to 2

## Test plan
- [ ] Verify 2 istiod pods running: `kubectl -n istio-system get pods -l app=istiod`
- [ ] Verify 2 Cilium operator pods: `kubectl -n kube-system get pods -l app.kubernetes.io/name=cilium-operator`
- [ ] Verify mesh connectivity and network policies still function correctly