### PR TITLE
fix(k8s): let tdarr s6-overlay run as root with least-privilege caps

### DIFF
--- a/kubernetes/clusters/live/charts/tdarr.yaml
+++ b/kubernetes/clusters/live/charts/tdarr.yaml
@@ -15,29 +15,10 @@ controllers:
         seccompProfile:
           type: RuntimeDefault
 
-    # s6-overlay preinit checks that /run is owned by the container UID.
-    # emptyDir mount points are always owned by root (uid 0) — Kubernetes
-    # only changes the GID via fsGroup, not the UID. This init container
-    # runs as root with CAP_CHOWN to fix the ownership before the app starts.
-    initContainers:
-      init-run:
-        image:
-          repository: busybox
-          tag: latest
-        command:
-          - /bin/sh
-          - -c
-          - chown 568:568 /run
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: false
-          runAsUser: 0
-          runAsGroup: 0
-          capabilities:
-            drop: ["ALL"]
-            add: ["CHOWN", "DAC_OVERRIDE", "FOWNER"]
-
+    # s6-overlay (LinuxServer.io) requires root to run its init system,
+    # then drops to PUID/PGID via s6-applyuidgid. Capabilities needed:
+    # SETUID/SETGID for user switching, CHOWN/DAC_OVERRIDE/FOWNER for
+    # file ownership fixups during init.
     containers:
       app:
         image:
@@ -45,6 +26,8 @@ controllers:
           tag: "${tdarr_version}"
         env:
           TZ: UTC
+          PUID: "568"
+          PGID: "568"
           serverIP: "0.0.0.0"
           serverPort: "8266"
           webUIPort: "8265"
@@ -52,8 +35,12 @@ controllers:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
+          runAsNonRoot: false
+          runAsUser: 0
+          runAsGroup: 0
           capabilities:
             drop: [ALL]
+            add: [CHOWN, DAC_OVERRIDE, FOWNER, SETGID, SETUID]
         resources:
           requests:
             cpu: 100m
@@ -132,5 +119,7 @@ persistence:
           - path: /app/transcode_cache
   run:
     type: emptyDir
-    globalMounts:
-      - path: /run
+    advancedMounts:
+      tdarr:
+        app:
+          - path: /run


### PR DESCRIPTION
## Summary
- Tdarr (LinuxServer.io) uses s6-overlay which must start as root to run its init system — `s6-applyuidgid` calls `setgroups()` which requires `CAP_SETGID`, only effective for UID 0
- Container now runs as root with explicit `PUID`/`PGID` env vars so s6-overlay drops to UID 568 after init, with a minimal capability set (`CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETGID`, `SETUID`)
- Removes the init-run busybox container (no longer needed — s6-overlay handles `/run` ownership itself when running as root)

## Test plan
- [ ] Validation passes: `task k8s:validate`
- [ ] Tdarr pod starts without `s6-applyuidgid: fatal: unable to set supplementary group list`
- [ ] Tdarr server responds on port 8265