### PR TITLE
fix(k8s): remove false-positive LonghornSnapshotSpaceWarning alert

### DIFF
--- a/kubernetes/platform/config/longhorn/prometheus-rules.yaml
+++ b/kubernetes/platform/config/longhorn/prometheus-rules.yaml
@@ -101,16 +101,6 @@ spec:
             summary: "Longhorn backup {{ $labels.backup }} failed"
             description: "Backup {{ $labels.backup }} for volume {{ $labels.volume }} is in error state. Check backup target connectivity and available space."
 
-        # Snapshot Space Warning
-        - alert: LonghornSnapshotSpaceWarning
-          expr: longhorn_snapshot_actual_size_bytes > 10737418240
-          for: 10m
-          labels:
-            severity: warning
-          annotations:
-            summary: "Longhorn snapshot {{ $labels.snapshot }} > 10GB"
-            description: "Snapshot {{ $labels.snapshot }} on volume {{ $labels.volume }} is {{ $value | humanize1024 }}. Consider pruning old snapshots."
-
         # Volume Read-Only (filesystem issue)
         - alert: LonghornVolumeReadOnly
           expr: longhorn_volume_file_system_read_only == 1


### PR DESCRIPTION
## Summary
- Remove the `LonghornSnapshotSpaceWarning` PrometheusRule alert, which fires when any single snapshot exceeds 10 GiB
- The oldest snapshot in a Longhorn chain structurally absorbs accumulated deltas, making this a false positive for high-write-rate volumes (Prometheus TSDB)
- Space exhaustion is already monitored by volume-level (90%), node-level (70%), and pool-level (80%/90%) alerts

## Test plan
- [x] `task k8s:validate` passes
- [ ] No new alerts firing after merge (existing coverage unchanged)