### PR TITLE
feat(k8s): enable Longhorn storage over-provisioning

### DIFF
--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -20,6 +20,8 @@ defaultSettings:
   createDefaultDiskLabeledNodes: true
   storageReservedPercentageForDefaultDisk: 0
   nodeDownPodDeletionPolicy: delete-both-statefulset-and-deployment-pod
+  storageOverProvisioningPercentage: 500
+  storageMinimalAvailablePercentage: 10
 defaultBackupStore:
   backupTarget: s3://homelab-longhorn-backup-${cluster_name}@us-east-2/
   backupTargetCredentialSecret: longhorn-s3-backup-credentials


### PR DESCRIPTION
## Summary
- Enable thin-provisioning / over-scheduling so Longhorn bases volume scheduling on actual disk usage rather than requested PVC sizes
- Eliminates scheduling friction caused by PVC requests exceeding physical capacity on dedicated storage disks where no other tenants compete for space

## Test plan
- [x] Validated with `task k8s:validate` (YAML lint, ResourceSet expansion, Helm templating, schema validation, deprecation checks)
- [ ] Verify Longhorn UI shows updated settings after promotion to integration
- [ ] Confirm existing Prometheus alerts (based on actual disk/pool usage ratios) continue to fire correctly