### PR TITLE
fix(platform): resolve kube-prometheus-stack, excalidraw, and immich failures

### DIFF
--- a/kubernetes/clusters/live/charts/excalidraw.yaml
+++ b/kubernetes/clusters/live/charts/excalidraw.yaml
@@ -30,7 +30,7 @@ controllers:
           - /bin/sh
           - -c
           - |
-            find /usr/share/nginx/html/assets -type f -name '*.js' \
+            find /usr/share/nginx/html/static/js -type f -name '*.js' \
               -exec sed -i 's|https://oss-collab\.excalidraw\.com|https://draw-ws.${external_domain}|g' {} + && \
             nginx -g 'daemon off;'
         resources:
@@ -85,6 +85,7 @@ controllers:
           tag: sha-03ff435
         env:
           PORT: "80"
+          YARN_CACHE_FOLDER: /tmp/.yarn-cache
         resources:
           requests:
             cpu: 10m
@@ -106,6 +107,16 @@ controllers:
               tcpSocket:
                 port: 80
               periodSeconds: 10
+
+persistence:
+  # Writable /tmp for excalidraw-room: yarn needs a cache directory
+  # (readOnlyRootFilesystem blocks default cache paths)
+  tmp:
+    type: emptyDir
+    advancedMounts:
+      room:
+        app:
+          - path: /tmp
 
 service:
   app:

--- a/kubernetes/clusters/live/charts/immich.yaml
+++ b/kubernetes/clusters/live/charts/immich.yaml
@@ -66,6 +66,7 @@ machine-learning:
   enabled: true
   controllers:
     main:
+      strategy: Recreate
       pod:
         runtimeClassName: nvidia
         nodeSelector:

--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -42,7 +42,6 @@ prometheus:
   prometheusSpec:
     priorityClassName: platform
     replicas: 2
-    podAntiAffinity: ""
     affinity:
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Summary
- Fix Prometheus StatefulSet failing to render due to duplicate `podAntiAffinity` keys in kube-prometheus-stack values
- Fix excalidraw CrashLoopBackOff: main container searched wrong asset path (`assets/` vs CRA's `static/js/`), room container lacked writable cache directory for yarn
- Fix immich machine-learning Multi-Attach volume errors by switching from RollingUpdate to Recreate strategy for its RWO PVC

## Test plan
- [x] `task k8s:validate` passes
- [ ] kube-prometheus-stack Prometheus StatefulSet deploys without Helm unmarshalling errors
- [ ] excalidraw main container starts and serves the UI with collaboration URL rewritten
- [ ] excalidraw-room container starts without yarn cache errors
- [ ] immich machine-learning pod upgrades cleanly without Multi-Attach volume errors