### PR TITLE
feat(k8s): establish Grafana dashboard folder taxonomy

### DIFF
--- a/kubernetes/platform/charts/grafana.yaml
+++ b/kubernetes/platform/charts/grafana.yaml
@@ -63,51 +63,64 @@ dashboardProviders:
   dashboardproviders.yaml:
     apiVersion: 1
     providers:
-      - name: default
+      - name: kubernetes
         orgId: 1
-        folder: ""
+        folder: Kubernetes
         type: file
         disableDeletion: false
         editable: true
         options:
-          path: /var/lib/grafana/dashboards/default
+          path: /var/lib/grafana/dashboards/kubernetes
+      - name: infrastructure
+        orgId: 1
+        folder: Infrastructure
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/infrastructure
+      - name: network
+        orgId: 1
+        folder: Network
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/network
+      - name: storage
+        orgId: 1
+        folder: Storage
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/storage
+      - name: hardware
+        orgId: 1
+        folder: Hardware
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/hardware
+      - name: applications
+        orgId: 1
+        folder: Applications
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/applications
+      - name: platform-services
+        orgId: 1
+        folder: Platform Services
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/platform-services
 dashboards:
-  default:
-    cert-manager:
-      # renovate: depName="Cert-manager-Kubernetes"
-      gnetId: 20842
-      revision: 3
-      datasource: Prometheus
-    cloudflared:
-      # renovate: depName="Cloudflare Tunnels (cloudflared)"
-      gnetId: 17457
-      revision: 6
-      datasource:
-        - { name: DS_PROMETHEUS, value: Prometheus }
-    external-dns:
-      # renovate: depName="External-dns"
-      gnetId: 15038
-      revision: 3
-      datasource: Prometheus
-    external-secrets:
-      url: https://raw.githubusercontent.com/external-secrets/external-secrets/main/docs/snippets/dashboard.json
-      datasource: Prometheus
-    flux-cluster:
-      url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/cluster.json
-      datasource: Prometheus
-    flux-control-plane:
-      url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/control-plane.json
-      datasource: Prometheus
-    kubernetes-api-server:
-      # renovate: depName="Kubernetes / System / API Server"
-      gnetId: 15761
-      revision: 18
-      datasource: Prometheus
-    kubernetes-coredns:
-      # renovate: depName="Kubernetes / System / CoreDNS"
-      gnetId: 15762
-      revision: 19
-      datasource: Prometheus
+  kubernetes:
     kubernetes-global:
       # renovate: depName="Kubernetes / Views / Global"
       gnetId: 15757
@@ -128,31 +141,38 @@ dashboards:
       gnetId: 15760
       revision: 34
       datasource: Prometheus
-    kubernetes-volumes:
-      # renovate: depName="K8s / Storage / Volumes / Cluster"
-      gnetId: 11454
-      revision: 14
+    kubernetes-api-server:
+      # renovate: depName="Kubernetes / System / API Server"
+      gnetId: 15761
+      revision: 18
       datasource: Prometheus
-    miniflux:
-      url: https://raw.githubusercontent.com/miniflux/v2/main/contrib/grafana/dashboard.json
+    kubernetes-coredns:
+      # renovate: depName="Kubernetes / System / CoreDNS"
+      gnetId: 15762
+      revision: 19
       datasource: Prometheus
+  infrastructure:
     node-exporter-full:
       # renovate: depName="Node Exporter Full"
       gnetId: 1860
       revision: 37
-      datasource: Prometheus
-    node-feature-discovery:
-      url: https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/examples/grafana-dashboard.json
       datasource: Prometheus
     prometheus:
       # renovate: depName="Prometheus"
       gnetId: 19105
       revision: 6
       datasource: Prometheus
-    smartctl-exporter:
-      # renovate: depName="SMARTctl Exporter Dashboard"
-      gnetId: 22604
-      revision: 2
+    flux-cluster:
+      url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/cluster.json
+      datasource: Prometheus
+    flux-control-plane:
+      url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/control-plane.json
+      datasource: Prometheus
+  network:
+    cloudflared:
+      # renovate: depName="Cloudflare Tunnels (cloudflared)"
+      gnetId: 17457
+      revision: 6
       datasource:
         - { name: DS_PROMETHEUS, value: Prometheus }
     unifi-insights:
@@ -175,6 +195,26 @@ dashboards:
       gnetId: 11312
       revision: 9
       datasource: Prometheus
+  storage:
+    kubernetes-volumes:
+      # renovate: depName="K8s / Storage / Volumes / Cluster"
+      gnetId: 11454
+      revision: 14
+      datasource: Prometheus
+  hardware:
+    smartctl-exporter:
+      # renovate: depName="SMARTctl Exporter Dashboard"
+      gnetId: 22604
+      revision: 2
+      datasource:
+        - { name: DS_PROMETHEUS, value: Prometheus }
+    node-feature-discovery:
+      url: https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/examples/grafana-dashboard.json
+      datasource: Prometheus
+  applications:
+    miniflux:
+      url: https://raw.githubusercontent.com/miniflux/v2/main/contrib/grafana/dashboard.json
+      datasource: Prometheus
     exportarr:
       url: https://raw.githubusercontent.com/onedr0p/exportarr/master/examples/grafana/dashboard2.json
       datasource: Prometheus
@@ -182,7 +222,21 @@ dashboards:
       # renovate: depName="Unpackerr"
       gnetId: 18817
       revision: 1
-      datasource.yaml:
+      datasource: Prometheus
+  platform-services:
+    cert-manager:
+      # renovate: depName="Cert-manager-Kubernetes"
+      gnetId: 20842
+      revision: 3
+      datasource: Prometheus
+    external-dns:
+      # renovate: depName="External-dns"
+      gnetId: 15038
+      revision: 3
+      datasource: Prometheus
+    external-secrets:
+      url: https://raw.githubusercontent.com/external-secrets/external-secrets/main/docs/snippets/dashboard.json
+      datasource: Prometheus
 sidecar:
   dashboards:
     enabled: true


### PR DESCRIPTION
## Summary
- Organize all Grafana dashboards into semantically meaningful folders (Kubernetes, Infrastructure, Network, Storage, Hardware, Applications, Platform Services) so the sidebar is navigable instead of a flat list in the General folder
- Fix a typo in the unpackerr dashboard where `datasource.yaml:` should have been `datasource: Prometheus`

**Note on kube-prometheus-stack built-in dashboards**: The dashboards deployed via `forceDeployDashboards: true` (etcd, scheduler, controller-manager, kubelet, etc.) are ConfigMaps generated by the kube-prometheus-stack chart. These ConfigMaps do not include a `grafana_folder` annotation and will remain in the General folder. Organizing these would require upstream support for per-dashboard folder annotations in the kube-prometheus-stack chart, which is not currently available. This can be addressed in a follow-up if desired.

Closes #523

## Test plan
- [x] `task k8s:validate` passes (YAML lint, ResourceSet expansion, Helm templating, kubeconform schema validation)
- [ ] After merge and promotion, verify in Grafana UI that dashboards appear in their assigned folders
- [ ] Verify Cilium dashboards remain in Network folder (sidecar `grafana_folder` annotation unchanged)
- [ ] Verify backup-health dashboard remains in Backup folder (ConfigMap annotation unchanged)
- [ ] Verify jellyfin dashboard remains in Media folder (ConfigMap annotation unchanged)