### PR TITLE
fix(platform): scale auth chain (LLDAP, oauth2-proxy) to 2 replicas

### DIFF
--- a/kubernetes/clusters/live/charts/lldap.yaml
+++ b/kubernetes/clusters/live/charts/lldap.yaml
@@ -4,7 +4,7 @@
 controllers:
   lldap:
     type: deployment
-    replicas: 1
+    replicas: 2
     annotations:
       reloader.stakater.com/auto: "true"
 

--- a/kubernetes/platform/charts/oauth2-proxy.yaml
+++ b/kubernetes/platform/charts/oauth2-proxy.yaml
@@ -1,5 +1,6 @@
 ---
 # https://github.com/oauth2-proxy/manifests/blob/main/helm/oauth2-proxy/values.yaml
+replicaCount: 2
 priorityClassName: platform
 
 podAnnotations:


### PR DESCRIPTION
## Summary
- HA audit finding #4: LLDAP and oauth2-proxy are single-replica SPOFs in the authentication chain
- LLDAP uses shared PostgreSQL (CNPG) so state is already replicated — safe to scale
- oauth2-proxy is stateless (cookie-based sessions signed with shared secret)

## Test plan
- [ ] Verify LLDAP pods schedule on different nodes
- [ ] Verify oauth2-proxy pods schedule on different nodes
- [ ] Test authentication flow through internal gateway
- [ ] Verify LDAP queries still work (Authelia → LLDAP)