### PR TITLE
fix(k8s): use default_replica_count for cilium-operator replicas

### DIFF
--- a/kubernetes/platform/charts/cilium.yaml
+++ b/kubernetes/platform/charts/cilium.yaml
@@ -48,7 +48,7 @@ socketLB:
   hostNamespaceOnly: true
 operator:
   rollOutPods: true
-  replicas: 2
+  replicas: ${default_replica_count}
   prometheus:
     enabled: true
     serviceMonitor:


### PR DESCRIPTION
## Summary
- Replace hardcoded `operator.replicas: 2` in Cilium Helm values with `${default_replica_count}` variable substitution
- On single-node clusters (dev, `default_replica_count=1`), the second cilium-operator pod is unschedulable due to host port conflicts, causing persistent `KubePodNotReady` and `KubeDeploymentReplicasMismatch` alerts
- Aligns with the existing pattern used by every other HA deployment in the platform (database, dragonfly, garage, gateways, etc.)

## Test plan
- [x] `task k8s:validate` passes (542 resources, 0 invalid)
- [ ] Verify dev cluster (`default_replica_count=1`): cilium-operator scales to 1 replica, pending pod eliminated
- [ ] Verify live cluster (`default_replica_count=3`): cilium-operator scales to 3 replicas (improvement from 2)
- [ ] `KubePodNotReady` and `KubeDeploymentReplicasMismatch` alerts for cilium-operator resolve on dev