### PR TITLE
fix(k8s): unblock Flux reconciliation to restore CNPG WAL archiving

### DIFF
--- a/kubernetes/clusters/live/config/ai-prereqs/open-webui-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/ai-prereqs/open-webui-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: ai
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/open-webui-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/authelia-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/authelia-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: authelia
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/authelia-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/lldap-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/lldap-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: authelia
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/lldap-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }

--- a/kubernetes/clusters/live/config/paperless/paperless-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/paperless/paperless-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: paperless
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/paperless-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }

--- a/kubernetes/clusters/live/config/tandoor/tandoor-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/tandoor/tandoor-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: tandoor
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/tandoor-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }

--- a/kubernetes/clusters/live/config/vaultwarden/vaultwarden-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/vaultwarden/vaultwarden-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: vaultwarden
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/vaultwarden-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }

--- a/kubernetes/clusters/live/config/zipline/zipline-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/zipline/zipline-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: zipline
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/zipline-role-password
-type: Opaque
+type: kubernetes.io/basic-auth
 data: { }


### PR DESCRIPTION
## Summary
- Fix Secret type mismatch (`Opaque` vs `kubernetes.io/basic-auth`) in 7 db-credentials replica secrets that was blocking 3 Flux Kustomizations (`cluster-config`, `authelia-prereqs`, `ai-prereqs`)
- The kubernetes-replicator changed the type of these secrets on the live cluster to match the source `basic-auth` type, making the `Opaque` manifests irreconcilable since Secret type is immutable
- Unblocking reconciliation allows the previously-committed immich-database `AWS_DEFAULT_REGION=garage` env fix (e8e90a8b) to be applied, resolving the WAL archiving HTTP 400 HeadBucket failure

## Test plan
- [x] Validated with `task k8s:validate` -- zero errors
- [ ] After merge, verify `cluster-config` Kustomization reaches `Ready: True`
- [ ] Verify `authelia-prereqs` and `ai-prereqs` Kustomizations reach `Ready: True`
- [ ] Verify `immich-database` CNPG cluster `ContinuousArchiving` condition becomes `True`
- [ ] Verify WAL files start archiving to `s3://cnpg-immich-backups/`