### PR TITLE
feat(k8s): split per-cluster application versions from platform versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,7 +38,7 @@
     // ============================================================
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^kubernetes/platform/versions\\.env$/"],
+      "managerFilePatterns": ["/^kubernetes/(platform|clusters/[^/]+)/versions\\.env$/"],
       "matchStringsStrategy": "any",
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)(?:\\s+packageName=(?<packageName>[^\\s]+))?(?:\\s+extractVersion=(?<extractVersion>[^\\s]+))?(?:\\s+registryUrl=(?<registryUrl>[^\\s]+))?(?:\\s+versioning=(?<versioning>[^\\s]+))?\\n[A-Za-z_]+=(?<currentValue>.+)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -482,23 +482,34 @@ mise doctor              # Diagnose environment issues
 
 ## Platform Version Management
 
-`kubernetes/platform/versions.env` is the **single source of truth** for all platform versions:
+Versions are split across two tiers:
 
+- **`kubernetes/platform/versions.env`** -- platform-wide versions shared by all clusters (infrastructure, platform Helm charts, shared container images)
+- **`kubernetes/clusters/<cluster>/versions.env`** -- per-cluster application versions (cluster-specific Helm charts and container image tags)
+
+**Platform versions** (`kubernetes/platform/versions.env`):
 - **Infrastructure versions**: Talos, Kubernetes, Cilium (read by Terragrunt)
-- **Helm chart versions**: All charts deployed via Flux (substituted at reconciliation)
+- **Platform Helm chart versions**: Charts deployed via platform ResourceSet (substituted at reconciliation)
 - **Upgrade operations**: Tuppr reads versions for declarative upgrades
-- **Dependency updates**: Renovate manages version bumps
+- **Shared versions**: `app_template_version` and other versions used by both platform and cluster
 
-See [kubernetes/platform/CLAUDE.md](kubernetes/platform/CLAUDE.md) for detailed version management patterns.
+**Cluster versions** (`kubernetes/clusters/<cluster>/versions.env`):
+- **Cluster-specific Helm chart versions**: Charts in the cluster's ResourceSet (e.g., `immich_version`, `authelia_version`)
+- **Container image tags**: App-specific image tags referenced in cluster chart values
+
+**Dependency updates**: Renovate manages version bumps in both files via inline `# renovate:` annotations.
+
+See [kubernetes/platform/CLAUDE.md](kubernetes/platform/CLAUDE.md) and [kubernetes/clusters/CLAUDE.md](kubernetes/clusters/CLAUDE.md) for detailed patterns.
 
 ### Data Flow
 
 ```mermaid
 flowchart LR
-    V["kubernetes/platform/versions.env"] --> S["infrastructure/stacks/*\n(Terragrunt reads versions)"]
+    PV["kubernetes/platform/versions.env"] --> S["infrastructure/stacks/*\n(Terragrunt reads versions)"]
     S --> G["generates .cluster-vars.env\nper cluster"]
     G --> C["kubernetes/clusters/‹cluster›/\n.cluster-vars.env"]
-    V --> F["kubernetes/platform/\n(Flux substitutes versions)"]
+    PV --> F["kubernetes/platform/\n(Flux substitutes platform versions)"]
+    CV["kubernetes/clusters/‹cluster›/versions.env"] --> CK["kubernetes/clusters/‹cluster›/\n(Flux substitutes cluster versions)"]
 ```
 
 ---

--- a/kubernetes/clusters/CLAUDE.md
+++ b/kubernetes/clusters/CLAUDE.md
@@ -14,6 +14,7 @@ clusters/<cluster-name>/
 ├── platform.yaml           # References the centralized platform definition
 ├── config.yaml             # Cluster-specific config Kustomization
 ├── helm-charts.yaml        # Flux Kustomization wrapper for cluster-specific Helm releases
+├── versions.env            # Cluster-specific application versions (Renovate-managed)
 ├── resourcesets/            # Cluster-specific ResourceSets (applied with version substitution)
 │   └── helm-charts.yaml    # ResourceSet defining cluster-specific Helm releases
 ├── config/                 # Cluster-specific resources (Silences, PrometheusRules, etc.)
