### PR TITLE
fix(k8s): use Opaque type for replicator-target db credential secrets

### DIFF
--- a/kubernetes/clusters/live/config/ai-prereqs/open-webui-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/ai-prereqs/open-webui-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: ai
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/open-webui-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/authelia-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/authelia-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: authelia
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/authelia-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/lldap-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/lldap-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: authelia
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/lldap-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }

--- a/kubernetes/clusters/live/config/media-prereqs/db-credentials.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/db-credentials.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: media
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/sonarr-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }
 ---
 apiVersion: v1
@@ -16,7 +16,7 @@ metadata:
   namespace: media
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/radarr-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }
 ---
 apiVersion: v1
@@ -26,7 +26,7 @@ metadata:
   namespace: media
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/prowlarr-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }
 ---
 apiVersion: v1
@@ -36,7 +36,7 @@ metadata:
   namespace: media
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/bazarr-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }
 ---
 apiVersion: v1
@@ -46,5 +46,5 @@ metadata:
   namespace: media
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/jellyseerr-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }

--- a/kubernetes/clusters/live/config/paperless/paperless-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/paperless/paperless-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: paperless
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/paperless-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }

--- a/kubernetes/clusters/live/config/tandoor/tandoor-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/tandoor/tandoor-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: tandoor
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/tandoor-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }

--- a/kubernetes/clusters/live/config/vaultwarden/vaultwarden-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/vaultwarden/vaultwarden-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: vaultwarden
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/vaultwarden-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }

--- a/kubernetes/clusters/live/config/zipline/zipline-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/zipline/zipline-db-credentials.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: zipline
   annotations:
     replicator.v1.mittwald.de/replicate-from: database/zipline-role-password
-type: kubernetes.io/basic-auth
+type: Opaque
 data: { }


### PR DESCRIPTION
## Summary

- Break the basic-auth/Opaque type flip-flop cycle (#510 → #532 → this PR) by standardizing all replicator-target db credential secrets on `type: Opaque`
- `basic-auth` requires `username`/`password` at creation, but these secrets start empty (populated by replicator) — causing permanent Flux dry-run deadlock for any secret that doesn't already exist on the cluster
- Unblocks `media-prereqs` Kustomization (stuck for 6 days) and enables PR #564's secret-generator changes to take effect

## Pre-merge: delete existing basic-auth secrets on live

The `type` field is immutable, so existing secrets must be deleted before Flux can recreate them as Opaque. The replicator repopulates within seconds.

```bash
KUBECONFIG=~/.kube/live.yaml kubectl delete secret authelia-db-credentials lldap-db-credentials -n authelia
KUBECONFIG=~/.kube/live.yaml kubectl delete secret paperless-db-credentials -n paperless
KUBECONFIG=~/.kube/live.yaml kubectl delete secret vaultwarden-db-credentials -n vaultwarden
KUBECONFIG=~/.kube/live.yaml kubectl delete secret tandoor-db-credentials -n tandoor
KUBECONFIG=~/.kube/live.yaml kubectl delete secret zipline-db-credentials -n zipline
KUBECONFIG=~/.kube/live.yaml kubectl delete secret open-webui-db-credentials -n ai
KUBECONFIG=~/.kube/live.yaml kubectl delete secret sonarr-db-credentials radarr-db-credentials prowlarr-db-credentials jellyseerr-db-credentials -n media
```

## Test plan

- [ ] Delete existing basic-auth secrets on live (commands above)
- [ ] Merge PR and wait for OCI artifact promotion
- [ ] Verify `media-prereqs` Kustomization reconciles successfully
- [ ] Verify replicator repopulates all secrets (check data is non-empty)
- [ ] Verify secret-generator creates sonarr/radarr/prowlarr-api-key secrets (from PR #564)
- [ ] Verify sonarr, radarr, prowlarr pods start with AUTH__APIKEY env vars
- [ ] Verify exportarr pods stop CrashLooping
- [ ] Confirm ExternalSecretNotReady alerts clear (except jellyfin)