### PR TITLE
fix(platform): migrate longhorn backup target to 1.11.0 defaultBackupStore

### DIFF
--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -19,8 +19,10 @@ defaultSettings:
   defaultReplicaCount: ${default_replica_count}
   createDefaultDiskLabeledNodes: true
   storageReservedPercentageForDefaultDisk: 0
+defaultBackupStore:
   backupTarget: s3://homelab-longhorn-backup-${cluster_name}@us-east-2/
   backupTargetCredentialSecret: longhorn-s3-backup-credentials
+  pollInterval: "86400"
 csi:
   attacherReplicaCount: ${default_replica_count}
   provisionerReplicaCount: ${default_replica_count}

--- a/kubernetes/platform/config/longhorn/backup/backup-target-credential-secret.yaml
+++ b/kubernetes/platform/config/longhorn/backup/backup-target-credential-secret.yaml
@@ -1,8 +1,0 @@
----
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/longhorn.io/setting_v1beta2.json
-apiVersion: longhorn.io/v1beta2
-kind: Setting
-metadata:
-  name: backup-target-credential-secret
-  namespace: longhorn-system
-value: longhorn-s3-backup-credentials

--- a/kubernetes/platform/config/longhorn/backup/backup-target.yaml
+++ b/kubernetes/platform/config/longhorn/backup/backup-target.yaml
@@ -1,8 +1,0 @@
----
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/longhorn.io/setting_v1beta2.json
-apiVersion: longhorn.io/v1beta2
-kind: Setting
-metadata:
-  name: backup-target
-  namespace: longhorn-system
-value: s3://homelab-longhorn-backup-${cluster_name}@us-east-2/

--- a/kubernetes/platform/config/longhorn/backup/kustomization.yaml
+++ b/kubernetes/platform/config/longhorn/backup/kustomization.yaml
@@ -5,5 +5,3 @@ kind: Kustomization
 
 resources:
   - external-secret.yaml
-  - backup-target.yaml
-  - backup-target-credential-secret.yaml


### PR DESCRIPTION
## Summary
- Longhorn 1.11.0 removed `backup-target` and `backup-target-credential-secret` from the Settings CRD, and silently ignores the old `defaultSettings.backupTarget` Helm values key. This left backups completely non-functional on both integration and live clusters (zero backups, empty BackupTarget URL).
- Migrate to the new `defaultBackupStore` top-level Helm values key and remove the Setting CRs that are now rejected by the Longhorn admission webhook.

## Test plan
- [x] `task k8s:validate` passes (all 31 charts template successfully, no schema or deprecation errors)
- [ ] Longhorn HelmRelease reconciles successfully on integration
- [ ] BackupTarget CR shows correct S3 URL after reconciliation
- [ ] Verify backup jobs resume (at least one successful backup within 24h)