### PR TITLE
fix(k8s): point open-webui REDIS_URL to shared Dragonfly instance

### DIFF
--- a/kubernetes/clusters/live/charts/open-webui.yaml
+++ b/kubernetes/clusters/live/charts/open-webui.yaml
@@ -34,6 +34,8 @@ extraEnvVars:
       secretKeyRef:
         name: dragonfly-password
         key: password
+  - name: REDIS_URL
+    value: "redis://:$(DRAGONFLY_PASS)@dragonfly.cache.svc.cluster.local:6379/0"
   - name: WEBSOCKET_REDIS_URL
     value: "redis://:$(DRAGONFLY_PASS)@dragonfly.cache.svc.cluster.local:6379/1"
   - name: WEBUI_URL


### PR DESCRIPTION
## Summary
- Open WebUI pod crash-loops because `REDIS_URL` points to a nonexistent `open-webui-redis` service in the `ai` namespace
- Override the chart-generated `REDIS_URL` to use the shared Dragonfly instance at `dragonfly.cache.svc.cluster.local:6379/0`, matching the existing `WEBSOCKET_REDIS_URL` pattern

## Test plan
- [ ] PR validation passes
- [ ] After promotion to live, verify `open-webui-0` pod starts successfully
- [ ] Confirm `KubePodCrashLooping`, `KubeStatefulSetReplicasMismatch`, and `KubeStatefulSetUpdateNotRolledOut` alerts resolve