@@ -34,6 +35,7 @@ clusters/<cluster-name>/
 | `platform.yaml` | Kustomization referencing platform source (GitRepository for dev, OCIRepository for others) | Static (git) |
 | `config.yaml` | Kustomization for cluster-specific config resources | Static (git) |
 | `helm-charts.yaml` | Flux Kustomization that applies `resourcesets/` with version substitution | Static (git) |
+| `versions.env` | Cluster-specific app versions (deployed as `cluster-versions` ConfigMap) | Static (git) |
 | `resourcesets/helm-charts.yaml` | ResourceSet for cluster-specific Helm releases | Static (git) |
 | `.cluster-vars.env` | Cluster identity variables (`cluster_name`, `source_kind`, etc.) | Terragrunt |
 
@@ -72,7 +74,7 @@ spec:
 
 ### Helm Releases (`resourcesets/helm-charts.yaml`)
 
-Cluster-specific Helm releases via ResourceSet (mirrors platform pattern). The ResourceSet is wrapped in a Flux Kustomization (`helm-charts.yaml`) that provides `platform-versions` variable substitution, enabling chart versions to reference `versions.env` variables:
+Cluster-specific Helm releases via ResourceSet (mirrors platform pattern). The ResourceSet is wrapped in a Flux Kustomization (`helm-charts.yaml`) that provides variable substitution from both `platform-versions` and `cluster-versions` ConfigMaps:
 
 ```yaml
 # Add entry to resourcesets/helm-charts.yaml inputs array
@@ -81,21 +83,22 @@ inputs:
     namespace: "my-namespace"
     chart:
       name: "app-template"
-      version: "${app_template_version}"  # From versions.env via platform-versions ConfigMap
+      version: "${app_template_version}"  # From platform-versions (shared)
       url: "oci://ghcr.io/bjw-s/helm"
     dependsOn: [kube-prometheus-stack]  # Can depend on platform releases
 ```
 
 **Adding a cluster-specific Helm release:**
-1. Add entry to `resourcesets/helm-charts.yaml` inputs array
-2. Create `charts/<release-name>.yaml` with Helm values
-3. Update `kustomization.yaml` configMapGenerator to include the values file:
+1. Add version to `versions.env` with Renovate annotation (for cluster-specific chart/image versions)
+2. Add entry to `resourcesets/helm-charts.yaml` inputs array
+3. Create `charts/<release-name>.yaml` with Helm values
+4. Update `kustomization.yaml` configMapGenerator to include the values file:
    ```yaml
    - name: cluster-values
      files:
        - my-app.yaml=charts/my-app.yaml
    ```
-4. Use `${version_var}` (no defaults) for chart versions — variables come from `platform-versions` ConfigMap
+5. Use `${version_var}` for chart versions -- platform-shared versions come from `platform-versions`, cluster-specific versions come from `cluster-versions`
 
 ### Dependency Model
 
@@ -124,11 +127,26 @@ source_kind=GitRepository
 
 These variables are injected into the `cluster-vars` ConfigMap and used throughout the platform via `${variable_name}` substitution.
 
+### Per-Cluster Versions
+
+The `versions.env` file in each cluster provides cluster-specific application versions, deployed as the `cluster-versions` ConfigMap. This separates cluster-specific app versions from platform-wide versions:
+
+```env
+# kubernetes/clusters/live/versions.env
+# renovate: datasource=helm depName=immich registryUrl=https://immich-app.github.io/immich-charts
+immich_version=0.10.3
+# renovate: datasource=docker depName=sonarr packageName=ghcr.io/home-operations/sonarr
+sonarr_version=4.0.16.2946
+```
+
+**Variable substitution priority**: Flux applies `platform-versions` first, then `cluster-versions`. If the same key exists in both, the cluster version wins (later ConfigMap in `substituteFrom` takes priority).
+
 ### When to Modify
 
 - **Platform configuration** (shared across clusters): Edit files in `kubernetes/platform/`
 - **Cluster-specific resources**: Add to `config/` directory
 - **Cluster-specific Helm releases**: Add to `helm-charts.yaml` and `charts/`
