### PR TITLE
fix(apps): allow health and WebUI ports through gluetun firewall

### DIFF
--- a/kubernetes/clusters/live/charts/qbittorrent.yaml
+++ b/kubernetes/clusters/live/charts/qbittorrent.yaml
@@ -44,6 +44,9 @@ controllers:
           # policies provide egress enforcement at the cluster level.
           FIREWALL: "off"
           FIREWALL_OUTBOUND_SUBNETS: "172.18.0.0/16,172.19.0.0/16,192.168.10.0/24"
+          # Allow kubelet probes (9999) and service traffic (8080) through
+          # gluetun's INPUT DROP policy.
+          FIREWALL_INPUT_PORTS: "8080,9999"
           HEALTH_SERVER_ADDRESS: "0.0.0.0:9999"
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
## Summary
- Gluetun's internal firewall overrides `FIREWALL=off` via `FIREWALL_ENABLED_DISABLING_IT_SHOOTS_YOU_IN_YOUR_FOOT=on`, maintaining INPUT DROP policy
- Kubelet startup probes to port 9999 are dropped, preventing the pod from becoming Ready
- `FIREWALL_INPUT_PORTS=8080,9999` explicitly opens the health check and WebUI ports through gluetun's firewall

## Test plan
- [ ] Startup probe passes (gluetun container marked Started)
- [ ] Pod reaches 2/2 Ready state
- [ ] qbittorrent WebUI accessible via Service on port 8080
- [ ] VPN tunnel established (public IP shows NordVPN endpoint)