### PR TITLE
feat(apps): add OAuth2 Proxy auth for media management UIs

### DIFF
--- a/kubernetes/clusters/live/config/media/kustomization.yaml
+++ b/kubernetes/clusters/live/config/media/kustomization.yaml
@@ -14,4 +14,5 @@ resources:
   - canary-jellyfin.yaml
   - canary-jellyseerr.yaml
   - canary-vpn-health.yaml
+  - media-auth-policy.yaml
   - prometheus-rules.yaml

--- a/kubernetes/clusters/live/config/media/media-auth-policy.yaml
+++ b/kubernetes/clusters/live/config/media/media-auth-policy.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/security.istio.io/authorizationpolicy_v1.json
+# Protect unauthenticated media management UIs with OAuth2 Proxy.
+# Jellyfin and Jellyseerr have built-in auth and are excluded.
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: media-app-auth
+  namespace: istio-gateway
+spec:
+  targetRefs:
+    - kind: Gateway
+      group: gateway.networking.k8s.io
+      name: internal
+  action: CUSTOM
+  provider:
+    name: oauth2-proxy
+  rules:
+    - to:
+        - operation:
+            hosts:
+              - "prowlarr.${internal_domain}"
+              - "radarr.${internal_domain}"
+              - "sonarr.${internal_domain}"
+              - "qbittorrent.${internal_domain}"


### PR DESCRIPTION
## Summary
- Prowlarr, Radarr, Sonarr, and qBittorrent are exposed on the internal gateway with no authentication
- Adds a cluster-scoped Istio AuthorizationPolicy that routes these through OAuth2 Proxy (Authelia/LLDAP SSO)
- Intentionally separate from `platform-ui-auth` to keep app-level auth decoupled from platform config

## Test plan
- [ ] Verify validation pipeline passes
- [ ] Confirm integration cluster deploys the AuthorizationPolicy
- [ ] Access prowlarr/radarr/sonarr/qbittorrent on internal gateway and verify OAuth2 Proxy redirect
- [ ] Confirm jellyfin, jellyseerr, and kromgo remain unaffected