### PR TITLE
fix(platform): remove descheduler defaultConstraints rejected by strict decoding

### DIFF
--- a/kubernetes/platform/charts/descheduler.yaml
+++ b/kubernetes/platform/charts/descheduler.yaml
@@ -25,10 +25,6 @@ deschedulerPolicy:
             constraints:
               - DoNotSchedule
               - ScheduleAnyway
-            defaultConstraints:
-              - maxSkew: 1
-                topologyKey: kubernetes.io/hostname
-                whenUnsatisfiable: ScheduleAnyway
         - name: RemoveFailedPods
           args:
             excludeOwnerKinds:


### PR DESCRIPTION
## Summary
- Both descheduler replicas are in CrashLoopBackOff (388 restarts over 33h) due to strict YAML decoding on `descheduler/v1alpha2` rejecting the `defaultConstraints` field
- The `defaultConstraints` field was added in #429 but is not a valid field in the `RemovePodsViolatingTopologySpreadConstraint` plugin args schema for descheduler v0.34.0
- Removes the invalid field while keeping the `constraints` list that controls which topology spread violations are acted on

## Test plan
- [x] `task k8s:validate` passes (YAML lint, ResourceSet expansion, Helm templating, kubeconform)
- [ ] After merge, verify descheduler pods are Running: `kubectl -n kube-system get pods -l app.kubernetes.io/name=descheduler`
- [ ] Verify no CrashLoopBackOff restarts: `kubectl -n kube-system describe pods -l app.kubernetes.io/name=descheduler | grep Restart`