### PR TITLE
feat(k8s): switch HelmReleases to RetryOnFailure strategy

### DIFF
--- a/kubernetes/clusters/dev/helm-charts.yaml
+++ b/kubernetes/clusters/dev/helm-charts.yaml
@@ -51,8 +51,8 @@ spec:
             name: << inputs.name >>
       install:
         createNamespace: false
-        remediation:
-          retries: 3
+        strategy:
+          name: RetryOnFailure
         timeout: 10m
       interval: 10m
       maxHistory: 3
@@ -62,8 +62,8 @@ spec:
         keepHistory: false
       upgrade:
         crds: CreateReplace
-        remediation:
-          retries: 3
+        strategy:
+          name: RetryOnFailure
         timeout: 10m
       valuesFrom:
         - kind: ConfigMap

--- a/kubernetes/clusters/integration/helm-charts.yaml
+++ b/kubernetes/clusters/integration/helm-charts.yaml
@@ -51,8 +51,8 @@ spec:
             name: << inputs.name >>
       install:
         createNamespace: false
-        remediation:
-          retries: 3
+        strategy:
+          name: RetryOnFailure
         timeout: 10m
       interval: 10m
       maxHistory: 3
@@ -62,8 +62,8 @@ spec:
         keepHistory: false
       upgrade:
         crds: CreateReplace
-        remediation:
-          retries: 3
+        strategy:
+          name: RetryOnFailure
         timeout: 10m
       valuesFrom:
         - kind: ConfigMap

--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -247,8 +247,8 @@ spec:
             name: << inputs.name >>
       install:
         createNamespace: false
-        remediation:
-          retries: 3
+        strategy:
+          name: RetryOnFailure
         timeout: 10m
       interval: 10m
       maxHistory: 3
@@ -258,8 +258,8 @@ spec:
         keepHistory: false
       upgrade:
         crds: CreateReplace
-        remediation:
-          retries: 3
+        strategy:
+          name: RetryOnFailure
         timeout: 10m
       valuesFrom:
         - kind: ConfigMap

--- a/kubernetes/platform/config/monitoring/flux-alerts.yaml
+++ b/kubernetes/platform/config/monitoring/flux-alerts.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: flux-alerts
+  labels:
+    app.kubernetes.io/name: flux
+spec:
+  groups:
+    - name: flux.rules
+      rules:
+        - alert: FluxHelmReleaseFailing
+          expr: |
+            flux_resource_info{kind="HelmRelease", ready!="True", suspended!="True"} == 1
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "HelmRelease {{ $labels.name }} failing in {{ $labels.exported_namespace }}"
+            description: >-
+              HelmRelease {{ $labels.exported_namespace }}/{{ $labels.name }} has been in a non-ready
+              state for more than 30 minutes (reason: {{ $labels.reason }}). With RetryOnFailure strategy,
+              the release will keep retrying but this indicates a persistent issue that needs investigation.
+
+        - alert: FluxKustomizationFailing
+          expr: |
+            flux_resource_info{kind="Kustomization", ready!="True", suspended!="True"} == 1
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Kustomization {{ $labels.name }} failing in {{ $labels.exported_namespace }}"
+            description: >-
+              Kustomization {{ $labels.exported_namespace }}/{{ $labels.name }} has been in a non-ready
+              state for more than 30 minutes. Check Flux logs and events for reconciliation errors.

--- a/kubernetes/platform/config/monitoring/kustomization.yaml
+++ b/kubernetes/platform/config/monitoring/kustomization.yaml
@@ -24,6 +24,7 @@ resources:
   - loki-mixin-recording-rules.yaml
 
   - flux-podmonitor.yaml
+  - flux-alerts.yaml
   - alloy-alerts.yaml
   - hardware-monitoring-secrets.yaml
   - hardware-monitoring-scrape.yaml

--- a/kubernetes/platform/helm-charts.yaml
+++ b/kubernetes/platform/helm-charts.yaml
@@ -281,8 +281,8 @@ spec:
             name: << inputs.name >>
       install:
         createNamespace: false
-        remediation:
-          retries: 5
+        strategy:
+          name: RetryOnFailure
         timeout: 10m
       interval: 10m
       maxHistory: 3
@@ -292,8 +292,8 @@ spec:
         keepHistory: false
       upgrade:
         crds: CreateReplace
-        remediation:
-          retries: 5
+        strategy:
+          name: RetryOnFailure
         timeout: 10m
       valuesFrom:
         - kind: ConfigMap


### PR DESCRIPTION
## Summary
- HelmReleases that exhaust retry budgets enter a permanent `Stalled/RetriesExceeded` state requiring manual `flux suspend/resume` — even after the fix is deployed through the OCI pipeline. This just happened with tdarr-node (stalled 5 days despite fix in PR #520)
- Switch all 4 ResourceSet templates (platform, live, dev, integration) from finite `remediation.retries` to the `RetryOnFailure` lifecycle strategy (helm-controller v1.5.0+, already available in Flux v2.8.1)
- Add `FluxHelmReleaseFailing` and `FluxKustomizationFailing` PrometheusRules using the `flux_resource_info` metric — fires when any non-suspended resource remains non-Ready for >30 minutes

## Test plan
- [x] `task k8s:validate` passes
- [x] Verified `flux_resource_info{kind="HelmRelease"}` metric is scraped on live (via flux-operator PodMonitor)
- [x] Verified `gotk_reconcile_condition` does NOT exist (confirming `flux_resource_info` is the correct metric)
- [ ] After promotion to integration, verify HelmReleases reconcile normally with the new strategy
- [ ] Verify PrometheusRule is picked up by Prometheus and alert expression evaluates correctly