### PR TITLE
feat(k8s): overhaul custom Grafana dashboards for consistency and accuracy

### DIFF
--- a/kubernetes/platform/config/monitoring/backup-health-dashboard.yaml
+++ b/kubernetes/platform/config/monitoring/backup-health-dashboard.yaml
@@ -27,9 +27,11 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Time since last successful backup per Longhorn volume. Red threshold at 36 hours indicates stale backups that may cause data loss.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
+              "noValue": "No backups",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -51,7 +53,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 24, "x": 0, "y": 1 },
-          "id": 1,
+          "id": 11,
           "options": {
             "cellHeight": "sm",
             "footer": { "enablePagination": false, "show": false },
@@ -60,7 +62,6 @@ data:
               { "desc": true, "displayName": "Backup Age" }
             ]
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -97,15 +98,17 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
-          "id": 11,
+          "id": 20,
           "title": "CNPG PostgreSQL Backups",
           "type": "row"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Time since last available base backup per CNPG cluster. Above 24h triggers CNPGClusterBackupStale alert.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
+              "noValue": "N/A",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -118,8 +121,8 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 6, "w": 12, "x": 0, "y": 10 },
-          "id": 2,
+          "gridPos": { "h": 5, "w": 8, "x": 0, "y": 10 },
+          "id": 21,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -132,7 +135,6 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -146,9 +148,11 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Count of WAL files waiting for archival per CNPG cluster. Above 10 triggers CNPGWALArchivingLagHigh alert; above 100 triggers CNPGWALArchivingStalled.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
+              "noValue": "N/A",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -161,8 +165,8 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 6, "w": 12, "x": 12, "y": 10 },
-          "id": 3,
+          "gridPos": { "h": 5, "w": 8, "x": 8, "y": 10 },
+          "id": 22,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
@@ -175,7 +179,6 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -189,9 +192,11 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Age of the earliest point-in-time recovery position per CNPG cluster. Represents the recovery window depth.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
+              "noValue": "N/A",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -204,8 +209,8 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 6, "w": 12, "x": 0, "y": 16 },
-          "id": 4,
+          "gridPos": { "h": 5, "w": 8, "x": 16, "y": 10 },
+          "id": 23,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -218,7 +223,6 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -232,6 +236,7 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "WAL archiving backlog trend over time. Sustained increases indicate archiving pipeline issues.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -244,10 +249,10 @@ data:
                 "barAlignment": 0,
                 "drawStyle": "line",
                 "fillOpacity": 20,
-                "gradientMode": "none",
+                "gradientMode": "scheme",
                 "hideFrom": { "legend": false, "tooltip": false, "viz": false },
                 "lineInterpolation": "linear",
-                "lineWidth": 1,
+                "lineWidth": 2,
                 "pointSize": 5,
                 "scaleDistribution": { "type": "linear" },
                 "showPoints": "never",
@@ -270,13 +275,12 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
-          "id": 5,
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 15 },
+          "id": 24,
           "options": {
-            "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" },
+            "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "none" }
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },

--- a/kubernetes/platform/config/monitoring/garage-s3-dashboard.yaml
+++ b/kubernetes/platform/config/monitoring/garage-s3-dashboard.yaml
@@ -21,12 +21,13 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
-          "id": 100,
+          "id": 10,
           "title": "Cluster Health",
           "type": "row"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Garage cluster health status. 1 = all nodes communicating, 0 = cluster degraded.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -44,7 +45,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
-          "id": 1,
+          "id": 11,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -53,7 +54,6 @@ data:
             "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
             "textMode": "auto"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -67,6 +67,7 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Garage cluster availability for read/write operations. 0 = service unavailable.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -84,7 +85,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
-          "id": 2,
+          "id": 12,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -93,7 +94,6 @@ data:
             "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
             "textMode": "auto"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -107,6 +107,7 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Number of connected vs total storage nodes in the Garage cluster.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -120,7 +121,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
-          "id": 3,
+          "id": 13,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -129,7 +130,6 @@ data:
             "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
             "textMode": "value_and_name"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -149,6 +149,7 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Configured data replication factor across Garage storage nodes.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -162,7 +163,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
-          "id": 4,
+          "id": 14,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -171,12 +172,11 @@ data:
             "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
             "textMode": "auto"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
               "expr": "garage_replication_factor{job=~\".*garage.*\"}",
-              "legendFormat": "",
+              "legendFormat": "Replication Factor",
               "refId": "A"
             }
           ],
@@ -185,6 +185,7 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Partition health: quorum partitions can serve requests, all-OK means fully replicated across all nodes.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -200,7 +201,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
-          "id": 5,
+          "id": 15,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -209,7 +210,6 @@ data:
             "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
             "textMode": "value_and_name"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -229,6 +229,7 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Running Garage version across cluster nodes.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -242,7 +243,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
