### PR TITLE
fix(infra): update node43 inventory for 1TB SSD → 20TB HDD drive swap

### DIFF
--- a/infrastructure/inventory.hcl
+++ b/infrastructure/inventory.hcl
@@ -214,11 +214,11 @@ locals {
           maxSize  = "100%"
           tags     = ["fast", "ssd", "any"]
         },
-        { # 1TB Crucial SSD
-          name     = "crucial-ssd-1tb-1"
+        { # 20TB Seagate HDD
+          name     = "seagate-hdd-20tb-0"
           selector = "disk.dev_path == '/dev/sdb'"
           maxSize  = "100%"
-          tags     = ["fast", "ssd", "any"]
+          tags     = ["slow", "hdd", "any"]
       }]
       bonds = [{
         link_permanentAddr = ["ac:1f:6b:2d:bb:c8"]


### PR DESCRIPTION
## Summary

- Node43's second data disk (`/dev/sdb`) was physically hot-swapped from a 1TB Crucial MX500 SSD to a 20TB Seagate HDD (`ST20000NT001-3MB`)
- Updates `inventory.hcl` to match hardware reality: disk name `seagate-hdd-20tb-0`, tags `[slow, hdd, any]` — consistent with node41/node42 convention
- Terragrunt apply will regenerate node43's Talos machine config, triggering a reboot that formats the new HDD as XFS and registers it with Longhorn

## Test plan

- [x] `task tg:fmt` passes
- [x] `task tg:validate-live` passes (5/5 units)
- [ ] `task tg:plan-live` shows only node43 disk config change
- [ ] `task tg:apply-live` succeeds, node43 reboots and rejoins as Ready
- [ ] Longhorn shows `seagate-hdd-20tb-0` as Ready with `[slow, hdd, any]` tags
- [ ] CNPG platform cluster: 3 healthy instances, replication caught up
- [ ] All Longhorn volumes return to healthy robustness
- [ ] Firing alerts return to zero baseline (excluding Watchdog)