### PR TITLE
fix(k8s): resolve homepage 500 by disabling file logging and adding writable logs dir

### DIFF
--- a/kubernetes/clusters/live/charts/homepage.yaml
+++ b/kubernetes/clusters/live/charts/homepage.yaml
@@ -29,6 +29,9 @@ controllers:
         env:
           # Required: homepage rejects requests not matching allowed hosts
           HOMEPAGE_ALLOWED_HOSTS: "home.${internal_domain}"
+          # Disable file logging to avoid writing to read-only ConfigMap mount
+          # https://github.com/gethomepage/homepage/discussions/5404
+          LOG_TARGETS: stdout
         resources:
           requests:
             cpu: 10m
@@ -121,3 +124,7 @@ persistence:
     name: homepage
     globalMounts:
       - path: /app/config
+  logs:
+    type: emptyDir
+    globalMounts:
+      - path: /app/config/logs


### PR DESCRIPTION
## Summary
- Homepage returns 500 errors because its entrypoint unconditionally runs `mkdir /app/config/logs/`, but `/app/config` is a read-only ConfigMap volume mount
- Set `LOG_TARGETS=stdout` to disable file logging and mount an `emptyDir` at `/app/config/logs` to satisfy the entrypoint's `mkdir` call
- Ref: https://github.com/gethomepage/homepage/discussions/5404

## Test plan
- [x] `task k8s:validate` passes
- [ ] After merge, verify homepage pod starts without CrashLoopBackOff on live
- [ ] Verify `https://home.internal.tomnowak.work/` returns 200