-          "id": 6,
+          "id": 16,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -251,7 +252,6 @@ data:
             "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
             "textMode": "auto"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -266,12 +266,13 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
-          "id": 101,
+          "id": 20,
           "title": "Storage",
           "type": "row"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Data partition disk utilization per node. Above 80% triggers capacity planning. Above 90% risks write failures.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -290,7 +291,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 6, "w": 8, "x": 0, "y": 6 },
-          "id": 7,
+          "id": 21,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
@@ -299,7 +300,6 @@ data:
             "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
             "textMode": "auto"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -313,6 +313,7 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Metadata partition disk utilization per node. Metadata disks fill slower but are critical for cluster operation.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -331,7 +332,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 6, "w": 8, "x": 8, "y": 6 },
-          "id": 8,
+          "id": 22,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
@@ -340,7 +341,6 @@ data:
             "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
             "textMode": "auto"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -354,6 +354,7 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Raw data stored per node over time. Growing trends inform capacity planning.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -366,10 +367,10 @@ data:
                 "barAlignment": 0,
                 "drawStyle": "line",
                 "fillOpacity": 20,
-                "gradientMode": "none",
+                "gradientMode": "scheme",
                 "hideFrom": { "legend": false, "tooltip": false, "viz": false },
                 "lineInterpolation": "linear",
-                "lineWidth": 1,
+                "lineWidth": 2,
                 "pointSize": 5,
                 "scaleDistribution": { "type": "linear" },
                 "showPoints": "never",
@@ -383,12 +384,11 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 6, "w": 8, "x": 16, "y": 6 },
-          "id": 9,
+          "id": 23,
           "options": {
-            "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom" },
+            "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -403,12 +403,13 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 12 },
-          "id": 102,
+          "id": 30,
           "title": "S3 API",
           "type": "row"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "S3 API request rate broken down by operation type (GetObject, PutObject, ListObjects, etc.).",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -421,10 +422,10 @@ data:
                 "barAlignment": 0,
                 "drawStyle": "line",
                 "fillOpacity": 20,
-                "gradientMode": "none",
+                "gradientMode": "scheme",
                 "hideFrom": { "legend": false, "tooltip": false, "viz": false },
                 "lineInterpolation": "linear",
-                "lineWidth": 1,
+                "lineWidth": 2,
                 "pointSize": 5,
                 "scaleDistribution": { "type": "linear" },
                 "showPoints": "never",
@@ -438,12 +439,11 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
-          "id": 10,
+          "id": 31,
           "options": {
-            "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+            "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -457,6 +457,7 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "S3 API error responses by HTTP status code. 4xx are client errors, 5xx indicate server issues.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -469,10 +470,10 @@ data:
                 "barAlignment": 0,
                 "drawStyle": "line",
                 "fillOpacity": 20,
-                "gradientMode": "none",
+                "gradientMode": "scheme",
                 "hideFrom": { "legend": false, "tooltip": false, "viz": false },
                 "lineInterpolation": "linear",
-                "lineWidth": 1,
+                "lineWidth": 2,
                 "pointSize": 5,
                 "scaleDistribution": { "type": "linear" },
                 "showPoints": "never",
@@ -486,12 +487,11 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
-          "id": 11,
+          "id": 32,
           "options": {
-            "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+            "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -505,6 +505,7 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "S3 API request latency at p50/p95/p99 percentiles. Above 1s triggers investigation, above 5s is degraded.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -517,10 +518,10 @@ data:
                 "barAlignment": 0,
                 "drawStyle": "line",
                 "fillOpacity": 10,
-                "gradientMode": "none",
+                "gradientMode": "scheme",
                 "hideFrom": { "legend": false, "tooltip": false, "viz": false },
                 "lineInterpolation": "linear",
-                "lineWidth": 1,
+                "lineWidth": 2,
                 "pointSize": 5,
                 "scaleDistribution": { "type": "linear" },
                 "showPoints": "never",
@@ -545,12 +546,11 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 21 },
-          "id": 12,
+          "id": 33,
           "options": {
             "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -576,6 +576,7 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Block-level read and write throughput per node. Shows actual storage I/O load.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -588,10 +589,10 @@ data:
                 "barAlignment": 0,
                 "drawStyle": "line",
                 "fillOpacity": 20,
-                "gradientMode": "none",
+                "gradientMode": "scheme",
                 "hideFrom": { "legend": false, "tooltip": false, "viz": false },
                 "lineInterpolation": "linear",
-                "lineWidth": 1,
+                "lineWidth": 2,
                 "pointSize": 5,
                 "scaleDistribution": { "type": "linear" },
                 "showPoints": "never",
@@ -605,12 +606,11 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 21 },
-          "id": 13,
+          "id": 34,
           "options": {
-            "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+            "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -631,15 +631,17 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 29 },
-          "id": 103,
+          "id": 40,
           "title": "Replication & Resync",
           "type": "row"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Number of blocks pending resynchronization. High values during normal operation indicate replication issues.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
+              "noValue": "N/A",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -652,7 +654,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 6, "w": 6, "x": 0, "y": 30 },
-          "id": 14,
+          "id": 41,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
@@ -661,7 +663,6 @@ data:
             "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
             "textMode": "auto"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -675,9 +676,11 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Blocks that failed resynchronization. Any non-zero value requires investigation.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
