### PR TITLE
fix(apps): use dataplane-mode label to opt qbittorrent out of ambient mesh

### DIFF
--- a/kubernetes/clusters/live/charts/qbittorrent.yaml
+++ b/kubernetes/clusters/live/charts/qbittorrent.yaml
@@ -9,15 +9,12 @@ controllers:
 
     pod:
       labels:
-        # Prevents Istio sidecar-injector webhook from firing on this pod.
-        # Required because the webhook overrides ambient.istio.io/redirection
-        # annotations at admission time.
-        sidecar.istio.io/inject: "false"
-      annotations:
         # Gluetun's iptables OUTPUT DROP policy conflicts with ztunnel's
         # DNS redirect (UDP:53 -> 15053). The VPN sidecar doesn't benefit
         # from mesh features, so opt the pod out of ambient interception.
-        ambient.istio.io/redirection: disabled
+        # The label is checked by Istio's CNI plugin at pod sandbox creation.
+        istio.io/dataplane-mode: none
+        sidecar.istio.io/inject: "false"
       securityContext:
         fsGroup: 568
         fsGroupChangePolicy: OnRootMismatch


### PR DESCRIPTION
## Summary
- The `ambient.istio.io/redirection` annotation is a **status** field written by the Istio CNI plugin — not an input it reads. PRs #428 and #433 targeted the wrong mechanism.
- The correct pod-level opt-out from Istio ambient is the **label** `istio.io/dataplane-mode: none`, which the CNI plugin checks at pod sandbox creation time.
- Without this, ztunnel's DNS redirect (UDP:53 → 15053) conflicts with gluetun's iptables OUTPUT DROP policy, causing EPERM on all DNS queries.

## Test plan
- [ ] Pod annotation shows `ambient.istio.io/redirection: disabled` (or absent) after rollout
- [ ] No ISTIO_OUTPUT iptables rules inside the pod
- [ ] Gluetun DNS resolution succeeds
- [ ] VPN tunnel establishes and health endpoint responds on port 9999
- [ ] qbittorrent WebUI accessible