### PR TITLE
fix(network): allow UDP egress for game servers

### DIFF
--- a/kubernetes/clusters/live/config/factorio/network-policy.yaml
+++ b/kubernetes/clusters/live/config/factorio/network-policy.yaml
@@ -6,7 +6,7 @@ metadata:
   name: factorio-game-server
   namespace: factorio
 spec:
-  description: "Factorio: UDP 34197 from internet, RCON TCP 27015 from cluster subnet"
+  description: "Factorio: UDP 34197 game traffic (ingress + egress), RCON TCP 27015 from cluster subnet"
   endpointSelector: { }
   ingress:
     - fromEntities:
@@ -21,3 +21,11 @@ spec:
         - ports:
             - port: "27015"
               protocol: TCP
+  egress:
+    # Game server sends UDP responses and heartbeats to clients
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "34197"
+              protocol: UDP

--- a/kubernetes/clusters/live/config/valheim/network-policy.yaml
+++ b/kubernetes/clusters/live/config/valheim/network-policy.yaml
@@ -6,7 +6,7 @@ metadata:
   name: valheim-default
   namespace: valheim
 spec:
-  description: "Allow Valheim game server: UDP ingress from internet, HTTPS egress for SteamCMD"
+  description: "Allow Valheim game server: UDP game + Steam matchmaking traffic, HTTPS egress for SteamCMD"
   endpointSelector: { }
   ingress:
     - fromEntities:
@@ -18,7 +18,23 @@ spec:
             - port: "2457"
               protocol: UDP
   egress:
-    # Allow external HTTPS (SteamCMD downloads, Steam API authentication)
+    # Game server sends UDP responses to connected clients
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "2456"
+              protocol: UDP
+            - port: "2457"
+              protocol: UDP
+    # Steam matchmaking and server registration (UDP to Steam backend)
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "27028"
+              protocol: UDP
+    # SteamCMD downloads and Steam API authentication
     - toEntities:
         - world
       toPorts:


### PR DESCRIPTION
## Summary
- Game servers (Factorio, Valheim) need outbound UDP traffic that the `internal-egress` profile doesn't provide (it only allows HTTPS egress)
- Factorio: adds UDP/34197 egress to `world` for game client responses and server heartbeats
- Valheim: adds UDP/2456-2457 egress for game client responses plus UDP/27028 for Steam matchmaking registration

## Test plan
- [ ] Verify Factorio server can send game traffic to connecting clients (UDP/34197)
- [ ] Verify Valheim server registers with Steam matchmaking (UDP/27028)
- [ ] Verify no DROPPED verdicts in Hubble for factorio/valheim namespaces: `hubble observe --verdict DROPPED --namespace factorio --since 10m`
- [ ] Verify existing ingress rules still work (clients can connect inbound)