### PR TITLE
fix(k8s): add OIDC client secret replica to ai namespace

### DIFF
--- a/kubernetes/clusters/live/config/ai-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/ai-prereqs/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - open-webui-oidc-client-secret.yaml
+  - oidc-secret-replication.yaml
   - open-webui-db-credentials.yaml
   - dragonfly-secret-replication.yaml
   - network-policy.yaml

--- a/kubernetes/clusters/live/config/ai-prereqs/oidc-secret-replication.yaml
+++ b/kubernetes/clusters/live/config/ai-prereqs/oidc-secret-replication.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: open-webui-oidc-client-secret
+  namespace: ai
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: authelia/open-webui-oidc-client-secret
+data: { }


### PR DESCRIPTION
## Summary
- Open-webui pod (`open-webui-0`) is stuck in `CreateContainerConfigError` on live because it references `open-webui-oidc-client-secret` in the `ai` namespace, but only the source secret exists in `authelia`
- The source secret had replicator annotations allowing replication to `ai`, but no replica Secret existed to pull it across namespaces
- Adds the missing kubernetes-replicator replica following the same pattern as `dragonfly-secret-replication.yaml` and `open-webui-db-credentials.yaml`

## Test plan
- [x] `task k8s:validate` passes
- [ ] After merge, verify `open-webui-oidc-client-secret` appears in the `ai` namespace on live
- [ ] Verify `open-webui-0` pod transitions from `CreateContainerConfigError` to `Running`