+              "noValue": "N/A",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -689,7 +692,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 6, "w": 6, "x": 6, "y": 30 },
-          "id": 15,
+          "id": 42,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
@@ -698,7 +701,6 @@ data:
             "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
             "textMode": "auto"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -712,6 +714,7 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Partition status trend: all-OK, quorum, and total partitions over time. Dips in all-OK indicate temporary replication degradation.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -724,10 +727,10 @@ data:
                 "barAlignment": 0,
                 "drawStyle": "line",
                 "fillOpacity": 20,
-                "gradientMode": "none",
+                "gradientMode": "scheme",
                 "hideFrom": { "legend": false, "tooltip": false, "viz": false },
                 "lineInterpolation": "linear",
-                "lineWidth": 1,
+                "lineWidth": 2,
                 "pointSize": 5,
                 "scaleDistribution": { "type": "linear" },
                 "showPoints": "never",
@@ -741,12 +744,11 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 6, "w": 12, "x": 12, "y": 30 },
-          "id": 16,
+          "id": 43,
           "options": {
-            "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom" },
+            "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -773,12 +775,13 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 },
-          "id": 104,
+          "id": 50,
           "title": "Inter-Node RPC",
           "type": "row"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Inter-node RPC call latency at p50/p95/p99. High latency indicates network issues between Garage nodes.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -791,10 +794,10 @@ data:
                 "barAlignment": 0,
                 "drawStyle": "line",
                 "fillOpacity": 10,
-                "gradientMode": "none",
+                "gradientMode": "scheme",
                 "hideFrom": { "legend": false, "tooltip": false, "viz": false },
                 "lineInterpolation": "linear",
-                "lineWidth": 1,
+                "lineWidth": 2,
                 "pointSize": 5,
                 "scaleDistribution": { "type": "linear" },
                 "showPoints": "never",
@@ -819,12 +822,11 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 37 },
-          "id": 17,
+          "id": 51,
           "options": {
             "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -850,6 +852,7 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Inter-node RPC failures: timeouts and network application errors. Non-zero rates indicate cluster communication issues.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -862,10 +865,10 @@ data:
                 "barAlignment": 0,
                 "drawStyle": "line",
                 "fillOpacity": 20,
-                "gradientMode": "none",
+                "gradientMode": "scheme",
                 "hideFrom": { "legend": false, "tooltip": false, "viz": false },
                 "lineInterpolation": "linear",
-                "lineWidth": 1,
+                "lineWidth": 2,
                 "pointSize": 5,
                 "scaleDistribution": { "type": "linear" },
                 "showPoints": "never",
@@ -879,12 +882,11 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 37 },
-          "id": 18,
+          "id": 52,
           "options": {
-            "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+            "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -903,107 +905,109 @@ data:
           "type": "timeseries"
         },
         {
-          "collapsed": false,
+          "collapsed": true,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 45 },
-          "id": 105,
+          "id": 60,
+          "panels": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "description": "Pending Merkle tree updates per table per node. Non-zero values during normal operation indicate anti-entropy repair activity.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": { "mode": "palette-classic" },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "gradientMode": "scheme",
+                    "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": { "type": "linear" },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": { "group": "A", "mode": "none" },
+                    "thresholdsStyle": { "mode": "off" }
+                  },
+                  "unit": "short",
+                  "min": 0
+                },
+                "overrides": []
+              },
+              "gridPos": { "h": 8, "w": 12, "x": 0, "y": 46 },
+              "id": 61,
+              "options": {
+                "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
+                "tooltip": { "mode": "multi", "sort": "desc" }
+              },
+              "targets": [
+                {
+                  "datasource": { "type": "prometheus", "uid": "prometheus" },
+                  "expr": "table_merkle_updater_todo_queue_length{job=~\".*garage.*\"}",
+                  "legendFormat": "{{ instance }} / {{ table_name }}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Merkle Tree Updater Queue",
+              "type": "timeseries"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "description": "Garbage collection queue length per table per node. Non-zero values indicate pending cleanup of deleted objects.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": { "mode": "palette-classic" },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "gradientMode": "scheme",
+                    "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": { "type": "linear" },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": { "group": "A", "mode": "none" },
+                    "thresholdsStyle": { "mode": "off" }
+                  },
+                  "unit": "short",
+                  "min": 0
+                },
+                "overrides": []
+              },
+              "gridPos": { "h": 8, "w": 12, "x": 12, "y": 46 },
+              "id": 62,
+              "options": {
+                "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
+                "tooltip": { "mode": "multi", "sort": "desc" }
+              },
+              "targets": [
+                {
+                  "datasource": { "type": "prometheus", "uid": "prometheus" },
+                  "expr": "table_gc_todo_queue_length{job=~\".*garage.*\"}",
+                  "legendFormat": "{{ instance }} / {{ table_name }}",
+                  "refId": "A"
+                }
+              ],
+              "title": "GC Queue Length",
+              "type": "timeseries"
+            }
+          ],
           "title": "Internal Tables",
           "type": "row"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "fieldConfig": {
-            "defaults": {
-              "color": { "mode": "palette-classic" },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 20,
-                "gradientMode": "none",
-                "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": { "type": "linear" },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": { "group": "A", "mode": "none" },
-                "thresholdsStyle": { "mode": "off" }
-              },
-              "unit": "short",
-              "min": 0
-            },
-            "overrides": []
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 46 },
-          "id": 19,
-          "options": {
-            "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
-            "tooltip": { "mode": "multi", "sort": "desc" }
-          },
-          "pluginVersion": "11.4.0",
-          "targets": [
-            {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
-              "expr": "table_merkle_updater_todo_queue_length{job=~\".*garage.*\"}",
-              "legendFormat": "{{ instance }} / {{ table_name }}",
-              "refId": "A"
-            }
-          ],
-          "title": "Merkle Tree Updater Queue",
-          "type": "timeseries"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "fieldConfig": {
-            "defaults": {
-              "color": { "mode": "palette-classic" },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 20,
-                "gradientMode": "none",
-                "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": { "type": "linear" },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": { "group": "A", "mode": "none" },
-                "thresholdsStyle": { "mode": "off" }
-              },
-              "unit": "short",
-              "min": 0
-            },
-            "overrides": []
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 46 },
-          "id": 20,
-          "options": {
-            "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
-            "tooltip": { "mode": "multi", "sort": "desc" }
-          },
-          "pluginVersion": "11.4.0",
-          "targets": [
-            {
-              "datasource": { "type": "prometheus", "uid": "prometheus" },
-              "expr": "table_gc_todo_queue_length{job=~\".*garage.*\"}",
-              "legendFormat": "{{ instance }} / {{ table_name }}",
-              "refId": "A"
-            }
-          ],
-          "title": "GC Queue Length",
-          "type": "timeseries"
         }
       ],
       "schemaVersion": 39,

