### PR TITLE
fix(k8s): add ai namespace to dragonfly-password replication allowlist

### DIFF
--- a/kubernetes/platform/config/dragonfly/password-secret.yaml
+++ b/kubernetes/platform/config/dragonfly/password-secret.yaml
@@ -8,6 +8,6 @@ metadata:
     secret-generator.v1.mittwald.de/length: "32"
     secret-generator.v1.mittwald.de/encoding: base64
     replicator.v1.mittwald.de/replication-allowed: "true"
-    replicator.v1.mittwald.de/replication-allowed-namespaces: "immich,authelia,paperless"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "ai,immich,authelia,paperless"
 type: Opaque
 data: { }


### PR DESCRIPTION
## Summary
- The `ai` namespace needs the `dragonfly-password` secret for open-webui websocket state, but the source secret's replication annotation did not include `ai` in its allowed namespaces

## Test plan
- [x] Validated with `task k8s:validate`
- [ ] After merge, verify the `dragonfly-password` secret is populated in the `ai` namespace