### PR TITLE
fix(k8s): resolve live cluster app failures and WAL archiving

### DIFF
--- a/kubernetes/clusters/live/charts/excalidraw.yaml
+++ b/kubernetes/clusters/live/charts/excalidraw.yaml
@@ -25,14 +25,15 @@ controllers:
           tag: sha-4bfc5bb
         # LIMITATION: The upstream excalidraw image (nginx:alpine) has no USER
         # directive and requires root for the copy + chown operations. Running as
-        # non-root would require a custom image build. Capabilities are still
-        # dropped and privilege escalation is denied to minimize risk.
+        # non-root would require a custom image build. CHOWN, DAC_OVERRIDE, and
+        # FOWNER are required for chown -R on nginx cache directories.
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
           runAsNonRoot: false
           capabilities:
             drop: ["ALL"]
+            add: ["CHOWN", "DAC_OVERRIDE", "FOWNER"]
         command:
           - /bin/sh
           - -c

--- a/kubernetes/clusters/live/charts/homepage.yaml
+++ b/kubernetes/clusters/live/charts/homepage.yaml
@@ -43,6 +43,9 @@ controllers:
               httpGet:
                 path: /api/healthcheck
                 port: 3000
+                httpHeaders:
+                  - name: Host
+                    value: "home.${internal_domain}"
               periodSeconds: 30
           readiness:
             enabled: true
@@ -51,6 +54,9 @@ controllers:
               httpGet:
                 path: /api/healthcheck
                 port: 3000
+                httpHeaders:
+                  - name: Host
+                    value: "home.${internal_domain}"
               periodSeconds: 10
           startup:
             enabled: true
@@ -59,6 +65,9 @@ controllers:
               httpGet:
                 path: /api/healthcheck
                 port: 3000
+                httpHeaders:
+                  - name: Host
+                    value: "home.${internal_domain}"
               initialDelaySeconds: 5
               periodSeconds: 5
               failureThreshold: 10

--- a/kubernetes/clusters/live/charts/open-webui.yaml
+++ b/kubernetes/clusters/live/charts/open-webui.yaml
@@ -58,7 +58,6 @@ sso:
     scopes: "openid email profile groups"
 
 podSecurityContext:
-  runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
 

--- a/kubernetes/clusters/live/charts/paperless.yaml
+++ b/kubernetes/clusters/live/charts/paperless.yaml
@@ -116,3 +116,7 @@ persistence:
     type: emptyDir
     globalMounts:
       - path: /tmp
+  run:
+    type: emptyDir
+    globalMounts:
+      - path: /run

--- a/kubernetes/clusters/live/charts/tandoor.yaml
+++ b/kubernetes/clusters/live/charts/tandoor.yaml
@@ -116,15 +116,13 @@ service:
     ports:
       http:
         port: 8080
-      metrics:
-        port: 8080
 
 serviceMonitor:
   main:
     enabled: true
     serviceName: app
     endpoints:
-      - port: metrics
+      - port: http
         scheme: http
         path: /metrics
         interval: 60s

--- a/kubernetes/clusters/live/charts/tdarr.yaml
+++ b/kubernetes/clusters/live/charts/tdarr.yaml
@@ -107,3 +107,7 @@ persistence:
       tdarr:
         app:
           - path: /app/transcode_cache
+  run:
+    type: emptyDir
+    globalMounts:
+      - path: /run

--- a/kubernetes/clusters/live/config/immich/immich-cluster.yaml
+++ b/kubernetes/clusters/live/config/immich/immich-cluster.yaml
@@ -11,6 +11,9 @@ spec:
       replicator.v1.mittwald.de/replication-allowed: "true"
       replicator.v1.mittwald.de/replication-allowed-namespaces: "immich"
   description: "Immich PostgreSQL with vectorchord for AI vector search"
+  env:
+    - name: AWS_DEFAULT_REGION
+      value: "garage"
   imageName: ghcr.io/tensorchord/cloudnative-vectorchord:${vectorchord_version:-17.7-1.0.0}
   instances: ${default_replica_count}
   primaryUpdateStrategy: unsupervised

--- a/kubernetes/platform/config/database/cluster.yaml
+++ b/kubernetes/platform/config/database/cluster.yaml
@@ -5,6 +5,9 @@ metadata:
   name: platform
 spec:
   description: "Shared platform PostgreSQL cluster"
+  env:
+    - name: AWS_DEFAULT_REGION
+      value: "garage"
   imageName: ghcr.io/cloudnative-pg/postgresql:${postgresql_image_version}
   instances: ${default_replica_count}
   primaryUpdateStrategy: unsupervised


### PR DESCRIPTION
## Summary
- Fix 7 issues across live cluster apps that cause pod failures, probe rejections, and backup failures
- Tandoor: duplicate service port breaks ServiceMonitor scraping
- Paperless/Tdarr: s6-overlay needs writable /run directory owned by pod fsGroup
- Open-WebUI: runAsNonRoot conflicts with chart-generated init container running as root
- Homepage: probes rejected by HOMEPAGE_ALLOWED_HOSTS because kubelet sends pod IP as Host header
- Excalidraw: init container chown fails without CHOWN/DAC_OVERRIDE/FOWNER capabilities
- CNPG (platform + immich): barman-cloud WAL archiving fails against Garage S3 due to default us-east-1 region signing

## Test plan
- [ ] `task k8s:validate` passes (verified locally)
- [ ] Tandoor ServiceMonitor scrapes metrics on `http` port
- [ ] Paperless and Tdarr pods start without s6-overlay /run permission errors
- [ ] Open-WebUI copy-app-data init container starts successfully as root
- [ ] Homepage probes pass with Host header matching HOMEPAGE_ALLOWED_HOSTS
- [ ] Excalidraw init-nginx container successfully chowns nginx cache directories
- [ ] CNPG WAL archiving succeeds for both platform and immich clusters