### PR TITLE
fix(platform): scale external-secrets to 2 replicas with leader election

### DIFF
--- a/kubernetes/platform/charts/external-secrets.yaml
+++ b/kubernetes/platform/charts/external-secrets.yaml
@@ -2,11 +2,14 @@
 # https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/values.yaml
 # yaml-language-server: $schema=https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/values.schema.json
 installCRDs: true
+replicaCount: 2
+leaderElect: true
 priorityClassName: platform
 serviceMonitor:
   enabled: true
   interval: 1m
 webhook:
+  replicaCount: 2
   priorityClassName: platform
   serviceMonitor:
     enabled: true
@@ -16,6 +19,7 @@ webhook:
       cpu: 10m
       memory: 100Mi
 certController:
+  replicaCount: 2
   priorityClassName: platform
   serviceMonitor:
     enabled: true


### PR DESCRIPTION
## Summary
- HA audit finding #13: all external-secrets components were single-replica on node2
- Enables leader election for the main controller to prevent concurrent reconciliation of ExternalSecret CRs
- Webhook and cert-controller are stateless and safe to scale independently

## Test plan
- [ ] Verify all external-secrets components have 2 running pods
- [ ] Verify leader election is active (check controller logs for leader lock)
- [ ] Test ExternalSecret sync still works (check a known ExternalSecret)
- [ ] Verify webhook validates ExternalSecret CRs correctly