--- a/kubernetes/platform/config/monitoring/hardware-health-dashboard.yaml
+++ b/kubernetes/platform/config/monitoring/hardware-health-dashboard.yaml
@@ -21,7 +21,7 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
-          "id": 50,
+          "id": 10,
           "title": "Disk Health",
           "type": "row"
         },
@@ -50,7 +50,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 24, "x": 0, "y": 1 },
-          "id": 1,
+          "id": 11,
           "options": {
             "cellHeight": "sm",
             "footer": { "enablePagination": false, "show": false },
@@ -59,7 +59,6 @@ data:
               { "desc": false, "displayName": "Instance" }
             ]
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -118,7 +117,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
-          "id": 2,
+          "id": 12,
           "options": {
             "displayMode": "gradient",
             "minVizHeight": 16,
@@ -134,7 +133,6 @@ data:
             "sizing": "auto",
             "valueMode": "color"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -161,7 +159,7 @@ data:
                 "barAlignment": 0,
                 "drawStyle": "line",
                 "fillOpacity": 15,
-                "gradientMode": "none",
+                "gradientMode": "scheme",
                 "hideFrom": { "legend": false, "tooltip": false, "viz": false },
                 "insertNulls": false,
                 "lineInterpolation": "smooth",
@@ -187,12 +185,11 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
-          "id": 3,
+          "id": 13,
           "options": {
             "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
             "tooltip": { "mode": "multi", "sort": "desc" }
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -230,7 +227,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 17 },
-          "id": 4,
+          "id": 14,
           "options": {
             "cellHeight": "sm",
             "footer": { "enablePagination": false, "show": false },
@@ -239,7 +236,6 @@ data:
               { "desc": true, "displayName": "Power-On Hours" }
             ]
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -294,7 +290,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 6, "x": 12, "y": 17 },
-          "id": 5,
+          "id": 15,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -307,7 +303,6 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -338,7 +333,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 6, "x": 18, "y": 17 },
-          "id": 6,
+          "id": 16,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
@@ -351,7 +346,6 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -378,7 +372,7 @@ data:
                 "barAlignment": 0,
                 "drawStyle": "line",
                 "fillOpacity": 15,
-                "gradientMode": "none",
+                "gradientMode": "scheme",
                 "hideFrom": { "legend": false, "tooltip": false, "viz": false },
                 "insertNulls": false,
                 "lineInterpolation": "smooth",
