### PR TITLE
fix(k8s): resolve s6-overlay /run ownership and tandoor probe failures

### DIFF
--- a/kubernetes/clusters/live/charts/paperless.yaml
+++ b/kubernetes/clusters/live/charts/paperless.yaml
@@ -18,6 +18,27 @@ controllers:
         seccompProfile:
           type: RuntimeDefault
 
+    # s6-overlay preinit checks that /run is owned by the container UID.
+    # emptyDir mount points are always owned by root (uid 0) — Kubernetes
+    # only changes the GID via fsGroup, not the UID. This init container
+    # runs as root with CAP_CHOWN to fix the ownership before the app starts.
+    initContainers:
+      init-run:
+        image:
+          repository: busybox
+          tag: latest
+        command:
+          - /bin/sh
+          - -c
+          - chown 1000:1000 /run
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: false
+          capabilities:
+            drop: ["ALL"]
+            add: ["CHOWN"]
+
     containers:
       app:
         image:

--- a/kubernetes/clusters/live/charts/tandoor.yaml
+++ b/kubernetes/clusters/live/charts/tandoor.yaml
@@ -90,6 +90,12 @@ controllers:
               httpGet:
                 path: /accounts/login/
                 port: 8080
+                # Django validates the Host header against ALLOWED_HOSTS.
+                # Kubernetes probes send the pod IP as Host, which Django
+                # rejects with DisallowedHost.
+                httpHeaders:
+                  - name: Host
+                    value: "recipes.${internal_domain}"
               initialDelaySeconds: 15
               periodSeconds: 5
               failureThreshold: 30
@@ -100,6 +106,9 @@ controllers:
               httpGet:
                 path: /accounts/login/
                 port: 8080
+                httpHeaders:
+                  - name: Host
+                    value: "recipes.${internal_domain}"
               periodSeconds: 30
           readiness:
             enabled: true
@@ -108,6 +117,9 @@ controllers:
               httpGet:
                 path: /accounts/login/
                 port: 8080
+                httpHeaders:
+                  - name: Host
+                    value: "recipes.${internal_domain}"
               periodSeconds: 10
 
 service:

--- a/kubernetes/clusters/live/charts/tdarr.yaml
+++ b/kubernetes/clusters/live/charts/tdarr.yaml
@@ -15,6 +15,27 @@ controllers:
         seccompProfile:
           type: RuntimeDefault
 
+    # s6-overlay preinit checks that /run is owned by the container UID.
+    # emptyDir mount points are always owned by root (uid 0) — Kubernetes
+    # only changes the GID via fsGroup, not the UID. This init container
+    # runs as root with CAP_CHOWN to fix the ownership before the app starts.
+    initContainers:
+      init-run:
+        image:
+          repository: busybox
+          tag: latest
+        command:
+          - /bin/sh
+          - -c
+          - chown 568:568 /run
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: false
+          capabilities:
+            drop: ["ALL"]
+            add: ["CHOWN"]
+
     containers:
       app:
         image:


### PR DESCRIPTION
## Summary
- Add `init-run` init containers to **paperless** and **tdarr** that `chown /run` to the correct UID before s6-overlay preinit runs -- emptyDir mount points are always owned by root (uid 0) and Kubernetes only changes the GID via fsGroup, not the UID
- Add `Host` header to **tandoor** probe specs so Django's `ALLOWED_HOSTS` validation accepts the health check requests instead of rejecting them with `DisallowedHost`

## Test plan
- [ ] `task k8s:validate` passes
- [ ] Paperless pod starts without s6-overlay `/run` ownership error
- [ ] Tdarr pod starts without s6-overlay `/run` ownership error
- [ ] Tandoor probes pass (no `DisallowedHost` rejections in logs)