### PR TITLE
fix(platform): add per-node IPMI credentials for node2

### DIFF
--- a/kubernetes/platform/config/monitoring/hardware-monitoring-scrape.yaml
+++ b/kubernetes/platform/config/monitoring/hardware-monitoring-scrape.yaml
@@ -41,6 +41,11 @@ spec:
       targetLabel: __param_target
     - sourceLabels: [__param_target]
       targetLabel: instance
+    # Route node2 to its own IPMI module (different BMC credentials)
+    - sourceLabels: [__address__]
+      regex: "node2-ipmi\\..*"
+      targetLabel: __param_module
+      replacement: node2
     - targetLabel: __address__
       replacement: prometheus-ipmi-exporter.monitoring.svc:9290
   scrapeInterval: 60s

--- a/kubernetes/platform/config/monitoring/hardware-monitoring-secrets.yaml
+++ b/kubernetes/platform/config/monitoring/hardware-monitoring-secrets.yaml
@@ -14,12 +14,25 @@ spec:
     template:
       engineVersion: v2
       data:
-        # IPMI exporter config referencing templated credentials
+        # IPMI exporter config with per-node modules for different credentials.
+        # node2 uses separate credentials (different BMC hardware/config than node41-43).
+        # ScrapeConfig relabeling routes each target to its module.
         ipmi-config.yml: |
           modules:
             default:
               user: "{{ .ipmiUsername }}"
               pass: "{{ .ipmiPassword }}"
+              driver: "LAN_2_0"
+              privilege: "operator"
+              timeout: 10000
+              collectors:
+                - bmc
+                - ipmi
+                - chassis
+                - sel
+            node2:
+              user: "{{ .ipmiNode2Username }}"
+              pass: "{{ .ipmiNode2Password }}"
               driver: "LAN_2_0"
               privilege: "operator"
               timeout: 10000
@@ -35,3 +48,9 @@ spec:
     - secretKey: ipmiPassword
       remoteRef:
         key: /homelab/kubernetes/${cluster_name}/ipmi-password
+    - secretKey: ipmiNode2Username
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/ipmi-node2-username
+    - secretKey: ipmiNode2Password
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/ipmi-node2-password


### PR DESCRIPTION
## Summary
- node2 (Supermicro 2xE5-2630v4 with MegaRAID) has different BMC credentials than node41-43, causing `password invalid` errors across all IPMI collectors (chassis, sel, sensors)
- Adds a dedicated `node2` IPMI exporter module with separate SSM-backed credentials alongside the existing `default` module
- Uses Prometheus relabeling in the ScrapeConfig to dynamically route `node2-ipmi.*` targets to the `node2` module while keeping all other targets on `default`

## Test plan
- [ ] Populate SSM parameters `/homelab/kubernetes/live/ipmi-node2-username` and `/homelab/kubernetes/live/ipmi-node2-password` with node2's BMC credentials
- [ ] Verify ExternalSecret `hardware-monitoring-credentials` syncs successfully after merge
- [ ] Confirm IPMI exporter can authenticate to `node2-ipmi.citadel.tomnowak.work` (check exporter logs for auth errors)
- [ ] Verify Prometheus scrape targets for node2 show `up=1` in `scrapeConfig/monitoring/ipmi-exporter-targets`
- [ ] Verify node41-43 IPMI targets remain unaffected (still using `default` module)