+- **Cluster-specific app versions**: Edit `versions.env` in the cluster directory
 - **Cluster variables**: Regenerate via Terragrunt (don't edit `.cluster-vars.env` manually)
 
 ---

--- a/kubernetes/clusters/dev/kustomization.yaml
+++ b/kubernetes/clusters/dev/kustomization.yaml
@@ -14,6 +14,13 @@ configMapGenerator:
     behavior: create
     envs:
       - .cluster-vars.env
+  - name: cluster-versions
+    options:
+      disableNameSuffixHash: true
+    namespace: flux-system
+    behavior: create
+    envs:
+      - versions.env
   - name: cluster-values
     options:
       disableNameSuffixHash: true

--- a/kubernetes/clusters/dev/versions.env
+++ b/kubernetes/clusters/dev/versions.env
@@ -1,0 +1,5 @@
+# Per-cluster application versions for the dev cluster
+# - Cluster-specific app versions go here (not in kubernetes/platform/versions.env)
+# - Platform-shared versions (app_template, talos, etc.) remain in kubernetes/platform/versions.env
+# - Renovate updates this file (via inline comment annotations)
+# - Currently empty — dev has no cluster-specific releases

--- a/kubernetes/clusters/integration/kustomization.yaml
+++ b/kubernetes/clusters/integration/kustomization.yaml
@@ -14,6 +14,13 @@ configMapGenerator:
     behavior: create
     envs:
       - .cluster-vars.env
+  - name: cluster-versions
+    options:
+      disableNameSuffixHash: true
+    namespace: flux-system
+    behavior: create
+    envs:
+      - versions.env
   - name: cluster-values
     options:
       disableNameSuffixHash: true

--- a/kubernetes/clusters/integration/versions.env
+++ b/kubernetes/clusters/integration/versions.env
@@ -1,0 +1,5 @@
+# Per-cluster application versions for the integration cluster
+# - Cluster-specific app versions go here (not in kubernetes/platform/versions.env)
+# - Platform-shared versions (app_template, talos, etc.) remain in kubernetes/platform/versions.env
+# - Renovate updates this file (via inline comment annotations)
+# - Currently empty — integration has no cluster-specific releases

--- a/kubernetes/clusters/live/chart-values.yaml
+++ b/kubernetes/clusters/live/chart-values.yaml
@@ -15,6 +15,9 @@ spec:
       - kind: ConfigMap
         name: platform-versions
         optional: false
+      - kind: ConfigMap
+        name: cluster-versions
+        optional: false
   prune: true
   sourceRef:
     kind: OCIRepository

--- a/kubernetes/clusters/live/config.yaml
+++ b/kubernetes/clusters/live/config.yaml
@@ -17,6 +17,9 @@ spec:
       - kind: ConfigMap
         name: platform-versions
         optional: true
+      - kind: ConfigMap
+        name: cluster-versions
+        optional: true
   prune: true
   sourceRef:
     kind: OCIRepository

--- a/kubernetes/clusters/live/helm-charts.yaml
+++ b/kubernetes/clusters/live/helm-charts.yaml
@@ -18,6 +18,9 @@ spec:
       - kind: ConfigMap
         name: platform-versions
         optional: false
+      - kind: ConfigMap
+        name: cluster-versions
+        optional: false
   prune: true
   sourceRef:
     kind: OCIRepository

--- a/kubernetes/clusters/live/kustomization.yaml
+++ b/kubernetes/clusters/live/kustomization.yaml
@@ -16,3 +16,10 @@ configMapGenerator:
     envs:
       - .cluster-vars.env
       - cluster-apps.env
+  - name: cluster-versions
+    options:
+      disableNameSuffixHash: true
+    namespace: flux-system
+    behavior: create
+    envs:
+      - versions.env

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -1,0 +1,73 @@
+# Per-cluster application versions for the live cluster
+# - Flux substitutes into cluster resourcesets/helm-charts.yaml and charts/
+# - Renovate updates this file (via inline comment annotations)
+# - Platform-shared versions (app_template, talos, etc.) remain in kubernetes/platform/versions.env
+
+# Helm chart versions (cluster-specific releases)
+# renovate: datasource=helm depName=immich registryUrl=https://immich-app.github.io/immich-charts
+immich_version=0.10.3
+# renovate: datasource=helm depName=authelia registryUrl=https://charts.authelia.com
+authelia_version=0.10.49
+# renovate: datasource=helm depName=open-webui registryUrl=https://helm.openwebui.com
+open_webui_version=12.5.0
+
+# Container image versions (Flux substitution into chart values)
+# renovate: datasource=docker depName=ghcr.io/immich-app/immich-machine-learning versioning=regex:^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-cuda$
+immich_ml_cuda_tag=v2.5.5-cuda
+# renovate: datasource=docker depName=cloudnative-vectorchord packageName=ghcr.io/tensorchord/cloudnative-vectorchord versioning=loose
+vectorchord_version=18.1-1.0.0
+# renovate: datasource=docker depName=lldap packageName=ghcr.io/lldap/lldap
+lldap_version=v0.6.2
+# renovate: datasource=docker depName=satisfactory-server packageName=wolveix/satisfactory-server
+satisfactory_server_version=v1.9.10
+# renovate: datasource=docker depName=netbootxyz packageName=netbootxyz/netbootxyz
+netbootxyz_version=0.7.6-nbxyz10
+# renovate: datasource=docker depName=qbittorrent packageName=ghcr.io/home-operations/qbittorrent
+qbittorrent_version=5.1.4
+# renovate: datasource=docker depName=prowlarr packageName=ghcr.io/home-operations/prowlarr
+prowlarr_version=2.3.2.5245
+# renovate: datasource=docker depName=sonarr packageName=ghcr.io/home-operations/sonarr
+sonarr_version=4.0.16.2946
+# renovate: datasource=docker depName=radarr packageName=ghcr.io/home-operations/radarr
+radarr_version=6.1.1.10317
+# renovate: datasource=docker depName=jellyfin packageName=jellyfin/jellyfin
+jellyfin_version=10.11.6
+# renovate: datasource=docker depName=jellyfin-exporter packageName=rebelcore/jellyfin-exporter
+jellyfin_exporter_version=v1.4.0
+# renovate: datasource=docker depName=tdarr packageName=ghcr.io/haveagitgat/tdarr
+tdarr_version=2.58.02
+# renovate: datasource=docker depName=tdarr-node packageName=ghcr.io/haveagitgat/tdarr_node
+tdarr_node_version=2.58.02
+# renovate: datasource=docker depName=seerr packageName=ghcr.io/seerr-team/seerr
+seerr_version=v3.0.1
+# renovate: datasource=docker depName=tandoor packageName=ghcr.io/tandoorrecipes/recipes versioning=loose
+tandoor_version=2.5.3
+# renovate: datasource=docker depName=recyclarr packageName=ghcr.io/recyclarr/recyclarr
+recyclarr_version=8.3.2
+# renovate: datasource=docker depName=bazarr packageName=ghcr.io/home-operations/bazarr
+bazarr_version=1.5.5
+# renovate: datasource=docker depName=paperless-ngx packageName=ghcr.io/paperless-ngx/paperless-ngx
+paperless_ngx_version=2.20.8
+# renovate: datasource=docker depName=vaultwarden packageName=vaultwarden/server
+vaultwarden_version=1.35.4-alpine
+# renovate: datasource=docker depName=homepage packageName=ghcr.io/gethomepage/homepage
+homepage_version=v1.10.1
+# renovate: datasource=docker depName=ollama packageName=ollama/ollama
+ollama_version=0.17.4
+# renovate: datasource=docker depName=exportarr packageName=ghcr.io/onedr0p/exportarr
+exportarr_version=v2.3.0
+# renovate: datasource=docker depName=gluetun packageName=ghcr.io/qdm12/gluetun
+gluetun_version=v3.40.0
+
+# Minecraft versions
+# renovate: datasource=docker depName=minecraft-server packageName=itzg/minecraft-server
+minecraft_server_version=2026.2.1
+# renovate: datasource=docker depName=mc-backup packageName=itzg/mc-backup
+minecraft_backup_version=2026.2.2
+# Minecraft game version (manual updates — no Renovate datasource)
+minecraft_game_version=1.21.4
+
+# Talos Image Factory schematic ID for PXE boot (iscsi-tools + util-linux-tools)
+# Content-addressed hash — only changes when extensions change, not on version bumps
+# Regenerate: POST https://factory.talos.dev/schematics with extensions YAML
+talos_pxe_schematic_id=613e1592b2da41ae5e265e8789429f22e121aab91cb4deb6bc3c0b6262961245

--- a/kubernetes/platform/CLAUDE.md
+++ b/kubernetes/platform/CLAUDE.md
@@ -244,30 +244,51 @@ cluster: ${cluster_name}
 
 ## Version Management
 
-The `versions.env` file is the **single source of truth** for ALL platform versions. This enables:
+Versions are split across two tiers:
+
+- **`kubernetes/platform/versions.env`** (this directory) -- platform-wide versions shared by all clusters
+- **`kubernetes/clusters/<cluster>/versions.env`** -- per-cluster application versions
+
+### Platform versions.env
+
+This file is the **single source of truth** for platform-wide versions:
 
 - **Terragrunt** reads infrastructure versions for bootstrap (talos, kubernetes, cilium, flux)
 - **Flux** deploys as `platform-versions` ConfigMap and substitutes into helm-charts.yaml
 - **Tuppr** reads Talos/Kubernetes versions for in-cluster upgrades
-- **Renovate** updates ONE file - changes flow through the promotion pipeline
+- **Shared versions** like `app_template_version` used by both platform and cluster releases
 
-### versions.env Structure
+### Per-Cluster versions.env
+
+Each cluster has its own `versions.env` deployed as a `cluster-versions` ConfigMap:
+
+- **Cluster-specific Helm chart versions**: `immich_version`, `authelia_version`, `open_webui_version`
+- **Container image tags**: App-specific image tags referenced in cluster chart values
+- **Renovate** manages both files using the same inline annotation pattern
+
+### Which file for a new version?
+
+| Version used by | File |
+|-----------------|------|
+| Platform `helm-charts.yaml` | `kubernetes/platform/versions.env` |
+| Cluster `resourcesets/helm-charts.yaml` | `kubernetes/clusters/<cluster>/versions.env` |
+| Both platform and cluster | `kubernetes/platform/versions.env` |
+| Infrastructure (Terragrunt, Tuppr) | `kubernetes/platform/versions.env` |
+
+### versions.env Annotation Structure
 
 Each version entry has a `# renovate:` annotation comment on the line above. Renovate's generic regex manager reads these annotations to determine how to update each version.
 
 ```env
 # Infrastructure versions (Terragrunt + Tuppr)
 # renovate: datasource=github-releases depName=talos packageName=siderolabs/talos
-talos_version=v1.12.2
-# renovate: datasource=github-tags depName=kubernetes packageName=kubernetes/kubernetes extractVersion=^v(?<version>.*)$
-kubernetes_version=1.35.0
+talos_version=v1.12.4
 
 # Helm chart versions (Flux substitution)
 # renovate: datasource=helm depName=grafana registryUrl=https://grafana.github.io/helm-charts
 grafana_version=10.5.15
-# renovate: datasource=docker depName=app-template packageName=ghcr.io/bjw-s/helm/app-template
-app_template_version=3.7.3
-# ... all chart versions with annotations
+# renovate: datasource=docker depName=app-template packageName=ghcr.io/bjw-s-labs/helm/app-template
+app_template_version=4.6.2
 ```
 
 ### Natural Convergence
@@ -282,19 +303,20 @@ sequenceDiagram
     participant Node
     participant TG as Terragrunt
 
-    PR->>Flux: Merge updates talos_version=v1.12.2
+    PR->>Flux: Merge updates talos_version=v1.12.4
     Flux->>Flux: Syncs new ConfigMap to cluster
-    Tuppr->>Node: Sees mismatch → executes upgrade to v1.12.2
-    Note over Node: Now at v1.12.2
-    TG->>PR: Reads versions.env → v1.12.2
-    TG->>Node: Sees node already at v1.12.2 → NO-OP
+    Tuppr->>Node: Sees mismatch → executes upgrade to v1.12.4
+    Note over Node: Now at v1.12.4
+    TG->>PR: Reads versions.env → v1.12.4
+    TG->>Node: Sees node already at v1.12.4 → NO-OP
 ```
 
 ### Adding/Updating Versions
 
-1. Edit `versions.env` with the new version
-2. If adding a new Helm chart, update `helm-charts.yaml` with `${new_chart_version}`
-3. Run `task k8s:validate` to verify substitution works
+1. Determine which file the version belongs in (platform vs cluster -- see table above)
+2. Edit the appropriate `versions.env` with the new version and Renovate annotation
+3. If adding a new Helm chart, update the corresponding `helm-charts.yaml` with `${new_chart_version}`
+4. Run `task k8s:validate` to verify substitution works
 
 ---
 

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -1,8 +1,9 @@
-# SINGLE SOURCE OF TRUTH for ALL platform versions
+# SINGLE SOURCE OF TRUTH for PLATFORM versions
 # - Terragrunt reads for infrastructure (talos, k8s, cilium bootstrap)
 # - Flux substitutes into helm-charts.yaml for chart versions
 # - Tuppr reads for upgrade execution
 # - Renovate updates this file (via inline comment annotations)
+# - Cluster-specific app versions live in kubernetes/clusters/<cluster>/versions.env
 
 # Infrastructure versions (Terragrunt + Tuppr)
 # renovate: datasource=github-releases depName=talos packageName=siderolabs/talos
@@ -69,59 +70,8 @@ prometheus_snmp_exporter_version=9.12.1
 prometheus_ipmi_exporter_version=0.8.0
 # renovate: datasource=helm depName=prometheus-smartctl-exporter registryUrl=https://prometheus-community.github.io/helm-charts
 prometheus_smartctl_exporter_version=0.16.0
-# renovate: datasource=helm depName=immich registryUrl=https://immich-app.github.io/immich-charts
-immich_version=0.10.3
-# renovate: datasource=docker depName=ghcr.io/immich-app/immich-machine-learning versioning=regex:^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-cuda$
-immich_ml_cuda_tag=v2.5.5-cuda
-# renovate: datasource=docker depName=cloudnative-vectorchord packageName=ghcr.io/tensorchord/cloudnative-vectorchord versioning=loose
-vectorchord_version=18.1-1.0.0
-# renovate: datasource=helm depName=authelia registryUrl=https://charts.authelia.com
-authelia_version=0.10.49
 # renovate: datasource=helm depName=oauth2-proxy registryUrl=https://oauth2-proxy.github.io/manifests
 oauth2_proxy_version=10.1.3
-# renovate: datasource=docker depName=lldap packageName=ghcr.io/lldap/lldap
-lldap_version=v0.6.2
-# renovate: datasource=docker depName=satisfactory-server packageName=wolveix/satisfactory-server
-satisfactory_server_version=v1.9.10
-# renovate: datasource=docker depName=netbootxyz packageName=netbootxyz/netbootxyz
-netbootxyz_version=0.7.6-nbxyz10
-# renovate: datasource=docker depName=qbittorrent packageName=ghcr.io/home-operations/qbittorrent
-qbittorrent_version=5.1.4
-# renovate: datasource=docker depName=prowlarr packageName=ghcr.io/home-operations/prowlarr
-prowlarr_version=2.3.2.5245
-# renovate: datasource=docker depName=sonarr packageName=ghcr.io/home-operations/sonarr
-sonarr_version=4.0.16.2946
-# renovate: datasource=docker depName=radarr packageName=ghcr.io/home-operations/radarr
-radarr_version=6.1.1.10317
-# renovate: datasource=docker depName=jellyfin packageName=jellyfin/jellyfin
-jellyfin_version=10.11.6
-# renovate: datasource=docker depName=jellyfin-exporter packageName=rebelcore/jellyfin-exporter
-jellyfin_exporter_version=v1.4.0
-# renovate: datasource=docker depName=tdarr packageName=ghcr.io/haveagitgat/tdarr
-tdarr_version=2.58.02
-# renovate: datasource=docker depName=tdarr-node packageName=ghcr.io/haveagitgat/tdarr_node
-tdarr_node_version=2.58.02
-# renovate: datasource=docker depName=seerr packageName=ghcr.io/seerr-team/seerr
-seerr_version=v3.0.1
-# renovate: datasource=docker depName=tandoor packageName=ghcr.io/tandoorrecipes/recipes versioning=loose
-tandoor_version=2.5.3
-# renovate: datasource=docker depName=recyclarr packageName=ghcr.io/recyclarr/recyclarr
-recyclarr_version=8.3.2
-# renovate: datasource=docker depName=bazarr packageName=ghcr.io/home-operations/bazarr
-bazarr_version=1.5.5
-# renovate: datasource=docker depName=paperless-ngx packageName=ghcr.io/paperless-ngx/paperless-ngx
-paperless_ngx_version=2.20.8
-# renovate: datasource=docker depName=vaultwarden packageName=vaultwarden/server
-vaultwarden_version=1.35.4-alpine
-# renovate: datasource=docker depName=homepage packageName=ghcr.io/gethomepage/homepage
-homepage_version=v1.10.1
-
-# renovate: datasource=docker depName=minecraft-server packageName=itzg/minecraft-server
-minecraft_server_version=2026.2.1
-# renovate: datasource=docker depName=mc-backup packageName=itzg/mc-backup
-minecraft_backup_version=2026.2.2
-# Minecraft game version (manual updates — no Renovate datasource)
-minecraft_game_version=1.21.4
 
 # GPU support (NVIDIA device plugin + DCGM metrics exporter)
 # renovate: datasource=helm depName=nvidia-device-plugin registryUrl=https://nvidia.github.io/k8s-device-plugin
@@ -129,22 +79,7 @@ nvidia_device_plugin_version=0.18.2
 # renovate: datasource=helm depName=dcgm-exporter registryUrl=https://nvidia.github.io/dcgm-exporter/helm-charts
 dcgm_exporter_version=4.8.1
 
-# AI stack
-# renovate: datasource=docker depName=ollama packageName=ollama/ollama
-ollama_version=0.17.4
-# renovate: datasource=helm depName=open-webui registryUrl=https://helm.openwebui.com
-open_webui_version=12.5.0
-
-# Talos Image Factory schematic ID for PXE boot (iscsi-tools + util-linux-tools)
-# Content-addressed hash — only changes when extensions change, not on version bumps
-# Regenerate: POST https://factory.talos.dev/schematics with extensions YAML
-talos_pxe_schematic_id=613e1592b2da41ae5e265e8789429f22e121aab91cb4deb6bc3c0b6262961245
-
-# Container image versions (Flux substitution into config CRs)
-# renovate: datasource=docker depName=exportarr packageName=ghcr.io/onedr0p/exportarr
-exportarr_version=v2.3.0
-# renovate: datasource=docker depName=gluetun packageName=ghcr.io/qdm12/gluetun
-gluetun_version=v3.40.0
+# Container image versions (Flux substitution into platform config CRs)
 # renovate: datasource=docker depName=garage packageName=dxflrs/garage
 garage_image_version=v2.2.0
 # renovate: datasource=docker depName=cloudnative-pg-postgresql packageName=ghcr.io/cloudnative-pg/postgresql versioning=loose


### PR DESCRIPTION
## Summary
- Cluster-specific app versions (~30 entries like immich, sonarr, jellyfin, minecraft) now live in `kubernetes/clusters/<cluster>/versions.env` instead of the monolithic `platform/versions.env`
- Each cluster gets a dedicated `cluster-versions` ConfigMap wired into Flux substitution, separating app version management from platform infrastructure versions
- Establishes the two-tier version model: platform-wide shared versions vs. per-cluster application versions

## Test plan
- [ ] `task k8s:validate` passes (yamllint, ResourceSet expansion, kubeconform, pluto)
- [ ] `task renovate:validate` passes (regex manager picks up per-cluster files)
- [ ] Integration cluster deploys cleanly (no unresolved `${var}` substitutions)
- [ ] Live cluster deploys cleanly with app versions from new `cluster-versions` ConfigMap
- [ ] Renovate dependency dashboard shows per-cluster versions tracked correctly