### PR TITLE
fix(platform): resolve kube-prometheus-stack duplicate podAntiAffinity key

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -42,6 +42,7 @@ prometheus:
   prometheusSpec:
     priorityClassName: platform
     replicas: 2
+    podAntiAffinity: ""
     affinity:
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Summary
- kube-prometheus-stack v82.1.1 upgrade fails on integration and live with a duplicate `podAntiAffinity` YAML key error, blocking 14+ downstream Kustomizations
- The chart template renders both its auto-generated `podAntiAffinity` (from the default `"soft"` value) and our explicit `affinity.podAntiAffinity` block, producing a duplicate mapping key in the post-rendered output
- Setting `podAntiAffinity: ""` disables the chart's auto-generated block while preserving our explicit preferred anti-affinity configuration

## Test plan
- [x] `task k8s:validate` passes
- [ ] kube-prometheus-stack HelmRelease reconciles successfully on integration
- [ ] Downstream Kustomizations (canary-checker, grafana, monitoring-config, dcgm-exporter) unblock