### PR TITLE
fix(monitoring): correct LonghornBackupFailed alert metric value

### DIFF
--- a/kubernetes/platform/config/longhorn/prometheus-rules.yaml
+++ b/kubernetes/platform/config/longhorn/prometheus-rules.yaml
@@ -93,7 +93,7 @@ spec:
 
         # Backup State - Error
         - alert: LonghornBackupFailed
-          expr: longhorn_backup_state == 3
+          expr: longhorn_backup_state == 4
           for: 5m
           labels:
             severity: critical


### PR DESCRIPTION
## Summary
- The `LonghornBackupFailed` alert fires on `longhorn_backup_state == 3`, but Longhorn v1.11.0's enum maps `3 = Completed` and `4 = Error`
- Every successful backup was triggering a critical false positive (10 alerts firing permanently)
- Corrects the expression to `== 4` per the [actual Longhorn metric mapping](https://github.com/longhorn/longhorn/issues/4521)

## Test plan
- [ ] Verify alert no longer fires for completed backups on integration
- [ ] Confirm alert would fire for an actual error state (value 4)