### PR TITLE
fix(k8s): track longhorn v1.11.1 release issue for instance manager hold

### DIFF
--- a/.github/version-holds.yaml
+++ b/.github/version-holds.yaml
@@ -12,5 +12,5 @@ holds:
   - dep: longhorn-instance-manager
     constraint: n/a
     reason: "v1.11.0 instance manager memory leak; using hotfix image override until v1.11.1+ includes the fix in chart defaults"
-    upstream_issue: https://github.com/longhorn/longhorn/issues/12573
+    upstream_issue: https://github.com/longhorn/longhorn/issues/12705
     created: "2026-03-03"


### PR DESCRIPTION
## Summary
- The version-hold for `longhorn-instance-manager` pointed to the bug fix issue (#12573), which was already closed when the hold was created, causing the monitoring workflow to immediately open a false-positive cleanup issue (#585)
- Updated `upstream_issue` to track the v1.11.1 release issue (longhorn/longhorn#12705, due March 18) so the hold correctly resolves when the release ships
- Closed false-positive issue #585

## Test plan
- [x] `task k8s:validate` passes
- [x] `task renovate:validate` passes
- [ ] `check-version-holds` workflow no longer flags this hold as resolved