@@ -396,12 +390,11 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 21 },
-          "id": 7,
+          "id": 17,
           "options": {
             "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
             "tooltip": { "mode": "multi", "sort": "desc" }
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -422,7 +415,7 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 29 },
-          "id": 51,
+          "id": 20,
           "title": "Server Sensors (IPMI)",
           "type": "row"
         },
@@ -441,7 +434,7 @@ data:
                 "barAlignment": 0,
                 "drawStyle": "line",
                 "fillOpacity": 15,
-                "gradientMode": "none",
+                "gradientMode": "scheme",
                 "hideFrom": { "legend": false, "tooltip": false, "viz": false },
                 "insertNulls": false,
                 "lineInterpolation": "smooth",
@@ -467,12 +460,11 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 10, "w": 12, "x": 0, "y": 30 },
-          "id": 8,
+          "id": 21,
           "options": {
             "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
             "tooltip": { "mode": "multi", "sort": "desc" }
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -499,7 +491,7 @@ data:
                 "barAlignment": 0,
                 "drawStyle": "line",
                 "fillOpacity": 15,
-                "gradientMode": "none",
+                "gradientMode": "scheme",
                 "hideFrom": { "legend": false, "tooltip": false, "viz": false },
                 "insertNulls": false,
                 "lineInterpolation": "smooth",
@@ -524,12 +516,11 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 10, "w": 12, "x": 12, "y": 30 },
-          "id": 9,
+          "id": 22,
           "options": {
             "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
             "tooltip": { "mode": "multi", "sort": "desc" }
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -562,7 +553,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 5, "w": 12, "x": 0, "y": 40 },
-          "id": 10,
+          "id": 23,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -575,7 +566,6 @@ data:
             },
             "textMode": "value_and_name"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -602,7 +592,7 @@ data:
                 "barAlignment": 0,
                 "drawStyle": "line",
                 "fillOpacity": 15,
-                "gradientMode": "none",
+                "gradientMode": "scheme",
                 "hideFrom": { "legend": false, "tooltip": false, "viz": false },
                 "insertNulls": false,
                 "lineInterpolation": "smooth",
@@ -619,13 +609,12 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 5, "w": 12, "x": 12, "y": 40 },
-          "id": 11,
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+          "id": 24,
           "options": {
             "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
             "tooltip": { "mode": "multi", "sort": "desc" }
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -639,8 +628,8 @@ data:
         },
         {
           "collapsed": false,
-          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 45 },
-          "id": 52,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 48 },
+          "id": 30,
           "title": "GPU Health (DCGM)",
           "type": "row"
         },
@@ -659,7 +648,7 @@ data:
                 "barAlignment": 0,
                 "drawStyle": "line",
                 "fillOpacity": 15,
-                "gradientMode": "none",
+                "gradientMode": "scheme",
                 "hideFrom": { "legend": false, "tooltip": false, "viz": false },
                 "insertNulls": false,
                 "lineInterpolation": "smooth",
@@ -685,13 +674,12 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 46 },
-          "id": 12,
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 49 },
+          "id": 31,
           "options": {
             "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
             "tooltip": { "mode": "multi", "sort": "desc" }
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -722,8 +710,8 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 4, "w": 6, "x": 12, "y": 46 },
-          "id": 13,
+          "gridPos": { "h": 4, "w": 6, "x": 12, "y": 49 },
+          "id": 32,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
@@ -736,7 +724,6 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -767,8 +754,8 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 4, "w": 6, "x": 18, "y": 46 },
-          "id": 14,
+          "gridPos": { "h": 4, "w": 6, "x": 18, "y": 49 },
+          "id": 33,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
@@ -781,7 +768,6 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -815,8 +801,8 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 4, "w": 12, "x": 12, "y": 50 },
-          "id": 15,
+          "gridPos": { "h": 4, "w": 12, "x": 12, "y": 53 },
+          "id": 34,
           "options": {
             "minVizHeight": 75,
             "minVizWidth": 75,
@@ -830,7 +816,6 @@ data:
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },

--- a/kubernetes/platform/config/monitoring/platform-home-dashboard.yaml
+++ b/kubernetes/platform/config/monitoring/platform-home-dashboard.yaml
@@ -34,7 +34,7 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
-          "id": 100,
+          "id": 10,
           "title": "Cluster Overview",
           "type": "row"
         },
@@ -57,7 +57,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
-          "id": 1,
+          "id": 11,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -94,7 +94,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
-          "id": 2,
+          "id": 12,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
@@ -133,7 +133,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
-          "id": 3,
+          "id": 13,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -172,7 +172,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
-          "id": 4,
+          "id": 14,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -195,7 +195,7 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
-          "id": 200,
+          "id": 20,
           "title": "Golden Signals",
           "type": "row"
         },
