### PR TITLE
fix(platform): add PromQL guard clauses to GPU alerts for non-GPU clusters

### DIFF
--- a/kubernetes/platform/config/monitoring/gpu-monitoring-alerts.yaml
+++ b/kubernetes/platform/config/monitoring/gpu-monitoring-alerts.yaml
@@ -15,11 +15,11 @@ spec:
           expr: |
             (
               kube_daemonset_status_number_available{daemonset="nvidia-device-plugin", namespace="gpu-system"}
-              /
+              <
               kube_daemonset_status_desired_number_scheduled{daemonset="nvidia-device-plugin", namespace="gpu-system"}
-            ) < 1
-            or
-            absent(kube_daemonset_status_desired_number_scheduled{daemonset="nvidia-device-plugin", namespace="gpu-system"})
+            )
+            and on()
+            kube_daemonset_status_desired_number_scheduled{daemonset="nvidia-device-plugin", namespace="gpu-system"} > 0
           for: 10m
           labels:
             severity: critical
@@ -34,6 +34,8 @@ spec:
         - alert: DcgmExporterDown
           expr: |
             absent(up{job=~".*dcgm-exporter.*"} == 1)
+            and on()
+            kube_daemonset_status_desired_number_scheduled{daemonset="nvidia-device-plugin", namespace="gpu-system"} > 0
           for: 10m
           labels:
             severity: warning


### PR DESCRIPTION
## Summary
- GPU health alerts (`GpuDevicePluginDown`, `DcgmExporterDown`) fire as false positives on dev and integration clusters that have no GPUs
- Gate both alerts on `nvidia-device-plugin` DaemonSet `desired > 0` using the `and on()` PromQL join pattern so they only evaluate when GPU nodes exist in the cluster
- Remove the `absent()` clause from `GpuDevicePluginDown` -- if the DaemonSet metric itself is absent, that is a Flux/HelmRelease concern, not a GPU monitoring concern

## Test plan
- [x] `task k8s:validate` passes
- [ ] Verify alerts do not fire on dev/integration clusters (no GPU nodes, desired=0)
- [ ] Verify alerts still fire on live cluster when nvidia-device-plugin pods are unhealthy (desired>0, available<desired)