### PR TITLE
chore: allow file tools in project settings for sub-agent support

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,11 @@
 {
   "permissions": {
     "allow": [
+      "Read",
+      "Edit",
+      "Write",
+      "Glob",
+      "Grep",
       "WebSearch",
       "Bash(ls:*)",
       "Bash(tree:*)",


### PR DESCRIPTION
## Summary
- Add Read, Edit, Write, Glob, and Grep to the project `settings.json` permissions allow list
- Background sub-agents auto-deny any tool not pre-approved in the allow list, which blocked all file modification work when delegating to parallel agents
- The main session interactive review gate is unchanged — these tools still show diffs and can be rejected

## Test plan
- [x] Verified sub-agents can now use Edit/Write tools when dispatched with `bypassPermissions` mode
- [ ] Confirm interactive session still prompts for Edit approval on first use