### PR TITLE
fix(k8s): escape Helm tpl delimiters in Homepage widget ConfigMap

### DIFF
--- a/kubernetes/clusters/live/charts/homepage.yaml
+++ b/kubernetes/clusters/live/charts/homepage.yaml
@@ -184,7 +184,7 @@ configMaps:
             cache: 15
         - healthchecks:
             url: https://healthchecks.io
-            key: "{{HOMEPAGE_VAR_HEALTHCHECKS_API_KEY}}"
+            key: "{{`{{HOMEPAGE_VAR_HEALTHCHECKS_API_KEY}}`}}"
       services.yaml: |
         - Gaming:
             - Minecraft:


### PR DESCRIPTION
## Summary
- Fix Homepage HelmRelease failure caused by `{{HOMEPAGE_VAR_HEALTHCHECKS_API_KEY}}` being interpreted as a Go template expression by app-template's `tpl` function
- Escape with backtick raw string syntax so the literal `{{...}}` passes through to Homepage's runtime variable resolver

## Test plan
- [x] `task k8s:validate` passes
- [ ] Homepage HelmRelease reconciles successfully after merge