### PR TITLE
fix(platform): improve node failure resilience

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -41,6 +41,16 @@ prometheus:
     enabled: false
   prometheusSpec:
     priorityClassName: platform
+    replicas: 2
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: prometheus
+              topologyKey: kubernetes.io/hostname
     podMetadata:
       labels:
         networking/allow-ingress-internal: "true"

--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -19,6 +19,7 @@ defaultSettings:
   defaultReplicaCount: ${default_replica_count}
   createDefaultDiskLabeledNodes: true
   storageReservedPercentageForDefaultDisk: 0
+  nodeDownPodDeletionPolicy: delete-both-statefulset-and-deployment-pod
 defaultBackupStore:
   backupTarget: s3://homelab-longhorn-backup-${cluster_name}@us-east-2/
   backupTargetCredentialSecret: longhorn-s3-backup-credentials

--- a/kubernetes/platform/helm-charts.yaml
+++ b/kubernetes/platform/helm-charts.yaml
@@ -268,7 +268,7 @@ spec:
       install:
         createNamespace: false
         remediation:
-          retries: 3
+          retries: 5
         timeout: 10m
       interval: 10m
       maxHistory: 3
@@ -279,7 +279,7 @@ spec:
       upgrade:
         crds: CreateReplace
         remediation:
-          retries: 3
+          retries: 5
         timeout: 10m
       valuesFrom:
         - kind: ConfigMap


### PR DESCRIPTION
## Summary

- Enable Longhorn `nodeDownPodDeletionPolicy` to force-delete pods stuck on unreachable nodes, fixing the root cause of StatefulSet deadlocks and cascading Flux failures during node outages
- Add Prometheus HA (2 replicas with soft anti-affinity) so alerting survives single-node failures
- Increase Flux HelmRelease remediation retries from 3 to 5, providing a wider recovery window for post-failure convergence

## Test plan

- [ ] `task k8s:validate` passes (verified locally)
- [ ] After promotion to integration: verify Longhorn setting via `kubectl get settings node-down-pod-deletion-policy -n longhorn-system`
- [ ] After promotion to live: verify 2 Prometheus pods on different nodes (`kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus -o wide`)
- [ ] Re-run node failure stress test to confirm pods reschedule within minutes