### PR TITLE
fix(k8s): apply s6-overlay pattern to tdarr-node and ban LSIO images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,22 @@ For dev cluster task commands and detailed procedures, see [.taskfiles/CLAUDE.md
 - **NEVER** commit secrets or credentials to Git - they belong in AWS Parameter Store
 - **NEVER** commit generated artifacts (`.rendered/`, `.terragrunt-cache/`, etc.)
 
+## Container Image Standards
+
+**NEVER** deploy container images that use s6-overlay or LinuxServer.io (LSIO) base images. These init systems require root privileges and conflict with Kubernetes security contexts (`runAsNonRoot`, `drop: [ALL]`).
+
+- **NEVER** introduce a new s6-overlay or LSIO-based image without explicit user approval
+- **ALWAYS** prefer upstream/official images designed for rootless operation
+- **ALWAYS** verify new images don't use s6-overlay by checking for `ENTRYPOINT ["/init"]` or LSIO base layers
+
+**Approved exceptions** (upstream provides no rootless alternative):
+
+| Image | Reason | Security Pattern |
+|-------|--------|-----------------|
+| `ghcr.io/haveagitgat/tdarr` | Upstream embeds s6-overlay, no alternative exists | Container-level `runAsUser: 0` + `PUID`/`PGID` env + least-privilege caps (`CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETGID`, `SETUID`) |
+| `ghcr.io/haveagitgat/tdarr_node` | Same as tdarr | Same as tdarr |
+| `ghcr.io/paperless-ngx/paperless-ngx` | Upstream embeds s6-overlay, rootless alt has OCR limitations | Init container with `runAsUser: 0` + `CAP_CHOWN`/`DAC_OVERRIDE`/`FOWNER` for `/run` ownership |
+
 ## Destructive Operations (Require EXPLICIT Human Authorization)
 
 - **NEVER** run `terragrunt apply` or `tofu apply` without explicit human approval

--- a/kubernetes/clusters/live/charts/tdarr-node.yaml
+++ b/kubernetes/clusters/live/charts/tdarr-node.yaml
@@ -18,6 +18,10 @@ controllers:
         seccompProfile:
           type: RuntimeDefault
 
+    # s6-overlay (LinuxServer.io) requires root to run its init system,
+    # then drops to PUID/PGID via s6-applyuidgid. Capabilities needed:
+    # SETUID/SETGID for user switching, CHOWN/DAC_OVERRIDE/FOWNER for
+    # file ownership fixups during init.
     containers:
       app:
         image:
@@ -25,6 +29,8 @@ controllers:
           tag: "${tdarr_node_version}"
         env:
           TZ: UTC
+          PUID: "568"
+          PGID: "568"
           nodeName: gpu-worker
           serverURL: "http://tdarr-app.media.svc.cluster.local:8266"
           NVIDIA_DRIVER_CAPABILITIES: all
@@ -32,8 +38,12 @@ controllers:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
+          runAsNonRoot: false
+          runAsUser: 0
+          runAsGroup: 0
           capabilities:
             drop: [ALL]
+            add: [CHOWN, DAC_OVERRIDE, FOWNER, SETGID, SETUID]
         resources:
           requests:
             cpu: 500m
@@ -80,3 +90,9 @@ persistence:
       tdarr-node:
         app:
           - path: /app/transcode_cache
+  run:
+    type: emptyDir
+    advancedMounts:
+      tdarr-node:
+        app:
+          - path: /run


### PR DESCRIPTION
## Summary
- tdarr-node needs the identical s6-overlay security pattern already proven working on tdarr server (PR #516): container-level `runAsUser: 0` with `PUID`/`PGID` env vars, least-privilege capabilities, and `/run` emptyDir
- Adds LSIO/s6-overlay image ban to CLAUDE.md with explicit exception table for apps where no rootless alternative exists

## Test plan
- [ ] Validation passes: `task k8s:validate`
- [ ] tdarr-node pod starts without s6-overlay errors
- [ ] tdarr-node connects to tdarr server