### PR TITLE
feat(k8s): provision CNPG databases and credentials for media stack

### DIFF
--- a/kubernetes/clusters/live/config/media-prereqs/cnpg-superuser-replica.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/cnpg-superuser-replica.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cnpg-superuser-replica
+  namespace: media
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: database/cnpg-platform-superuser
+type: Opaque
+data: { }

--- a/kubernetes/clusters/live/config/media-prereqs/db-credentials.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/db-credentials.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sonarr-db-credentials
+  namespace: media
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+data: { }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: radarr-db-credentials
+  namespace: media
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+data: { }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prowlarr-db-credentials
+  namespace: media
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+data: { }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bazarr-db-credentials
+  namespace: media
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+data: { }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jellyseerr-db-credentials
+  namespace: media
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+data: { }

--- a/kubernetes/clusters/live/config/media-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/kustomization.yaml
@@ -14,3 +14,5 @@ resources:
   - jellyfin-exporter-api-token.yaml
   - recyclarr-api-keys.yaml
   - recyclarr-config.yaml
+  - cnpg-superuser-replica.yaml
+  - db-credentials.yaml

--- a/kubernetes/platform/config/database/superuser-secret.yaml
+++ b/kubernetes/platform/config/database/superuser-secret.yaml
@@ -8,7 +8,7 @@ metadata:
     secret-generator.v1.mittwald.de/length: "32"
     secret-generator.v1.mittwald.de/encoding: base64
     replicator.v1.mittwald.de/replication-allowed: "true"
-    replicator.v1.mittwald.de/replication-allowed-namespaces: "zipline,authelia,tandoor,paperless,vaultwarden"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "zipline,authelia,tandoor,paperless,vaultwarden,media"
 type: kubernetes.io/basic-auth
 stringData:
   username: postgres


### PR DESCRIPTION
## Summary
- Provision PostgreSQL database infrastructure for migrating the media/arr stack (Sonarr, Radarr, Prowlarr, Bazarr, Jellyseerr) from SQLite to the shared CNPG platform cluster
- This is PR 1 of 2 -- non-breaking, adds databases and credentials only. A follow-up PR will update app chart values to consume PostgreSQL
- Databases and users will be created by postgres-init when apps connect in the second PR

## Test plan
- [x] `task k8s:validate` passes
- [ ] After merge, verify `cnpg-superuser-replica` secret appears in media namespace
- [ ] Verify five `*-db-credentials` secrets are created with auto-generated passwords in media namespace
- [ ] Verify superuser secret replication works (media namespace added to allowed list)