@@ -216,7 +216,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 8, "x": 0, "y": 6 },
-          "id": 5,
+          "id": 21,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
@@ -260,7 +260,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 8, "x": 8, "y": 6 },
-          "id": 6,
+          "id": 22,
           "options": {
             "minVizHeight": 75,
             "minVizWidth": 75,
@@ -302,7 +302,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 8, "x": 16, "y": 6 },
-          "id": 7,
+          "id": 23,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
@@ -325,13 +325,13 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 10 },
-          "id": 300,
+          "id": 30,
           "title": "Infrastructure",
           "type": "row"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "description": "Total power consumption from IPMI servers plus GPU power.",
+          "description": "Total power draw measured at the UPS output.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -348,7 +348,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 6, "x": 0, "y": 11 },
-          "id": 8,
+          "id": 31,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
@@ -360,7 +360,7 @@ data:
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
-              "expr": "sum(ipmi_dcmi_power_consumption_watts) + sum(DCGM_FI_DEV_POWER_USAGE) or sum(ipmi_dcmi_power_consumption_watts)",
+              "expr": "upsAdvanceOutputPower",
               "legendFormat": "Total",
               "refId": "A"
             }
@@ -378,7 +378,7 @@ data:
                 "mode": "absolute",
                 "steps": [
                   { "color": "green", "value": null },
-                  { "color": "#EAB839", "value": 60 },
+                  { "color": "yellow", "value": 60 },
                   { "color": "orange", "value": 80 },
                   { "color": "red", "value": 95 }
                 ]
@@ -390,7 +390,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 6, "x": 6, "y": 11 },
-          "id": 9,
+          "id": 32,
           "options": {
             "minVizHeight": 75,
             "minVizWidth": 75,
@@ -413,7 +413,7 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "description": "Estimated monthly electricity cost at $0.12/kWh.",
+          "description": "Projected monthly electricity cost: (watts / 1000) * 730 hours * $electricity_rate/kWh.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -421,7 +421,7 @@ data:
                 "mode": "absolute",
                 "steps": [
                   { "color": "green", "value": null },
-                  { "color": "#EAB839", "value": 50 },
+                  { "color": "yellow", "value": 50 },
                   { "color": "red", "value": 100 }
                 ]
               },
@@ -431,7 +431,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 6, "x": 12, "y": 11 },
-          "id": 10,
+          "id": 33,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -443,7 +443,7 @@ data:
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
-              "expr": "((sum(ipmi_dcmi_power_consumption_watts) + sum(DCGM_FI_DEV_POWER_USAGE)) or sum(ipmi_dcmi_power_consumption_watts)) / 1000 * 730 * 0.12",
+              "expr": "upsAdvanceOutputPower / 1000 * 730 * $electricity_rate",
               "legendFormat": "Est. Monthly",
               "refId": "A"
             }
@@ -471,7 +471,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 6, "x": 18, "y": 11 },
-          "id": 11,
+          "id": 34,
           "options": {
             "colorMode": "background",
             "graphMode": "area",
@@ -494,7 +494,7 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 },
-          "id": 400,
+          "id": 40,
           "title": "Storage & Data",
           "type": "row"
         },
@@ -520,7 +520,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 8, "x": 0, "y": 16 },
-          "id": 12,
+          "id": 41,
           "options": {
             "minVizHeight": 75,
             "minVizWidth": 75,
@@ -561,7 +561,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 8, "x": 8, "y": 16 },
-          "id": 13,
+          "id": 42,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -602,7 +602,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 8, "x": 16, "y": 16 },
-          "id": 14,
+          "id": 43,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -625,7 +625,7 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 20 },
-          "id": 500,
+          "id": 50,
           "title": "Database & Cache",
           "type": "row"
         },
@@ -649,7 +649,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 8, "x": 0, "y": 21 },
-          "id": 15,
+          "id": 51,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -691,7 +691,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 8, "x": 8, "y": 21 },
-          "id": 16,
+          "id": 52,
           "options": {
             "minVizHeight": 75,
             "minVizWidth": 75,
@@ -734,7 +734,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 8, "x": 16, "y": 21 },
-          "id": 17,
+          "id": 53,
           "options": {
             "minVizHeight": 75,
             "minVizWidth": 75,
@@ -758,7 +758,7 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 25 },
-          "id": 600,
+          "id": 60,
           "title": "Backup & Alerts",
           "type": "row"
         },
@@ -781,7 +781,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 6, "w": 8, "x": 0, "y": 26 },
-          "id": 18,
+          "id": 61,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -850,7 +850,7 @@ data:
             ]
           },
           "gridPos": { "h": 6, "w": 16, "x": 8, "y": 26 },
