### PR TITLE
fix(infra): pass default_replica_count to cilium templatestring

### DIFF
--- a/infrastructure/modules/config/main.tf
+++ b/infrastructure/modules/config/main.tf
@@ -341,9 +341,10 @@ locals {
 
   # Cilium values for bootstrap - uses kubernetes platform as single source of truth
   cilium_values = templatestring(var.cilium_values_template, {
-    cluster_name       = var.name
-    cluster_pod_subnet = var.networking.pod_subnet
-    internal_domain    = var.networking.internal_tld
+    cluster_name          = var.name
+    cluster_pod_subnet    = var.networking.pod_subnet
+    internal_domain       = var.networking.internal_tld
+    default_replica_count = tostring(min(3, length(local.machines)))
   })
 
   # Cluster environment variables for flux post-build substitution (non-version)

--- a/kubernetes/platform/charts/cilium.yaml
+++ b/kubernetes/platform/charts/cilium.yaml
@@ -1,4 +1,7 @@
 ---
+# This template is dual-use: consumed by Flux (in-cluster substitution) AND
+# by the Terragrunt config module (infrastructure/modules/config/main.tf).
+# Any new template variables must be added to both consumers.
 # https://raw.githubusercontent.com/cilium/cilium/main/install/kubernetes/cilium/values.yaml
 # yaml-language-server: $schema=https://raw.githubusercontent.com/cilium/cilium/main/install/kubernetes/cilium/values.schema.json
 autoDirectNodeRoutes: true


### PR DESCRIPTION
## Summary
- The cilium.yaml template is dual-use: consumed by both Flux (in-cluster) and the Terragrunt config module for bootstrap. PR #497 added `${default_replica_count}` to the template but only updated the Flux consumer, leaving the Terragrunt `templatestring()` call without the variable -- breaking `tg:destroy-integration`.
- Adds a comment at the top of cilium.yaml documenting this dual-use contract so future contributors know to update both consumers.

## Test plan
- [x] `task tg:fmt` passes
- [x] `task k8s:validate` passes (33 charts templated, 0 invalid)
- [x] `task tg:test-config` passes (128 passed, 0 failed)