### PR TITLE
fix(k8s): use Opaque type for replicator-target db credential secrets

### DIFF
--- a/kubernetes/clusters/live/config/ai-prereqs/open-webui-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/ai-prereqs/open-webui-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: ai
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/open-webui-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/authelia-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/authelia-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: authelia
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/authelia-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/lldap-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/lldap-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: authelia
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/lldap-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }

--- a/kubernetes/clusters/live/config/media-prereqs/db-credentials.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/db-credentials.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: media
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/sonarr-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }
 ---
 apiVersion: v1
@@ -16,7 +16,7 @@ metadata:
   namespace: media
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/radarr-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }
 ---
 apiVersion: v1
@@ -26,7 +26,7 @@ metadata:
   namespace: media
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/prowlarr-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }
 ---
 apiVersion: v1
@@ -36,7 +36,7 @@ metadata:
   namespace: media
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/bazarr-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }
 ---
 apiVersion: v1
@@ -46,5 +46,5 @@ metadata:
   namespace: media
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/jellyseerr-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }

--- a/kubernetes/clusters/live/config/paperless/paperless-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/paperless/paperless-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: paperless
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/paperless-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }

--- a/kubernetes/clusters/live/config/tandoor/tandoor-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/tandoor/tandoor-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: tandoor
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/tandoor-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }

--- a/kubernetes/clusters/live/config/vaultwarden/vaultwarden-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/vaultwarden/vaultwarden-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: vaultwarden
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/vaultwarden-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }

--- a/kubernetes/clusters/live/config/zipline/zipline-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/zipline/zipline-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: zipline
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/zipline-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }


### PR DESCRIPTION
## Summary
- Fix media-prereqs Kustomization failure on live caused by `kubernetes.io/basic-auth` secrets with empty data failing Flux server-side dry-run validation
- Change all 12 replicator-target db credential secrets across 8 files from `type: kubernetes.io/basic-auth` to `type: Opaque`, since the replicator does not require a specific secret type
- Prevent the same failure on other prereqs Kustomizations during future cluster rebuilds (authelia, ai, paperless, tandoor, vaultwarden, zipline)

## Test plan
- [x] `task k8s:validate` passes
- [ ] media-prereqs Kustomization reconciles successfully on live after merge
- [ ] All affected prereqs Kustomizations remain healthy
- [ ] kubernetes-replicator continues to populate credentials from database namespace