-          "id": 19,
+          "id": 62,
           "options": {
             "showHeader": true,
             "footer": { "enablePagination": false },
@@ -900,10 +900,24 @@ data:
       "refresh": "30s",
       "schemaVersion": 39,
       "tags": ["home", "overview", "executive", "platform"],
-      "templating": { "list": [] },
+      "templating": {
+        "list": [
+          {
+            "current": { "selected": false, "text": "0.15", "value": "0.15" },
+            "description": "Electricity rate in $/kWh for cost estimation",
+            "label": "Electricity Rate ($/kWh)",
+            "name": "electricity_rate",
+            "options": [
+              { "selected": true, "text": "0.15", "value": "0.15" }
+            ],
+            "query": "0.15",
+            "type": "textbox"
+          }
+        ]
+      },
       "time": { "from": "now-1h", "to": "now" },
       "timepicker": {},
-      "timezone": "browser",
+      "timezone": "",
       "title": "Platform Home",
       "uid": "platform-home",
       "version": 1

--- a/kubernetes/platform/config/monitoring/platform-signals-dashboard.yaml
+++ b/kubernetes/platform/config/monitoring/platform-signals-dashboard.yaml
@@ -19,22 +19,66 @@ data:
       "id": null,
       "links": [
         {
-          "asDropdown": true,
-          "icon": "external link",
+          "asDropdown": false,
+          "icon": "dashboard",
           "includeVars": false,
           "keepTime": true,
           "tags": [],
-          "targetBlank": true,
-          "title": "Related Dashboards",
+          "targetBlank": false,
+          "title": "Platform Home",
           "type": "link",
-          "url": ""
+          "url": "/d/platform-home"
+        },
+        {
+          "asDropdown": false,
+          "icon": "dashboard",
+          "includeVars": false,
+          "keepTime": true,
+          "tags": [],
+          "targetBlank": false,
+          "title": "Hardware Health",
+          "type": "link",
+          "url": "/d/hardware-health"
+        },
+        {
+          "asDropdown": false,
+          "icon": "dashboard",
+          "includeVars": false,
+          "keepTime": true,
+          "tags": [],
+          "targetBlank": false,
+          "title": "Backup Health",
+          "type": "link",
+          "url": "/d/backup-health"
+        },
+        {
+          "asDropdown": false,
+          "icon": "dashboard",
+          "includeVars": false,
+          "keepTime": true,
+          "tags": [],
+          "targetBlank": false,
+          "title": "Garage S3",
+          "type": "link",
+          "url": "/d/garage-s3-storage"
+        },
+        {
+          "asDropdown": false,
+          "icon": "dashboard",
+          "includeVars": false,
+          "keepTime": true,
+          "tags": [],
+          "targetBlank": false,
+          "title": "Power Accounting",
+          "type": "link",
+          "url": "/d/power-accounting"
         }
       ],
       "panels": [
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
-          "id": 1,
+          "id": 10,
           "title": "Gateway Traffic (Latency / Traffic / Errors)",
           "type": "row"
         },
@@ -60,7 +104,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 8, "x": 0, "y": 1 },
-          "id": 2,
+          "id": 11,
           "options": {
             "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
@@ -104,7 +148,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 8, "x": 8, "y": 1 },
-          "id": 3,
+          "id": 12,
           "options": {
             "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
@@ -145,7 +189,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 8, "x": 16, "y": 1 },
-          "id": 4,
+          "id": 13,
           "options": {
             "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
@@ -173,7 +217,7 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
-          "id": 10,
+          "id": 20,
           "title": "Database Saturation (CNPG)",
           "type": "row"
         },
@@ -199,7 +243,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 8, "x": 0, "y": 10 },
-          "id": 11,
+          "id": 21,
           "options": {
             "reduceOptions": {
               "calcs": ["lastNotNull"],
@@ -241,7 +285,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 8, "x": 8, "y": 10 },
-          "id": 12,
+          "id": 22,
           "options": {
             "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
@@ -285,7 +329,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 8, "x": 16, "y": 10 },
-          "id": 13,
+          "id": 23,
           "options": {
             "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
@@ -303,7 +347,7 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 },
-          "id": 20,
+          "id": 30,
           "title": "Cache Performance (Dragonfly)",
           "type": "row"
         },
@@ -329,7 +373,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 8, "x": 0, "y": 19 },
-          "id": 21,
+          "id": 31,
           "options": {
             "reduceOptions": {
               "calcs": ["lastNotNull"],
@@ -371,7 +415,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 8, "x": 8, "y": 19 },
-          "id": 22,
+          "id": 32,
           "options": {
             "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
@@ -407,7 +451,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 8, "x": 16, "y": 19 },
-          "id": 23,
+          "id": 33,
           "options": {
             "reduceOptions": {
               "calcs": ["lastNotNull"],
@@ -420,7 +464,7 @@ data:
           },
           "targets": [
             {
-              "expr": "100 * (dragonfly_keyspace_hits_total{namespace=\"cache\"} / (dragonfly_keyspace_hits_total{namespace=\"cache\"} + dragonfly_keyspace_misses_total{namespace=\"cache\"}))",
+              "expr": "100 * (rate(dragonfly_keyspace_hits_total{namespace=\"cache\"}[5m]) / (rate(dragonfly_keyspace_hits_total{namespace=\"cache\"}[5m]) + rate(dragonfly_keyspace_misses_total{namespace=\"cache\"}[5m])))",
               "legendFormat": "{{ pod }}",
               "refId": "A"
             }
@@ -431,7 +475,7 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 },
-          "id": 30,
+          "id": 40,
           "title": "Storage Saturation",
           "type": "row"
         },
@@ -477,7 +521,7 @@ data:
             ]
           },
           "gridPos": { "h": 10, "w": 12, "x": 0, "y": 28 },
