### PR TITLE
fix(platform): remove alertmanager PDB that conflicts with chart defaults

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -5,9 +5,6 @@ crds:
 cleanPrometheusOperatorObjectNames: true
 alertmanager:
   enabled: true
-  podDisruptionBudget:
-    enabled: true
-    maxUnavailable: 1
   alertmanagerSpec:
     priorityClassName: platform
     podMetadata:


### PR DESCRIPTION
## Summary
- Remove the alertmanager `podDisruptionBudget` section from kube-prometheus-stack values
- PR #432 added `maxUnavailable: 1`, but the chart defaults include `minAvailable: 1` — Kubernetes rejects PDBs with both fields set
- This unblocks the kube-prometheus-stack HelmRelease (currently `RetriesExceeded`), which cascades to unblock 17 Kustomizations and 8 HelmReleases

## Test plan
- [x] `task k8s:validate` passes
- [ ] After merge + promotion: HelmRelease upgrades successfully
- [ ] After promotion: suspend/resume HelmRelease on integration and live to clear stalled state
- [ ] All blocked Kustomizations reconcile (`flux get kustomizations -A`)