### PR TITLE
fix(apps): add nvidia runtimeClass to dcgm-exporter and fix GPU alert

### DIFF
--- a/kubernetes/platform/charts/dcgm-exporter.yaml
+++ b/kubernetes/platform/charts/dcgm-exporter.yaml
@@ -2,6 +2,10 @@
 # DCGM Exporter — GPU metrics for Prometheus
 # Runs as a DaemonSet on GPU nodes, exposes DCGM metrics
 
+# Required for GPU device injection — without this, the container runs
+# under the default containerd runtime with no access to GPU devices
+runtimeClassName: nvidia
+
 serviceMonitor:
   enabled: true
   interval: 30s

--- a/kubernetes/platform/config/monitoring/gpu-monitoring-alerts.yaml
+++ b/kubernetes/platform/config/monitoring/gpu-monitoring-alerts.yaml
@@ -13,16 +13,23 @@ spec:
       rules:
         - alert: GpuDevicePluginDown
           expr: |
-            absent(up{job=~".*nvidia-device-plugin.*"} == 1)
+            (
+              kube_daemonset_status_number_available{daemonset="nvidia-device-plugin", namespace="gpu-system"}
+              /
+              kube_daemonset_status_desired_number_scheduled{daemonset="nvidia-device-plugin", namespace="gpu-system"}
+            ) < 1
+            or
+            absent(kube_daemonset_status_desired_number_scheduled{daemonset="nvidia-device-plugin", namespace="gpu-system"})
           for: 10m
           labels:
             severity: critical
           annotations:
-            summary: "NVIDIA device plugin is not running"
+            summary: "NVIDIA device plugin is not fully available"
             description: >-
-              The NVIDIA device plugin has been unreachable for 10+ minutes.
-              GPU resources will not be allocatable to pods.
-              Check the nvidia-device-plugin DaemonSet in gpu-system namespace.
+              The NVIDIA device plugin DaemonSet in gpu-system has unavailable
+              replicas for 10+ minutes. GPU resources will not be allocatable
+              to pods on affected nodes. Check the nvidia-device-plugin
+              DaemonSet: kubectl get ds -n gpu-system nvidia-device-plugin.
 
         - alert: DcgmExporterDown
           expr: |


### PR DESCRIPTION
## Summary
- dcgm-exporter pod on node2 is in CrashLoopBackOff because it lacks `runtimeClassName: nvidia`, so the container runs under the default containerd runtime with no GPU device injection
- GpuDevicePluginDown alert is a false positive because it uses `absent(up{job=...})` but nvidia-device-plugin has no ServiceMonitor and exposes no metrics port -- the `up` metric never exists
- Rewrote the alert to use `kube_daemonset_status_number_available` from kube-state-metrics, which reliably detects when the DaemonSet has unavailable replicas

## Test plan
- [x] `task k8s:validate` passes
- [ ] dcgm-exporter pod starts successfully on node2 (no longer CrashLoopBackOff)
- [ ] GpuDevicePluginDown alert no longer fires as a false positive
- [ ] DCGM GPU metrics (e.g., `DCGM_FI_DEV_GPU_TEMP`) are present in Prometheus