-          "id": 31,
+          "id": 41,
           "options": {
             "showHeader": true,
             "sortBy": [{ "desc": true, "displayName": "Used %" }],
@@ -547,7 +591,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 10, "w": 12, "x": 12, "y": 28 },
-          "id": 32,
+          "id": 42,
           "options": {
             "reduceOptions": {
               "calcs": ["lastNotNull"],
@@ -571,7 +615,7 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 38 },
-          "id": 40,
+          "id": 50,
           "title": "GitOps Health (Flux)",
           "type": "row"
         },
@@ -594,7 +638,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 6, "x": 0, "y": 39 },
-          "id": 41,
+          "id": 51,
           "options": {
             "reduceOptions": {
               "calcs": ["lastNotNull"],
@@ -634,7 +678,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 6, "x": 6, "y": 39 },
-          "id": 42,
+          "id": 52,
           "options": {
             "reduceOptions": {
               "calcs": ["lastNotNull"],
@@ -674,7 +718,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 6, "x": 12, "y": 39 },
-          "id": 43,
+          "id": 53,
           "options": {
             "reduceOptions": {
               "calcs": ["lastNotNull"],
@@ -716,7 +760,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 4, "w": 6, "x": 18, "y": 39 },
-          "id": 44,
+          "id": 54,
           "options": {
             "reduceOptions": {
               "calcs": ["lastNotNull"],
@@ -758,7 +802,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 24, "x": 0, "y": 43 },
-          "id": 45,
+          "id": 55,
           "options": {
             "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
@@ -781,7 +825,7 @@ data:
         {
           "collapsed": false,
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 51 },
-          "id": 50,
+          "id": 60,
           "title": "Garage S3 Storage",
           "type": "row"
         },
@@ -807,7 +851,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 8, "x": 0, "y": 52 },
-          "id": 51,
+          "id": 61,
           "options": {
             "reduceOptions": {
               "calcs": ["lastNotNull"],
@@ -849,7 +893,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 8, "x": 8, "y": 52 },
-          "id": 52,
+          "id": 62,
           "options": {
             "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
@@ -890,7 +934,7 @@ data:
             "overrides": []
           },
           "gridPos": { "h": 8, "w": 8, "x": 16, "y": 52 },
-          "id": 53,
+          "id": 63,
           "options": {
             "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
             "tooltip": { "mode": "multi", "sort": "desc" }
@@ -917,7 +961,7 @@ data:
       "templating": { "list": [] },
       "time": { "from": "now-3h", "to": "now" },
       "timepicker": {},
-      "timezone": "browser",
+      "timezone": "",
       "title": "Platform Signals",
       "uid": "platform-signals",
       "version": 1


### PR DESCRIPTION
## Summary

- Apply grafana-dashboards skill conventions across all 5 remaining custom dashboards (garage-s3, backup-health, hardware-health, platform-signals, platform-home), matching the standard set by the power-accounting redesign in #569
- Fix critical bugs: Dragonfly hit ratio using raw counters instead of rate(), Platform Home power metric using broken ipmi_dcmi instead of UPS output, hardcoded electricity rate
- Standardize all dashboards: remove pluginVersion fields, add panel descriptions, decade-based IDs, consistent timeseries styling, fix timezone settings

## Test plan

- [ ] `task k8s:validate` passes (verified locally)
- [ ] Verify each dashboard renders correctly after merge:
  - [ ] [Garage S3 Storage](https://grafana.internal.tomnowak.work/d/garage-s3-storage) — collapsed Internal Tables section, all panels have data
  - [ ] [Backup Health](https://grafana.internal.tomnowak.work/d/backup-health) — rebalanced CNPG layout (3 stats side-by-side)
  - [ ] [Hardware Health](https://grafana.internal.tomnowak.work/d/hardware-health) — taller Server Power Draw panel
  - [ ] [Platform Signals](https://grafana.internal.tomnowak.work/d/platform-signals) — Related Dashboards links work, Dragonfly hit ratio shows recent rate
  - [ ] [Platform Home](https://grafana.internal.tomnowak.work/d/platform-home) — electricity_rate variable visible, cost reflects $0.15/kWh default
- [ ] Confirm zero "No data" panels on each dashboard
- [ ] Confirm Platform Home "Total Power Draw" shows UPS output wattage (not IPMI sum)