### PR TITLE
fix(k8s): remove v prefix from recyclarr image version

### DIFF
--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -106,7 +106,7 @@ seerr_version=v3.0.1
 # renovate: datasource=docker depName=tandoor packageName=ghcr.io/tandoorrecipes/recipes versioning=loose
 tandoor_version=2.5.3
 # renovate: datasource=docker depName=recyclarr packageName=ghcr.io/recyclarr/recyclarr
-recyclarr_version=v8.2.1
+recyclarr_version=8.3.2
 # renovate: datasource=docker depName=bazarr packageName=ghcr.io/home-operations/bazarr
 bazarr_version=1.5.5
 # renovate: datasource=docker depName=paperless-ngx packageName=ghcr.io/paperless-ngx/paperless-ngx


### PR DESCRIPTION
## Summary
- `ghcr.io/recyclarr/recyclarr` publishes tags without a `v` prefix, so the previous `v8.2.1` tag did not exist on GHCR
- Drops the incorrect `v` prefix and bumps to `8.3.2` (latest), aligning the version format so Renovate can track future updates correctly

## Test plan
- [x] Validated with `task k8s:validate` (all checks pass)
- [ ] Integration cluster deploys recyclarr cronjob with valid image tag