### PR TITLE
fix(apps): add nginx-cache emptyDir to excalidraw container

### DIFF
--- a/kubernetes/clusters/live/charts/excalidraw.yaml
+++ b/kubernetes/clusters/live/charts/excalidraw.yaml
@@ -117,6 +117,15 @@ persistence:
       room:
         app:
           - path: /tmp
+  # Nginx tries to chown /var/cache/nginx/client_temp at startup, which
+  # fails when all capabilities (including CHOWN) are dropped. An emptyDir
+  # sidesteps this by providing a pre-owned writable directory.
+  nginx-cache:
+    type: emptyDir
+    advancedMounts:
+      excalidraw:
+        app:
+          - path: /var/cache/nginx
 
 service:
   app:


### PR DESCRIPTION
## Summary
- Excalidraw's nginx container crashes because dropping ALL capabilities removes CHOWN, and nginx tries to chown `/var/cache/nginx/client_temp` at startup
- Adding an emptyDir at `/var/cache/nginx` provides a pre-owned writable directory, letting nginx write its cache without needing the CHOWN capability

## Test plan
- [x] `task k8s:validate` passes
- [ ] Excalidraw pod starts without CrashLoopBackOff on live cluster after promotion