### PR TITLE
feat(k8s): migrate media apps from SQLite to PostgreSQL on CNPG

### DIFF
--- a/kubernetes/clusters/live/charts/bazarr.yaml
+++ b/kubernetes/clusters/live/charts/bazarr.yaml
@@ -15,11 +15,72 @@ controllers:
         seccompProfile:
           type: RuntimeDefault
 
+    initContainers:
+      init-db:
+        image:
+          repository: ghcr.io/home-operations/postgres-init
+          # renovate: datasource=docker depName=ghcr.io/home-operations/postgres-init
+          tag: "18"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        env:
+          INIT_POSTGRES_HOST: platform-rw.database.svc.cluster.local
+          INIT_POSTGRES_SUPER_USER: postgres
+          INIT_POSTGRES_SUPER_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: cnpg-superuser-replica
+                key: password
+          INIT_POSTGRES_USER: bazarr
+          INIT_POSTGRES_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: bazarr-db-credentials
+                key: password
+          INIT_POSTGRES_DBNAME: bazarr
+
+      schema-grants:
+        dependsOn: init-db
+        image:
+          repository: ghcr.io/home-operations/postgres-init
+          tag: "18"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        command: ["psql"]
+        args:
+          - --host=platform-rw.database.svc.cluster.local
+          - --username=postgres
+          - --dbname=bazarr
+          - --command=GRANT ALL ON SCHEMA public TO bazarr; ALTER DATABASE bazarr OWNER TO bazarr;
+        env:
+          PGPASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: cnpg-superuser-replica
+                key: password
+
     containers:
       app:
         image:
           repository: ghcr.io/home-operations/bazarr
           tag: "${bazarr_version}"
+        env:
+          POSTGRES_ENABLED: "true"
+          POSTGRES_HOST: platform-rw.database.svc.cluster.local
+          POSTGRES_PORT: "5432"
+          POSTGRES_DATABASE: bazarr
+          POSTGRES_USERNAME: bazarr
+          POSTGRES_PASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: bazarr-db-credentials
+                key: password
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/kubernetes/clusters/live/charts/jellyseerr.yaml
+++ b/kubernetes/clusters/live/charts/jellyseerr.yaml
@@ -15,11 +15,72 @@ controllers:
         seccompProfile:
           type: RuntimeDefault
 
+    initContainers:
+      init-db:
+        image:
+          repository: ghcr.io/home-operations/postgres-init
+          # renovate: datasource=docker depName=ghcr.io/home-operations/postgres-init
+          tag: "18"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        env:
+          INIT_POSTGRES_HOST: platform-rw.database.svc.cluster.local
+          INIT_POSTGRES_SUPER_USER: postgres
+          INIT_POSTGRES_SUPER_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: cnpg-superuser-replica
+                key: password
+          INIT_POSTGRES_USER: jellyseerr
+          INIT_POSTGRES_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: jellyseerr-db-credentials
+                key: password
+          INIT_POSTGRES_DBNAME: jellyseerr
+
+      schema-grants:
+        dependsOn: init-db
+        image:
+          repository: ghcr.io/home-operations/postgres-init
+          tag: "18"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        command: ["psql"]
+        args:
+          - --host=platform-rw.database.svc.cluster.local
+          - --username=postgres
+          - --dbname=jellyseerr
+          - --command=GRANT ALL ON SCHEMA public TO jellyseerr; ALTER DATABASE jellyseerr OWNER TO jellyseerr;
+        env:
+          PGPASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: cnpg-superuser-replica
+                key: password
+
     containers:
       app:
         image:
           repository: ghcr.io/seerr-team/seerr
           tag: "${seerr_version}"
+        env:
+          DB_TYPE: postgres
+          DB_HOST: platform-rw.database.svc.cluster.local
+          DB_PORT: "5432"
+          DB_USER: jellyseerr
+          DB_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: jellyseerr-db-credentials
+                key: password
+          DB_NAME: jellyseerr
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false

--- a/kubernetes/clusters/live/charts/prowlarr.yaml
+++ b/kubernetes/clusters/live/charts/prowlarr.yaml
@@ -15,11 +15,98 @@ controllers:
         seccompProfile:
           type: RuntimeDefault
 
