### PR TITLE
fix(platform): scale cert-manager to 2 replicas

### DIFF
--- a/kubernetes/platform/charts/cert-manager.yaml
+++ b/kubernetes/platform/charts/cert-manager.yaml
@@ -6,6 +6,7 @@ global:
     namespace: cert-manager
   priorityClassName: platform
   commonLabels:
+replicaCount: 2
 podLabels:
   networking/allow-egress-internet: "true"
   networking/allow-ingress-prometheus: "true"
@@ -17,12 +18,14 @@ prometheus:
   servicemonitor:
     enabled: true
 webhook:
+  replicaCount: 2
   podLabels:
     networking/allow-ingress-prometheus: "true"
     networking/allow-cluster-egress: "true"
   networkPolicy:
     enabled: false
 cainjector:
+  replicaCount: 2
   podLabels:
     networking/allow-ingress-prometheus: "true"
     networking/allow-cluster-egress: "true"


### PR DESCRIPTION
## Summary
- HA audit finding #12: cert-manager controller, webhook, and cainjector were all single-replica with 3/4 pods on node2
- Webhook is especially critical — failure blocks all deployments using cert-manager annotations
- Leader election already configured for controller and cainjector via `global.leaderElection`

## Test plan
- [ ] Verify all cert-manager components have 2 running pods
- [ ] Verify leader election is active for controller and cainjector
- [ ] Test certificate issuance still works
- [ ] Verify webhook responds correctly (deploy a Certificate resource)