### PR TITLE
fix(k8s): resolve Open WebUI Redis auth by controlling env var ordering

### DIFF
--- a/kubernetes/clusters/live/charts/open-webui.yaml
+++ b/kubernetes/clusters/live/charts/open-webui.yaml
@@ -11,10 +11,13 @@ ollamaUrls:
 pipelines:
   enabled: false
 
+# websocket.enabled=false prevents the chart from generating REDIS_URL and
+# WEBSOCKET_MANAGER env vars at fixed positions that precede DRAGONFLY_PASS
+# from extraEnvVars — causing $(DRAGONFLY_PASS) to resolve as a literal string.
+# We provide all websocket env vars ourselves in extraEnvVars where ordering is
+# controlled (same pattern as databaseUrl: "" below).
 websocket:
-  enabled: true
-  manager: redis
-  url: ""
+  enabled: false
   redis:
     enabled: false
 
@@ -29,6 +32,10 @@ extraEnvVars:
         key: password
   - name: DATABASE_URL
     value: "postgresql://open-webui:$(DB_PASSWORD)@platform-pooler-rw.database.svc.cluster.local:5432/open-webui"
+  - name: ENABLE_WEBSOCKET_SUPPORT
+    value: "True"
+  - name: WEBSOCKET_MANAGER
+    value: "redis"
   - name: DRAGONFLY_PASS
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION
## Summary
- Open WebUI's Redis connection fails because the chart generates `REDIS_URL` at an env var position before `DRAGONFLY_PASS` from `extraEnvVars`, causing `$(DRAGONFLY_PASS)` to resolve as a literal string instead of the actual password
- Disable chart-generated websocket env vars (`websocket.enabled: false`) and provide them in `extraEnvVars` where ordering is fully controlled — same pattern as the existing `databaseUrl: ""` workaround
- Completes the Redis integration started in PR #565

## Test plan
- [ ] `task k8s:validate` passes (verified locally)
- [ ] After promotion to live: pod starts without `AuthenticationError`
- [ ] `kubectl -n ai exec open-webui-0 -- env | grep REDIS` shows resolved URLs (not literal `$(DRAGONFLY_PASS)`)
- [ ] Open WebUI websocket connections work (real-time updates in UI)