### PR TITLE
feat(k8s): add Istio mesh and Gateway API observability dashboards

### DIFF
--- a/kubernetes/platform/charts/grafana.yaml
+++ b/kubernetes/platform/charts/grafana.yaml
@@ -175,6 +175,27 @@ dashboards:
       revision: 6
       datasource:
         - { name: DS_PROMETHEUS, value: Prometheus }
+    istio-mesh:
+      url: https://raw.githubusercontent.com/istio/istio/master/manifests/addons/dashboards/istio-mesh-dashboard.gen.json
+      datasource: Prometheus
+    istio-service:
+      url: https://raw.githubusercontent.com/istio/istio/master/manifests/addons/dashboards/istio-service-dashboard.json
+      datasource: Prometheus
+    istio-workload:
+      url: https://raw.githubusercontent.com/istio/istio/master/manifests/addons/dashboards/istio-workload-dashboard.json
+      datasource: Prometheus
+    istio-control-plane:
+      url: https://raw.githubusercontent.com/istio/istio/master/manifests/addons/dashboards/pilot-dashboard.gen.json
+      datasource: Prometheus
+    istio-performance:
+      url: https://raw.githubusercontent.com/istio/istio/master/manifests/addons/dashboards/istio-performance-dashboard.json
+      datasource: Prometheus
+    istio-ztunnel:
+      url: https://raw.githubusercontent.com/istio/istio/master/manifests/addons/dashboards/ztunnel-dashboard.gen.json
+      datasource: Prometheus
+    istio-wasm-extensions:
+      url: https://raw.githubusercontent.com/istio/istio/master/manifests/addons/dashboards/istio-extension-dashboard.json
+      datasource: Prometheus
     unifi-insights:
       # renovate: depName="UniFi-Poller: Client Insights - Prometheus"
       gnetId: 11315


### PR DESCRIPTION
## Summary
- Add 7 Istio official dashboards to the Grafana Network folder for mesh, service, workload, control plane, performance, ztunnel, and wasm extension observability
- Ztunnel dashboard is especially relevant for ambient mode L4 proxy visibility, and the wasm extension dashboard provides Coraza WAF operational insights
- Envoy Gateway Overview (gnetId 24460) was intentionally skipped because it targets standalone Envoy Gateway, not Istio's gateway implementation

## Notes
- Some service/workload dashboards may show partial data in ambient mode since L7 metrics require waypoint proxies

## Test plan
- [x] Validated with `task k8s:validate`
- [ ] Verify dashboards load in Grafana under the Network folder after promotion
- [ ] Confirm Istio mesh dashboard shows topology and traffic flow data
- [ ] Confirm ztunnel dashboard reflects ambient mode L4 connections

Closes #525