### PR TITLE
fix(platform): resolve duplicate podAntiAffinity key in kube-prometheus-stack

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -51,6 +51,7 @@ prometheus:
                 matchLabels:
                   app.kubernetes.io/name: prometheus
               topologyKey: kubernetes.io/hostname
+    podAntiAffinity: ""
     podMetadata:
       labels:
         networking/allow-ingress-internal: "true"


### PR DESCRIPTION
## Summary
- The v82.2.0 chart upgrade fails because both our custom `affinity.podAntiAffinity` block and the chart's built-in `podAntiAffinity` (defaulting to `"soft"`) emit duplicate mapping keys in the rendered YAML
- Setting `podAntiAffinity: ""` at the `prometheusSpec` level disables the chart's built-in generation while preserving our custom anti-affinity rules

## Test plan
- [x] `task k8s:validate` passes
- [x] Applied fix to dev cluster ConfigMap and verified HelmRelease reconciles successfully with chart v82.2.0
- [x] All dependent HelmReleases (grafana, canary-checker, kromgo, exporters) unblocked and Ready