### PR TITLE
fix(storage): correct recurringJobSelector parameter name in StorageClasses

### DIFF
--- a/kubernetes/platform/config/longhorn/storage-classes/fast-local.yaml
+++ b/kubernetes/platform/config/longhorn/storage-classes/fast-local.yaml
@@ -13,4 +13,4 @@ parameters:
   staleReplicaTimeout: "30"
   dataLocality: best-effort
   diskSelector: fast
-  recurringJobSelectors: '[{"name": "snapshot-minimal", "isGroup": true}, {"name": "filesystem-trim-daily", "isGroup": true}]'
+  recurringJobSelector: '[{"name": "snapshot-minimal", "isGroup": true}, {"name": "filesystem-trim-daily", "isGroup": true}]'

--- a/kubernetes/platform/config/longhorn/storage-classes/fast-nr.yaml
+++ b/kubernetes/platform/config/longhorn/storage-classes/fast-nr.yaml
@@ -13,4 +13,4 @@ parameters:
   staleReplicaTimeout: "30"
   dataLocality: best-effort
   diskSelector: fast
-  recurringJobSelectors: '[{"name": "snapshot-daily", "isGroup": true}, {"name": "backup-daily", "isGroup": true}, {"name": "filesystem-trim-daily", "isGroup": true}]'
+  recurringJobSelector: '[{"name": "snapshot-daily", "isGroup": true}, {"name": "backup-daily", "isGroup": true}, {"name": "filesystem-trim-daily", "isGroup": true}]'

--- a/kubernetes/platform/config/longhorn/storage-classes/fast.yaml
+++ b/kubernetes/platform/config/longhorn/storage-classes/fast.yaml
@@ -13,4 +13,4 @@ parameters:
   staleReplicaTimeout: "30"
   dataLocality: best-effort
   diskSelector: fast
-  recurringJobSelectors: '[{"name": "snapshot-frequent", "isGroup": true}, {"name": "backup-frequent", "isGroup": true}, {"name": "filesystem-trim-daily", "isGroup": true}]'
+  recurringJobSelector: '[{"name": "snapshot-frequent", "isGroup": true}, {"name": "backup-frequent", "isGroup": true}, {"name": "filesystem-trim-daily", "isGroup": true}]'

--- a/kubernetes/platform/config/longhorn/storage-classes/slow-local.yaml
+++ b/kubernetes/platform/config/longhorn/storage-classes/slow-local.yaml
@@ -13,4 +13,4 @@ parameters:
   staleReplicaTimeout: "30"
   dataLocality: best-effort
   diskSelector: slow
-  recurringJobSelectors: '[{"name": "snapshot-minimal", "isGroup": true}, {"name": "filesystem-trim-daily", "isGroup": true}]'
+  recurringJobSelector: '[{"name": "snapshot-minimal", "isGroup": true}, {"name": "filesystem-trim-daily", "isGroup": true}]'

--- a/kubernetes/platform/config/longhorn/storage-classes/slow.yaml
+++ b/kubernetes/platform/config/longhorn/storage-classes/slow.yaml
@@ -13,4 +13,4 @@ parameters:
   staleReplicaTimeout: "30"
   dataLocality: best-effort
   diskSelector: slow
-  recurringJobSelectors: '[{"name": "snapshot-frequent", "isGroup": true}, {"name": "backup-frequent", "isGroup": true}, {"name": "filesystem-trim-daily", "isGroup": true}]'
+  recurringJobSelector: '[{"name": "snapshot-frequent", "isGroup": true}, {"name": "backup-frequent", "isGroup": true}, {"name": "filesystem-trim-daily", "isGroup": true}]'


### PR DESCRIPTION
## Summary
- Fix typo in all 5 Longhorn StorageClass definitions: `recurringJobSelectors` (plural) should be `recurringJobSelector` (singular)
- This typo has been silently ignored by the Longhorn CSI driver since the StorageClasses were created, causing all volumes to fall back to the `default` recurring job group instead of their intended groups (`backup-frequent`, `snapshot-daily`, `snapshot-minimal`, etc.)
- As a result, recurring backups and snapshots were never scheduled on any volume -- only the default group applied

## Test plan
- [x] `task k8s:validate` passes
- [ ] After merge, verify new volumes created from these StorageClasses get the correct `recurringJobSelector` labels
- [ ] Existing volumes will need their `recurringJobSelector` labels updated manually via the Longhorn UI or API (the StorageClass fix only affects new volumes)