### PR TITLE
fix(platform): remove custom Prometheus affinity conflicting with chart defaults

### DIFF
--- a/.taskfiles/kubernetes/scripts/check-duplicate-keys.py
+++ b/.taskfiles/kubernetes/scripts/check-duplicate-keys.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Detect duplicate YAML mapping keys in multi-document YAML files.
+
+Python's yaml.safe_load() silently takes the last value when duplicate keys
+exist. Flux's helm-controller uses Go's yaml.v3 strict mode which rejects
+duplicates. This script bridges that gap by using a custom YAML loader that
+raises on any duplicate mapping key.
+
+Usage:
+    check-duplicate-keys.py <file1.yaml> [file2.yaml ...]
+
+Exit codes:
+    0 - No duplicate keys found
+    1 - Duplicate keys detected (prints details to stderr)
+"""
+import sys
+
+import yaml
+
+
+class DuplicateKeyError(Exception):
+    pass
+
+
+def make_strict_loader():
+    """Create a YAML SafeLoader subclass that rejects duplicate mapping keys."""
+
+    class StrictSafeLoader(yaml.SafeLoader):
+        pass
+
+    def strict_construct_mapping(loader, node, deep=False):
+        loader.flatten_mapping(node)
+        pairs = loader.construct_pairs(node, deep=deep)
+        seen = {}
+        for key, _value in pairs:
+            if key in seen:
+                # node.start_mark gives the mapping start; individual key
+                # marks are on the key nodes but we report the mapping context
+                raise DuplicateKeyError(
+                    f"Duplicate key '{key}' "
+                    f"at line {node.start_mark.line + 1}"
+                )
+            seen[key] = True
+        return dict(pairs)
+
+    StrictSafeLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        strict_construct_mapping,
+    )
+    return StrictSafeLoader
+
+
+def check_file(filepath):
+    """Check a YAML file for duplicate keys across all documents."""
+    StrictLoader = make_strict_loader()
+    errors = []
+    try:
+        with open(filepath) as f:
+            content = f.read()
+        # load_all handles multi-document YAML (---) which helm template produces
+        for _doc in yaml.load_all(content, Loader=StrictLoader):
+            pass
+    except DuplicateKeyError as e:
+        errors.append(f"{filepath}: {e}")
+    except yaml.YAMLError as e:
+        # Other YAML errors (syntax) are caught by yamllint; skip here
+        pass
+    return errors
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <file1.yaml> [file2.yaml ...]", file=sys.stderr)
+        sys.exit(2)
+
+    all_errors = []
+    for filepath in sys.argv[1:]:
+        all_errors.extend(check_file(filepath))
+
+    if all_errors:
+        print("Duplicate YAML mapping keys detected:", file=sys.stderr)
+        for error in all_errors:
+            print(f"  {error}", file=sys.stderr)
+        sys.exit(1)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.taskfiles/kubernetes/taskfile.yaml
+++ b/.taskfiles/kubernetes/taskfile.yaml
@@ -43,12 +43,13 @@ tasks:
   # =============================================================================
 
   validate:
-    desc: Cluster-independent validation (lint, ResourceSets, Helm charts, kubeconform, deprecations)
+    desc: Cluster-independent validation (lint, ResourceSets, Helm charts, kubeconform, duplicate keys, deprecations)
     cmds:
       - task: _lint
       - task: _expand-resourcesets
       - task: _build-manifests
       - task: _template-all-charts
+      - task: _validate-duplicate-keys
       - task: _validate-kubeconform-base
       - task: _validate-deprecations
 
@@ -293,6 +294,17 @@ tasks:
       - "{{.TASKFILE_DIR}}/scripts/template-all-charts.sh"
     preconditions:
       - which helm yq jq envsubst
+
+  _validate-duplicate-keys:
+    internal: true
+    desc: Detect duplicate YAML mapping keys in helm-templated output
+    deps: [_template-all-charts]
+    cmds:
+      - echo "Checking for duplicate YAML mapping keys in Helm chart output..."
+      - python3 "{{.TASKFILE_DIR}}/scripts/check-duplicate-keys.py" {{.EXPANDED_DIR}}/helm/*.yaml
+    preconditions:
+      - which python3
+      - test -d {{.EXPANDED_DIR}}/helm
 
   _substitute-vars-cluster:
     internal: true

--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -42,15 +42,6 @@ prometheus:
   prometheusSpec:
     priorityClassName: platform
     replicas: 2
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: prometheus
-              topologyKey: kubernetes.io/hostname
     podMetadata:
       labels:
         networking/allow-ingress-internal: "true"


### PR DESCRIPTION
## Summary
- The kube-prometheus-stack chart's built-in `podAntiAffinity: "soft"` default generates a `podAntiAffinity` block in the template output. Our custom `prometheusSpec.affinity` block added a second `podAntiAffinity` key in the same mapping, producing duplicate keys that Flux's helm-controller (Go yaml.v3 strict mode) rejects. This has caused 3 failed PRs (#477, #480, #494).
- Removes the custom affinity block entirely -- the chart's built-in anti-affinity is functionally equivalent and more precise (matches on both `app.kubernetes.io/name` AND `app.kubernetes.io/instance` labels).
- Adds strict YAML duplicate-key detection to `task k8s:validate` to prevent this class of bug from recurring. The check uses a custom Python YAML loader since `helm template`, `kubeconform`, and `yamllint` all silently deduplicate keys.

## Test plan
- [x] `task k8s:validate` passes (including new duplicate-key check)
- [x] Verified on dev cluster: HelmRelease went from `UpgradeFailed` (duplicate key error at line 91) to `Ready=True (UpgradeSucceeded)`
- [x] All 33 HelmReleases on dev are `Ready=True`
- [x] Both Prometheus pods running 2/2 with anti-affinity applied via chart's built-in `podAntiAffinity: "soft"`
- [x] Duplicate-key script tested against known-bad YAML (catches duplicates) and valid YAML (no false positives)