### PR TITLE
feat(apps): add huntarr for automated media discovery

### DIFF
--- a/kubernetes/clusters/live/charts/huntarr.yaml
+++ b/kubernetes/clusters/live/charts/huntarr.yaml
@@ -1,0 +1,77 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+# https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+controllers:
+  huntarr:
+    type: deployment
+
+    pod:
+      securityContext:
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+
+    containers:
+      app:
+        image:
+          repository: ghcr.io/plexguide/huntarr
+          tag: "${huntarr_version}"
+        env:
+          PUID: "568"
+          PGID: "568"
+        resources:
+          requests:
+            cpu: 10m
+            memory: 128Mi
+          limits:
+            memory: 256Mi
+        probes:
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api/health
+                port: 9705
+              initialDelaySeconds: 5
+              periodSeconds: 5
+              failureThreshold: 30
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api/health
+                port: 9705
+              periodSeconds: 30
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api/health
+                port: 9705
+              periodSeconds: 10
+
+service:
+  app:
+    controller: huntarr
+    ports:
+      http:
+        port: 9705
+
+persistence:
+  config:
+    type: persistentVolumeClaim
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    storageClass: fast
+    advancedMounts:
+      huntarr:
+        app:
+          - path: /config
+  tmp:
+    type: emptyDir
+    advancedMounts:
+      huntarr:
+        app:
+          - path: /tmp

--- a/kubernetes/clusters/live/charts/kustomization.yaml
+++ b/kubernetes/clusters/live/charts/kustomization.yaml
@@ -26,6 +26,7 @@ configMapGenerator:
       - jellyfin.yaml=jellyfin.yaml
       - jellyfin-exporter.yaml=jellyfin-exporter.yaml
       - jellyseerr.yaml=jellyseerr.yaml
+      - huntarr.yaml=huntarr.yaml
       - tandoor.yaml=tandoor.yaml
       - paperless.yaml=paperless.yaml
       - ollama.yaml=ollama.yaml

--- a/kubernetes/clusters/live/config/cluster-config-resourceset.yaml
+++ b/kubernetes/clusters/live/config/cluster-config-resourceset.yaml
@@ -21,7 +21,7 @@ spec:
       dependsOn: [platform, secret-generator, external-secrets-stores]
     - name: media-config
       path: kubernetes/clusters/live/config/media
-      dependsOn: [bazarr, jellyfin-exporter, jellyfin, jellyseerr, sonarr, radarr, prowlarr, qbittorrent, exportarr, canary-checker, kube-prometheus-stack]
+      dependsOn: [bazarr, huntarr, jellyfin-exporter, jellyfin, jellyseerr, sonarr, radarr, prowlarr, qbittorrent, exportarr, canary-checker, kube-prometheus-stack]
     - name: ai-prereqs
       path: kubernetes/clusters/live/config/ai-prereqs
       dependsOn: [platform, secret-generator, external-secrets-stores]

--- a/kubernetes/clusters/live/config/media/huntarr-internal.yaml
+++ b/kubernetes/clusters/live/config/media/huntarr-internal.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: huntarr-internal
+  namespace: media
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Huntarr"
+    gethomepage.dev/group: "Media"
+    gethomepage.dev/icon: "huntarr.svg"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: istio-gateway
+  hostnames:
+    - "huntarr.${internal_domain}"
+  rules:
+    - backendRefs:
+        - name: huntarr
+          port: 9705

--- a/kubernetes/clusters/live/config/media/kustomization.yaml
+++ b/kubernetes/clusters/live/config/media/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - bazarr-internal.yaml
+  - huntarr-internal.yaml
   - jellyfin-external.yaml
   - jellyfin-internal.yaml
   - jellyseerr-external.yaml

--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -141,6 +141,13 @@ spec:
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
       dependsOn: []
+    - name: huntarr
+      namespace: media
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: []
     - name: tandoor
       namespace: tandoor
       chart:

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -103,6 +103,8 @@ seerr_version=v3.0.1
 tandoor_version=2.5.3
 # renovate: datasource=docker depName=bazarr packageName=ghcr.io/home-operations/bazarr
 bazarr_version=1.5.5
+# renovate: datasource=docker depName=huntarr packageName=ghcr.io/plexguide/huntarr
+huntarr_version=6.5.18
 # renovate: datasource=docker depName=paperless-ngx packageName=ghcr.io/paperless-ngx/paperless-ngx
 paperless_ngx_version=2.20.8
 # renovate: datasource=docker depName=vaultwarden packageName=vaultwarden/server


### PR DESCRIPTION
## Summary
- Deploy Huntarr to automate missing/cutoff media searches in Sonarr and Radarr, reducing manual intervention for library completeness
- Internal-only web UI at `huntarr.${internal_domain}` for configuration (API keys, search schedules)

## Test plan
- [ ] Verify `task k8s:validate` passes in CI
- [ ] Confirm Huntarr pod starts and passes health checks in live cluster
- [ ] Access Huntarr web UI via internal gateway and configure Sonarr/Radarr connections
- [ ] Verify automated media searches begin running on configured schedule