### PR TITLE
fix(k8s): add missing capabilities to s6-overlay init containers

### DIFF
--- a/kubernetes/clusters/live/charts/paperless.yaml
+++ b/kubernetes/clusters/live/charts/paperless.yaml
@@ -37,7 +37,7 @@ controllers:
           runAsNonRoot: false
           capabilities:
             drop: ["ALL"]
-            add: ["CHOWN"]
+            add: ["CHOWN", "DAC_OVERRIDE", "FOWNER"]
 
     containers:
       app:

--- a/kubernetes/clusters/live/charts/tdarr.yaml
+++ b/kubernetes/clusters/live/charts/tdarr.yaml
@@ -34,7 +34,7 @@ controllers:
           runAsNonRoot: false
           capabilities:
             drop: ["ALL"]
-            add: ["CHOWN"]
+            add: ["CHOWN", "DAC_OVERRIDE", "FOWNER"]
 
     containers:
       app:


### PR DESCRIPTION
## Summary
- CAP_CHOWN alone is insufficient for chown on emptyDir mount points — also needs CAP_DAC_OVERRIDE and CAP_FOWNER
- Matches the pattern already working for excalidraw's init-nginx container
- Fixes paperless and tdarr init-run containers that were failing with "Operation not permitted"

## Test plan
- [ ] Paperless pod starts without s6-overlay `/run` ownership error
- [ ] Tdarr pod starts without s6-overlay `/run` ownership error