### PR TITLE
fix(apps): remove false-positive JellyfinDown and QbittorrentDown alerts

### DIFF
--- a/kubernetes/clusters/live/config/media/prometheus-rules.yaml
+++ b/kubernetes/clusters/live/config/media/prometheus-rules.yaml
@@ -11,24 +11,6 @@ spec:
   groups:
     - name: media.rules
       rules:
-        - alert: JellyfinDown
-          expr: |
-            absent(up{job="jellyfin"}) or up{job="jellyfin"} == 0
-          for: 5m
-          labels:
-            severity: critical
-          annotations:
-            summary: "Jellyfin media server is unreachable"
-
-        - alert: QbittorrentDown
-          expr: |
-            absent(up{job="qbittorrent"}) or up{job="qbittorrent"} == 0
-          for: 5m
-          labels:
-            severity: warning
-          annotations:
-            summary: "qBittorrent download client is unreachable"
-
         - alert: MediaVolumeNearlyFull
           expr: |
             (


### PR DESCRIPTION
## Summary
- `JellyfinDown` and `QbittorrentDown` alerts use `absent(up{job="..."})` but no ServiceMonitors exist for either app, so the `up` metric is never populated and the alerts are permanent false positives
- Both services already have canary-checker HTTP health checks (`canary-jellyfin` and `canary-vpn-health`) that detect downtime via the platform-wide `CanaryCheckFailure` alert
- Retains the valid `MediaVolumeNearlyFull` alert in the same PrometheusRule

## Test plan
- [ ] Verify `JellyfinDown` and `QbittorrentDown` alerts stop firing after deployment
- [ ] Verify `MediaVolumeNearlyFull` alert still exists in Prometheus rules
- [ ] Verify canary-checker checks (`http-check-jellyfin`, `http-check-qbittorrent-vpn`) continue running