### PR TITLE
feat(infra): add topology spread constraints to Flux controllers

### DIFF
--- a/infrastructure/modules/bootstrap/resources/instance-oci.yaml.tftpl
+++ b/infrastructure/modules/bootstrap/resources/instance-oci.yaml.tftpl
@@ -32,5 +32,17 @@ instance:
           - op: add
             path: /spec/template/spec/containers/0/args/-
             value: --helm-cache-max-size=16
+      - target:
+          kind: Deployment
+        patch: |
+          - op: add
+            path: /spec/template/spec/topologySpreadConstraints
+            value:
+              - maxSkew: 1
+                topologyKey: kubernetes.io/hostname
+                whenUnsatisfiable: ScheduleAnyway
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/part-of: flux
 healthcheck:
   enabled: true

--- a/infrastructure/modules/bootstrap/resources/instance.yaml.tftpl
+++ b/infrastructure/modules/bootstrap/resources/instance.yaml.tftpl
@@ -27,6 +27,18 @@ instance:
           - op: add
             path: /spec/template/spec/containers/0/args/-
             value: --helm-cache-max-size=16
+      - target:
+          kind: Deployment
+        patch: |
+          - op: add
+            path: /spec/template/spec/topologySpreadConstraints
+            value:
+              - maxSkew: 1
+                topologyKey: kubernetes.io/hostname
+                whenUnsatisfiable: ScheduleAnyway
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/part-of: flux
 healthcheck:
   enabled: true
 


### PR DESCRIPTION
## Summary
- 6 of 7 Flux controllers were scheduled on the same node, creating a single point of failure for GitOps reconciliation
- Adds a soft topology spread constraint (ScheduleAnyway) to both FluxInstance templates (git and OCI), preferring controller distribution across nodes
- Applied to both instance templates so all clusters (dev, integration, live) benefit

## Test plan
- [ ] Verify bootstrap module tests pass: `task tg:test-bootstrap`
- [ ] After next cluster rebuild or flux-operator reconciliation, verify flux pods are distributed: `kubectl -n flux-system get pods -o wide`
- [ ] Note: this takes effect on next pod reschedule (rollout, node drain, or cluster rebuild)