### PR TITLE
fix(network): restrict BGP peering to control-plane nodes

### DIFF
--- a/kubernetes/platform/config/cilium/bgp-cluster-config.yaml
+++ b/kubernetes/platform/config/cilium/bgp-cluster-config.yaml
@@ -5,10 +5,12 @@ kind: CiliumBGPClusterConfig
 metadata:
   name: bgp-policy
 spec:
-  # Select all Linux nodes as potential BGP speakers
+  # Restrict BGP to control-plane nodes whose IPs are configured as
+  # neighbors on the UniFi router. Worker nodes are not in the router's
+  # BGP neighbor list, causing idle peering state.
   nodeSelector:
     matchLabels:
-      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
   bgpInstances:
     - name: instance-1
       localASN: ${bgp_cluster_asn}


### PR DESCRIPTION
## Summary
- node2 (worker) had BGP peering stuck in `idle` state because the UniFi router only has the 3 control-plane node IPs configured as BGP neighbors
- Restricts CiliumBGPClusterConfig nodeSelector from all Linux nodes to control-plane nodes only, aligning Cilium's config with the router's actual neighbor list
- Cilium DSR load balancing ensures traffic still reaches gateway pods on any node — no gateway scheduling constraints needed

## Test plan
- [ ] Verify BGP sessions are established on all 3 CP nodes: `kubectl get ciliumbgpnodeconfig -o wide`
- [ ] Verify node2 no longer has a CiliumBGPNodeConfig (the controller should remove it)
- [ ] Verify LoadBalancer services still get external traffic: `curl -kI --resolve "grafana.internal.live.tomnowak.work:443:<VIP>" https://grafana.internal.live.tomnowak.work/`