### PR TITLE
fix(k8s): disable s6 service timeout for tdarr-node encoder probes

### DIFF
--- a/kubernetes/clusters/live/charts/tdarr-node.yaml
+++ b/kubernetes/clusters/live/charts/tdarr-node.yaml
@@ -31,6 +31,8 @@ controllers:
           TZ: UTC
           PUID: "568"
           PGID: "568"
+          # s6-overlay default 5s timeout is too short — encoder probes take minutes
+          S6_CMD_WAIT_FOR_SERVICES_MAXTIME: "0"
           nodeName: gpu-worker
           serverURL: "http://tdarr.media.svc.cluster.local:8266"
           NVIDIA_DRIVER_CAPABILITIES: all


### PR DESCRIPTION
## Summary
- tdarr_node runs encoder probes for every FFmpeg codec at startup (~3 minutes), far exceeding s6-overlay's default 5-second service readiness timeout (`S6_CMD_WAIT_FOR_SERVICES_MAXTIME`)
- Setting to `0` (infinite) delegates timeout responsibility to Kubernetes startup probes where it belongs

## Test plan
- [ ] Validation passes: `task k8s:validate`
- [ ] tdarr-node starts without `s6-svwait: fatal: timed out`
- [ ] tdarr-node connects to tdarr server and registers