### PR TITLE
fix(k8s): match db-credential replica secret types to source

### DIFF
--- a/kubernetes/clusters/live/config/ai-prereqs/open-webui-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/ai-prereqs/open-webui-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: ai
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/open-webui-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/authelia-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/authelia-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: authelia
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/authelia-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/lldap-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/lldap-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: authelia
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/lldap-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }

--- a/kubernetes/clusters/live/config/media-prereqs/db-credentials.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/db-credentials.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: media
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/sonarr-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }
 ---
 apiVersion: v1
@@ -16,7 +16,7 @@ metadata:
   namespace: media
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/radarr-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }
 ---
 apiVersion: v1
@@ -26,7 +26,7 @@ metadata:
   namespace: media
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/prowlarr-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }
 ---
 apiVersion: v1
@@ -36,7 +36,7 @@ metadata:
   namespace: media
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/bazarr-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }
 ---
 apiVersion: v1
@@ -46,5 +46,5 @@ metadata:
   namespace: media
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/jellyseerr-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }

--- a/kubernetes/clusters/live/config/paperless/paperless-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/paperless/paperless-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: paperless
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/paperless-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }

--- a/kubernetes/clusters/live/config/tandoor/tandoor-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/tandoor/tandoor-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: tandoor
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/tandoor-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }

--- a/kubernetes/clusters/live/config/vaultwarden/vaultwarden-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/vaultwarden/vaultwarden-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: vaultwarden
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/vaultwarden-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }

--- a/kubernetes/clusters/live/config/zipline/zipline-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/zipline/zipline-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: zipline
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/zipline-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }


### PR DESCRIPTION
## Summary
- Fix immutable Secret `type` field mismatch blocking Flux reconciliation on the live cluster
- All db-credential replica secrets declared `type: Opaque` but the replicator source secrets (CNPG role-passwords) use `type: kubernetes.io/basic-auth` -- Kubernetes rejects the type change since it is immutable
- Unblocks `cluster-config`, `authelia-prereqs`, and `ai-prereqs` Kustomizations plus fixes the same latent issue in 5 other app credential replicas (media, zipline, vaultwarden, tandoor)

## Test plan
- [x] `task k8s:validate` passes (0 invalid resources)
- [ ] Flux Kustomizations `cluster-config`, `authelia-prereqs`, `ai-prereqs` reconcile successfully on live after merge
- [ ] Existing secrets may need manual deletion on live if the old `type: Opaque` secrets already exist (Kubernetes cannot mutate the type field in-place)