### PR TITLE
fix(k8s): pin longhorn instance manager to hotfix image for memory leak

### DIFF
--- a/.github/version-holds.yaml
+++ b/.github/version-holds.yaml
@@ -9,3 +9,8 @@ holds:
     reason: "v3.41.x healthcheck regression blocks DNS queries to kube-dns after VPN tunnel establishment"
     upstream_issue: https://github.com/qdm12/gluetun/issues/3132
     created: "2026-02-18"
+  - dep: longhorn-instance-manager
+    constraint: n/a
+    reason: "v1.11.0 instance manager memory leak; using hotfix image override until v1.11.1+ includes the fix in chart defaults"
+    upstream_issue: https://github.com/longhorn/longhorn/issues/12573
+    created: "2026-03-03"

--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -1,5 +1,11 @@
 ---
 # https://raw.githubusercontent.com/longhorn/charts/master/charts/longhorn/values.yaml
+# Temporary instance manager image override for v1.11.0 memory leak hotfix
+# https://github.com/longhorn/longhorn/issues/12573
+image:
+  longhorn:
+    instanceManager:
+      tag: ${longhorn_instance_manager_tag}
 longhornManager:
   priorityClass: infrastructure-critical
 longhornDriver:

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -30,6 +30,8 @@ descheduler_version=0.35.0
 metrics_server_version=3.13.0
 # renovate: datasource=helm depName=longhorn registryUrl=https://charts.longhorn.io
 longhorn_version=1.11.0
+# renovate: datasource=docker depName=longhorn-instance-manager packageName=docker.io/longhornio/longhorn-instance-manager versioning=loose
+longhorn_instance_manager_tag=v1.11.0-hotfix-2
 # renovate: datasource=helm depName=reloader registryUrl=https://stakater.github.io/stakater-charts
 reloader_version=2.2.8
 # renovate: datasource=helm depName=kubernetes-replicator registryUrl=https://helm.mittwald.de


### PR DESCRIPTION
## Summary

- Longhorn v1.11.0 instance managers have a memory leak (~1-2.6 GiB/day) caused by Proxy connection leaks ([longhorn/longhorn#12573](https://github.com/longhorn/longhorn/issues/12573))
- Pins the instance manager image to `v1.11.0-hotfix-2` via Helm values override with Flux variable substitution
- Adds Renovate tracking with `versioning=loose` so future hotfixes (and the eventual v1.11.1) are auto-proposed
- Adds version-hold lifecycle entry so we get notified when the upstream fix ships and the override can be removed

## Test plan

- [x] `task k8s:validate` passes (all 33 charts templated, 137 ResourceSet + 555 Helm resources validated)
- [x] `task renovate:validate` passes
- [ ] After merge, verify instance managers restart with `v1.11.0-hotfix-2` image on integration
- [ ] Monitor instance manager memory usage stabilizes (no more linear growth)
- [ ] Verify `NodeMemoryHighUtilization` alert resolves on live after promotion