### PR TITLE
fix(network): add kube-API access label to gpu-system namespace

### DIFF
--- a/kubernetes/platform/namespaces.yaml
+++ b/kubernetes/platform/namespaces.yaml
@@ -84,6 +84,7 @@ spec:
       dataplane: standard
       security: privileged
       networkPolicy: false
+      kubeApiAccess: true
     - name: system-upgrade
       dataplane: ambient
       security: privileged
@@ -126,4 +127,7 @@ spec:
         pod-security.kubernetes.io/enforce: baseline
         pod-security.kubernetes.io/audit: restricted
         pod-security.kubernetes.io/warn: restricted
+        <<- end >>
+        <<- if (index inputs "kubeApiAccess") >>
+        access.network-policy.homelab/kube-api: "true"
         <<- end >>


### PR DESCRIPTION
## Summary
- The nvidia-device-plugin sidecar in gpu-system needs Kubernetes API access to register GPU extended resources (`nvidia.com/gpu`)
- Cilium drops egress packets because the baseline CCNP `baseline-kube-api-access` only matches namespaces labeled with `access.network-policy.homelab/kube-api=true`
- Extends the namespaces ResourceSet template with a `kubeApiAccess` input field that renders the required label

## Test plan
- [x] `task k8s:validate` passes
- [x] Expanded ResourceSet output shows `access.network-policy.homelab/kube-api: "true"` on gpu-system namespace
- [x] Other namespaces render unchanged
- [ ] nvidia-device-plugin pods can reach kube-apiserver after deployment