### PR TITLE
fix(network): assign explicit IP to valheim LoadBalancer

### DIFF
--- a/kubernetes/clusters/live/charts/valheim.yaml
+++ b/kubernetes/clusters/live/charts/valheim.yaml
@@ -83,6 +83,8 @@ service:
   game:
     controller: valheim
     type: LoadBalancer
+    annotations:
+      lbipam.cilium.io/ips: ${valheim_ip}
     ports:
       gameplay:
         port: 2456

--- a/kubernetes/clusters/live/cluster-apps.env
+++ b/kubernetes/clusters/live/cluster-apps.env
@@ -3,4 +3,5 @@
 factorio_ip=192.168.10.24
 satisfactory_ip=192.168.10.25
 minecraft_ip=192.168.10.26
+valheim_ip=192.168.10.27
 pxe_ip=192.168.10.21


### PR DESCRIPTION
## Summary
- Valheim's LoadBalancer lacked an explicit `lbipam.cilium.io/ips` annotation, allowing Cilium to auto-assign `192.168.10.26` — the same IP explicitly requested by minecraft
- This IP conflict left minecraft's Service in `<pending>` state, causing repeated Helm install timeouts and a Stalled HelmRelease
- Assigns valheim its own explicit IP (`192.168.10.27`), matching the pattern used by factorio, satisfactory, and minecraft

## Test plan
- [ ] Verify minecraft Service gets `192.168.10.26` and exits `<pending>` state
- [ ] Verify valheim Service gets `192.168.10.27`
- [ ] Suspend/resume minecraft HelmRelease to clear Stalled state after deployment
- [ ] Confirm both game servers are reachable on their respective IPs