+    initContainers:
+      init-db-main:
+        image:
+          repository: ghcr.io/home-operations/postgres-init
+          # renovate: datasource=docker depName=ghcr.io/home-operations/postgres-init
+          tag: "18"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        env:
+          INIT_POSTGRES_HOST: platform-rw.database.svc.cluster.local
+          INIT_POSTGRES_SUPER_USER: postgres
+          INIT_POSTGRES_SUPER_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: cnpg-superuser-replica
+                key: password
+          INIT_POSTGRES_USER: prowlarr
+          INIT_POSTGRES_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: prowlarr-db-credentials
+                key: password
+          INIT_POSTGRES_DBNAME: prowlarr-main
+
+      init-db-log:
+        dependsOn: init-db-main
+        image:
+          repository: ghcr.io/home-operations/postgres-init
+          tag: "18"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        env:
+          INIT_POSTGRES_HOST: platform-rw.database.svc.cluster.local
+          INIT_POSTGRES_SUPER_USER: postgres
+          INIT_POSTGRES_SUPER_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: cnpg-superuser-replica
+                key: password
+          INIT_POSTGRES_USER: prowlarr
+          INIT_POSTGRES_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: prowlarr-db-credentials
+                key: password
+          INIT_POSTGRES_DBNAME: prowlarr-log
+
+      schema-grants:
+        dependsOn: init-db-log
+        image:
+          repository: ghcr.io/home-operations/postgres-init
+          tag: "18"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        command: ["psql"]
+        args:
+          - --host=platform-rw.database.svc.cluster.local
+          - --username=postgres
+          - --dbname=prowlarr-main
+          - --command=GRANT ALL ON SCHEMA public TO prowlarr; ALTER DATABASE "prowlarr-main" OWNER TO prowlarr; ALTER DATABASE "prowlarr-log" OWNER TO prowlarr;
+        env:
+          PGPASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: cnpg-superuser-replica
+                key: password
+
     containers:
       app:
         image:
           repository: ghcr.io/home-operations/prowlarr
           tag: "${prowlarr_version}"
+        env:
+          PROWLARR__POSTGRES__HOST: platform-rw.database.svc.cluster.local
+          PROWLARR__POSTGRES__PORT: "5432"
+          PROWLARR__POSTGRES__USER: prowlarr
+          PROWLARR__POSTGRES__PASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: prowlarr-db-credentials
+                key: password
+          PROWLARR__POSTGRES__MAINDB: prowlarr-main
+          PROWLARR__POSTGRES__LOGDB: prowlarr-log
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/kubernetes/clusters/live/charts/radarr.yaml
+++ b/kubernetes/clusters/live/charts/radarr.yaml
@@ -15,11 +15,98 @@ controllers:
         seccompProfile:
           type: RuntimeDefault
 
+    initContainers:
+      init-db-main:
+        image:
+          repository: ghcr.io/home-operations/postgres-init
+          # renovate: datasource=docker depName=ghcr.io/home-operations/postgres-init
+          tag: "18"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        env:
+          INIT_POSTGRES_HOST: platform-rw.database.svc.cluster.local
+          INIT_POSTGRES_SUPER_USER: postgres
+          INIT_POSTGRES_SUPER_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: cnpg-superuser-replica
+                key: password
+          INIT_POSTGRES_USER: radarr
+          INIT_POSTGRES_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: radarr-db-credentials
+                key: password
+          INIT_POSTGRES_DBNAME: radarr-main
+
+      init-db-log:
+        dependsOn: init-db-main
+        image:
+          repository: ghcr.io/home-operations/postgres-init
+          tag: "18"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        env:
+          INIT_POSTGRES_HOST: platform-rw.database.svc.cluster.local
+          INIT_POSTGRES_SUPER_USER: postgres
+          INIT_POSTGRES_SUPER_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: cnpg-superuser-replica
+                key: password
+          INIT_POSTGRES_USER: radarr
+          INIT_POSTGRES_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: radarr-db-credentials
+                key: password
+          INIT_POSTGRES_DBNAME: radarr-log
+
+      schema-grants:
+        dependsOn: init-db-log
+        image:
+          repository: ghcr.io/home-operations/postgres-init
+          tag: "18"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        command: ["psql"]
+        args:
+          - --host=platform-rw.database.svc.cluster.local
+          - --username=postgres
+          - --dbname=radarr-main
+          - --command=GRANT ALL ON SCHEMA public TO radarr; ALTER DATABASE "radarr-main" OWNER TO radarr; ALTER DATABASE "radarr-log" OWNER TO radarr;
+        env:
+          PGPASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: cnpg-superuser-replica
+                key: password
+
     containers:
       app:
         image:
           repository: ghcr.io/home-operations/radarr
           tag: "${radarr_version}"
