### PR TITLE
feat(apps): add unpackerr for automated archive extraction

### DIFF
--- a/kubernetes/clusters/live/charts/kustomization.yaml
+++ b/kubernetes/clusters/live/charts/kustomization.yaml
@@ -32,5 +32,6 @@ configMapGenerator:
       - open-webui.yaml=open-webui.yaml
       - vaultwarden.yaml=vaultwarden.yaml
       - exportarr.yaml=exportarr.yaml
+      - unpackerr.yaml=unpackerr.yaml
       - excalidraw.yaml=excalidraw.yaml
       - homepage.yaml=homepage.yaml

--- a/kubernetes/clusters/live/charts/unpackerr.yaml
+++ b/kubernetes/clusters/live/charts/unpackerr.yaml
@@ -1,0 +1,106 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+# https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+controllers:
+  unpackerr:
+    type: deployment
+    annotations:
+      reloader.stakater.com/auto: "true"
+
+    pod:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+    containers:
+      app:
+        image:
+          repository: ghcr.io/unpackerr/unpackerr
+          tag: "${unpackerr_version}"
+        env:
+          # Metrics endpoint
+          UN_WEBSERVER_METRICS: "true"
+          UN_WEBSERVER_LOG_FILE: /dev/null
+          # Sonarr integration
+          UN_SONARR_0_URL: http://sonarr-app.media.svc:8989
+          UN_SONARR_0_PATHS_0: /media/downloads/complete/sonarr
+          UN_SONARR_0_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: unpackerr-api-keys
+                key: sonarr-api-key
+          # Radarr integration
+          UN_RADARR_0_URL: http://radarr-app.media.svc:7878
+          UN_RADARR_0_PATHS_0: /media/downloads/complete/radarr
+          UN_RADARR_0_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: unpackerr-api-keys
+                key: radarr-api-key
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            memory: 256Mi
+        probes:
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /metrics
+                port: 5656
+              initialDelaySeconds: 5
+              periodSeconds: 5
+              failureThreshold: 10
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /metrics
+                port: 5656
+              periodSeconds: 30
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /metrics
+                port: 5656
+              periodSeconds: 10
+
+service:
+  app:
+    controller: unpackerr
+    ports:
+      metrics:
+        port: 5656
+
+serviceMonitor:
+  app:
+    serviceName: unpackerr-app
+    endpoints:
+      - port: metrics
+        interval: 60s
+        scrapeTimeout: 30s
+
+persistence:
+  media:
+    type: persistentVolumeClaim
+    existingClaim: media-library
+    advancedMounts:
+      unpackerr:
+        app:
+          - path: /media

--- a/kubernetes/clusters/live/config/cluster-config-resourceset.yaml
+++ b/kubernetes/clusters/live/config/cluster-config-resourceset.yaml
@@ -21,7 +21,7 @@ spec:
       dependsOn: [platform, secret-generator, external-secrets-stores]
     - name: media-config
       path: kubernetes/clusters/live/config/media
-      dependsOn: [bazarr, jellyfin-exporter, jellyfin, jellyseerr, sonarr, radarr, prowlarr, qbittorrent, exportarr, canary-checker, kube-prometheus-stack]
+      dependsOn: [bazarr, jellyfin-exporter, jellyfin, jellyseerr, sonarr, radarr, prowlarr, qbittorrent, exportarr, unpackerr, canary-checker, kube-prometheus-stack]
     - name: ai-prereqs
       path: kubernetes/clusters/live/config/ai-prereqs
       dependsOn: [platform, secret-generator, external-secrets-stores]

--- a/kubernetes/clusters/live/config/media-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - nordvpn-wireguard-credentials.yaml
   - exportarr-api-keys.yaml
   - jellyfin-exporter-api-token.yaml
+  - unpackerr-api-keys.yaml

--- a/kubernetes/clusters/live/config/media-prereqs/unpackerr-api-keys.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/unpackerr-api-keys.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# API keys for unpackerr to authenticate with Sonarr and Radarr.
+# Stored in AWS SSM as individual plain string parameters.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: unpackerr-api-keys
+  namespace: media
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: unpackerr-api-keys
+  data:
+    - secretKey: sonarr-api-key
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/unpackerr/sonarr-api-key
+    - secretKey: radarr-api-key
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/unpackerr/radarr-api-key

--- a/kubernetes/clusters/live/config/media/kustomization.yaml
+++ b/kubernetes/clusters/live/config/media/kustomization.yaml
@@ -19,3 +19,4 @@ resources:
   - jellyfin-dashboard.yaml
   - prometheus-rules.yaml
   - exportarr-alerts.yaml
+  - unpackerr-alerts.yaml

--- a/kubernetes/clusters/live/config/media/unpackerr-alerts.yaml
+++ b/kubernetes/clusters/live/config/media/unpackerr-alerts.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: unpackerr-alerts
+  namespace: media
+  labels:
+    prometheus: kube-prometheus-stack
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: unpackerr.rules
+      rules:
+        - alert: UnpackerrDown
+          expr: up{job="unpackerr-app", namespace="media"} == 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Unpackerr metrics endpoint is down"
+            description: "The unpackerr metrics endpoint has been unreachable for more than 10 minutes."

--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -155,6 +155,13 @@ spec:
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
       dependsOn: [sonarr, radarr, prowlarr]
+    - name: unpackerr
+      namespace: media
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: [sonarr, radarr]
     - name: paperless
       namespace: paperless
       chart:

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -103,6 +103,8 @@ seerr_version=v3.0.1
 tandoor_version=2.5.3
 # renovate: datasource=docker depName=bazarr packageName=ghcr.io/home-operations/bazarr
 bazarr_version=1.5.5
+# renovate: datasource=docker depName=unpackerr packageName=ghcr.io/unpackerr/unpackerr
+unpackerr_version=v0.14.5
 # renovate: datasource=docker depName=paperless-ngx packageName=ghcr.io/paperless-ngx/paperless-ngx
 paperless_ngx_version=2.20.8
 # renovate: datasource=docker depName=vaultwarden packageName=vaultwarden/server


### PR DESCRIPTION
## Summary
- Deploy Unpackerr to automatically extract archived downloads so Sonarr and Radarr can import media files
- Includes Prometheus metrics endpoint with ServiceMonitor and down alert
- API keys for Sonarr/Radarr integration provisioned via ExternalSecret from AWS SSM

## Test plan
- [ ] Verify `task k8s:validate` passes in CI
- [ ] Confirm ExternalSecret syncs after populating SSM parameters
- [ ] Verify Unpackerr pod starts and metrics endpoint responds on port 5656
- [ ] Confirm ServiceMonitor target appears in Prometheus
- [ ] Test archive extraction by downloading an archived release