### PR TITLE
fix(platform): disable kube-rbac-proxy to fix dragonfly-operator metrics

### DIFF
--- a/kubernetes/platform/charts/dragonfly-operator.yaml
+++ b/kubernetes/platform/charts/dragonfly-operator.yaml
@@ -15,6 +15,11 @@ resources:
   limits:
     memory: 256Mi
 
+# Disable kube-rbac-proxy sidecar so the manager binds metrics to 0.0.0.0:8080
+# instead of 127.0.0.1:8080, allowing Prometheus to scrape directly.
+rbacProxy:
+  enabled: false
+
 serviceMonitor:
   enabled: true
   interval: 60s


### PR DESCRIPTION
## Summary
- The dragonfly-operator chart's default `kube-rbac-proxy` sidecar binds the manager's metrics endpoint to `127.0.0.1:8080`, making it unreachable from Prometheus and causing a persistent `TargetDown` alert
- Disabling `rbacProxy` lets the manager bind to `0.0.0.0:8080`, allowing the ServiceMonitor (enabled in #422) to scrape metrics directly
- Network policies already permit Prometheus ingress on port 8080 to dragonfly-system, so no policy changes are needed

## Test plan
- [ ] Verify dragonfly-operator pod restarts with only 1 container (manager, no kube-rbac-proxy sidecar)
- [ ] Verify Prometheus target `dragonfly-system/dragonfly-operator` is UP
- [ ] Verify `TargetDown` alert for dragonfly-operator resolves