+        env:
+          RADARR__POSTGRES__HOST: platform-rw.database.svc.cluster.local
+          RADARR__POSTGRES__PORT: "5432"
+          RADARR__POSTGRES__USER: radarr
+          RADARR__POSTGRES__PASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: radarr-db-credentials
+                key: password
+          RADARR__POSTGRES__MAINDB: radarr-main
+          RADARR__POSTGRES__LOGDB: radarr-log
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/kubernetes/clusters/live/charts/sonarr.yaml
+++ b/kubernetes/clusters/live/charts/sonarr.yaml
@@ -15,11 +15,98 @@ controllers:
         seccompProfile:
           type: RuntimeDefault
 
+    initContainers:
+      init-db-main:
+        image:
+          repository: ghcr.io/home-operations/postgres-init
+          # renovate: datasource=docker depName=ghcr.io/home-operations/postgres-init
+          tag: "18"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        env:
+          INIT_POSTGRES_HOST: platform-rw.database.svc.cluster.local
+          INIT_POSTGRES_SUPER_USER: postgres
+          INIT_POSTGRES_SUPER_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: cnpg-superuser-replica
+                key: password
+          INIT_POSTGRES_USER: sonarr
+          INIT_POSTGRES_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: sonarr-db-credentials
+                key: password
+          INIT_POSTGRES_DBNAME: sonarr-main
+
+      init-db-log:
+        dependsOn: init-db-main
+        image:
+          repository: ghcr.io/home-operations/postgres-init
+          tag: "18"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        env:
+          INIT_POSTGRES_HOST: platform-rw.database.svc.cluster.local
+          INIT_POSTGRES_SUPER_USER: postgres
+          INIT_POSTGRES_SUPER_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: cnpg-superuser-replica
+                key: password
+          INIT_POSTGRES_USER: sonarr
+          INIT_POSTGRES_PASS:
+            valueFrom:
+              secretKeyRef:
+                name: sonarr-db-credentials
+                key: password
+          INIT_POSTGRES_DBNAME: sonarr-log
+
+      schema-grants:
+        dependsOn: init-db-log
+        image:
+          repository: ghcr.io/home-operations/postgres-init
+          tag: "18"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        command: ["psql"]
+        args:
+          - --host=platform-rw.database.svc.cluster.local
+          - --username=postgres
+          - --dbname=sonarr-main
+          - --command=GRANT ALL ON SCHEMA public TO sonarr; ALTER DATABASE "sonarr-main" OWNER TO sonarr; ALTER DATABASE "sonarr-log" OWNER TO sonarr;
+        env:
+          PGPASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: cnpg-superuser-replica
+                key: password
+
     containers:
       app:
         image:
           repository: ghcr.io/home-operations/sonarr
           tag: "${sonarr_version}"
+        env:
+          SONARR__POSTGRES__HOST: platform-rw.database.svc.cluster.local
+          SONARR__POSTGRES__PORT: "5432"
+          SONARR__POSTGRES__USER: sonarr
+          SONARR__POSTGRES__PASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: sonarr-db-credentials
+                key: password
+          SONARR__POSTGRES__MAINDB: sonarr-main
+          SONARR__POSTGRES__LOGDB: sonarr-log
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary
- Migrate Sonarr, Radarr, Prowlarr, Bazarr, and Jellyseerr from embedded SQLite to the shared CNPG PostgreSQL platform cluster for proper backup, HA, and disaster recovery
- This is PR 2 of 2 -- depends on the infra PR (which provisions cnpg-superuser-replica and per-app db-credentials secrets in the media namespace) being merged first
- Apps will start fresh on PostgreSQL (no SQLite data migration); Recyclarr will automatically re-sync quality profiles for Sonarr and Radarr
- Jellyfin stays on SQLite (PostgreSQL plugin is experimental)

## Test plan
- [ ] Merge the companion infra PR first (credentials provisioning)
- [ ] Merge this PR and verify all 5 apps start successfully on integration
- [ ] Check init container logs for successful database/user creation
- [ ] Verify Sonarr, Radarr, Prowlarr respond on their health endpoints
- [ ] Verify Bazarr and Jellyseerr connect to PostgreSQL without errors
- [ ] Confirm Recyclarr syncs quality profiles to Sonarr and Radarr