### PR TITLE
fix(k8s): run init-run containers as root for effective capabilities

### DIFF
--- a/kubernetes/clusters/live/charts/paperless.yaml
+++ b/kubernetes/clusters/live/charts/paperless.yaml
@@ -35,6 +35,8 @@ controllers:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
+          runAsUser: 0
+          runAsGroup: 0
           capabilities:
             drop: ["ALL"]
             add: ["CHOWN", "DAC_OVERRIDE", "FOWNER"]

--- a/kubernetes/clusters/live/charts/tdarr.yaml
+++ b/kubernetes/clusters/live/charts/tdarr.yaml
@@ -32,6 +32,8 @@ controllers:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
+          runAsUser: 0
+          runAsGroup: 0
           capabilities:
             drop: ["ALL"]
             add: ["CHOWN", "DAC_OVERRIDE", "FOWNER"]


### PR DESCRIPTION
## Summary
- Init-run containers for paperless and tdarr need `runAsUser: 0` to make Linux capabilities effective — without it they inherit the pod-level non-root UID where `CAP_CHOWN`/`CAP_DAC_OVERRIDE`/`CAP_FOWNER` are silently ignored by the kernel

## Test plan
- [ ] Validation passes: `task k8s:validate`
- [ ] Paperless pod starts without `chown: /run: Operation not permitted`
- [ ] Tdarr pod starts without `chown: /run: Operation not permitted`