### PR TITLE
fix(apps): remove FIREWALL=off to use gluetun's native kill switch

### DIFF
--- a/kubernetes/clusters/live/charts/qbittorrent.yaml
+++ b/kubernetes/clusters/live/charts/qbittorrent.yaml
@@ -39,13 +39,7 @@ controllers:
           SERVER_CATEGORIES: P2P
           DNS_KEEP_NAMESERVER: "on"
           DOT: "off"
-          # Talos v1.12 kernel 6.18 disables CONFIG_NETFILTER_XTABLES_LEGACY,
-          # breaking gluetun's iptables test rule cleanup. Cilium network
-          # policies provide egress enforcement at the cluster level.
-          FIREWALL: "off"
           FIREWALL_OUTBOUND_SUBNETS: "172.18.0.0/16,172.19.0.0/16,192.168.10.0/24"
-          # Allow kubelet probes (9999) and service traffic (8080) through
-          # gluetun's INPUT DROP policy.
           FIREWALL_INPUT_PORTS: "8080,9999"
           HEALTH_SERVER_ADDRESS: "0.0.0.0:9999"
         securityContext:


### PR DESCRIPTION
## Summary
- `FIREWALL=off` was added in PR #425 to bypass an iptables detection test crash on Talos kernel 6.18 (no legacy xtables)
- An internal gluetun override (`FIREWALL_ENABLED_DISABLING_IT_SHOOTS_YOU_IN_YOUR_FOOT=on`) kept the firewall active anyway — making `FIREWALL=off` misleading
- This PR removes `FIREWALL=off` entirely, letting gluetun default to `FIREWALL=on` with an explicit kill switch
- If the iptables detection test now passes (because `iptables` is `iptables-nft` on this kernel), this is the correct and clean configuration

## Test plan
- [ ] Gluetun starts without iptables test rule crash
- [ ] Pod reaches 2/2 Running
- [ ] OUTPUT chain has policy DROP (kill switch active)
- [ ] INPUT chain has ACCEPT for ports 8080, 9999
- [ ] VPN tunnel establishes and health check passes
- [ ] **If gluetun crashes**: revert this PR and restore `FIREWALL=off` with an updated comment