### PR TITLE
fix(k8s): correct Homepage pod status selectors and game server DNS names

### DIFF
--- a/kubernetes/clusters/live/charts/homepage.yaml
+++ b/kubernetes/clusters/live/charts/homepage.yaml
@@ -193,7 +193,7 @@ configMaps:
                 widget:
                   type: gamedig
                   serverType: minecraft
-                  host: minecraft-game.minecraft.svc.cluster.local
+                  host: minecraft.minecraft.svc.cluster.local
                   port: 25565
             - Valheim:
                 icon: valheim.svg
@@ -201,7 +201,7 @@ configMaps:
                 widget:
                   type: gamedig
                   serverType: valheim
-                  host: valheim-game.valheim.svc.cluster.local
+                  host: valheim.valheim.svc.cluster.local
                   port: 2457
             - Satisfactory:
                 icon: satisfactory.svg
@@ -209,7 +209,7 @@ configMaps:
                 widget:
                   type: gamedig
                   serverType: satisfactory
-                  host: satisfactory-app.satisfactory.svc.cluster.local
+                  host: satisfactory.satisfactory.svc.cluster.local
                   port: 7777
             - Factorio:
                 icon: factorio.svg
@@ -217,7 +217,7 @@ configMaps:
                 widget:
                   type: gamedig
                   serverType: factorio
-                  host: factorio-game.factorio.svc.cluster.local
+                  host: factorio.factorio.svc.cluster.local
                   port: 34197
       bookmarks.yaml: |
         - Infrastructure:

--- a/kubernetes/clusters/live/config/ai/internal-route.yaml
+++ b/kubernetes/clusters/live/config/ai/internal-route.yaml
@@ -10,6 +10,7 @@ metadata:
     gethomepage.dev/name: "Open WebUI"
     gethomepage.dev/group: "AI"
     gethomepage.dev/icon: "open-webui.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=open-webui"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/authelia/internal-route.yaml
+++ b/kubernetes/clusters/live/config/authelia/internal-route.yaml
@@ -10,6 +10,7 @@ metadata:
     gethomepage.dev/name: "Authelia"
     gethomepage.dev/group: "Apps"
     gethomepage.dev/icon: "authelia.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=authelia"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/authelia/lldap-route.yaml
+++ b/kubernetes/clusters/live/config/authelia/lldap-route.yaml
@@ -10,6 +10,7 @@ metadata:
     gethomepage.dev/name: "LLDAP"
     gethomepage.dev/group: "Apps"
     gethomepage.dev/icon: "light-ldap.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=lldap"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/homepage/internal-route.yaml
+++ b/kubernetes/clusters/live/config/homepage/internal-route.yaml
@@ -10,6 +10,7 @@ metadata:
     gethomepage.dev/name: "Home"
     gethomepage.dev/group: "Platform"
     gethomepage.dev/icon: "homepage.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=homepage"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/immich/internal-route.yaml
+++ b/kubernetes/clusters/live/config/immich/internal-route.yaml
@@ -13,6 +13,7 @@ metadata:
     gethomepage.dev/widget.type: "immich"
     gethomepage.dev/widget.url: "http://immich-server.immich.svc:2283"
     gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_IMMICH_API_KEY}}"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=server"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/media/bazarr-internal.yaml
+++ b/kubernetes/clusters/live/config/media/bazarr-internal.yaml
@@ -13,6 +13,7 @@ metadata:
     gethomepage.dev/widget.type: "bazarr"
     gethomepage.dev/widget.url: "http://bazarr.media.svc:6767"
     gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_BAZARR_API_KEY}}"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=bazarr"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/media/jellyfin-internal.yaml
+++ b/kubernetes/clusters/live/config/media/jellyfin-internal.yaml
@@ -14,6 +14,7 @@ metadata:
     gethomepage.dev/widget.url: "http://jellyfin.media.svc:8096"
     gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_JELLYFIN_API_KEY}}"
     gethomepage.dev/widget.enableNowPlaying: "true"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=jellyfin"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/media/jellyseerr-internal.yaml
+++ b/kubernetes/clusters/live/config/media/jellyseerr-internal.yaml
@@ -13,6 +13,7 @@ metadata:
     gethomepage.dev/widget.type: "jellyseerr"
     gethomepage.dev/widget.url: "http://jellyseerr.media.svc:5055"
     gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_JELLYSEERR_API_KEY}}"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=jellyseerr"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/media/prowlarr-internal.yaml
+++ b/kubernetes/clusters/live/config/media/prowlarr-internal.yaml
@@ -13,6 +13,7 @@ metadata:
     gethomepage.dev/widget.type: "prowlarr"
     gethomepage.dev/widget.url: "http://prowlarr.media.svc:9696"
     gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_PROWLARR_API_KEY}}"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=prowlarr"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/media/qbittorrent-internal.yaml
+++ b/kubernetes/clusters/live/config/media/qbittorrent-internal.yaml
@@ -12,6 +12,7 @@ metadata:
     gethomepage.dev/icon: "qbittorrent.svg"
     gethomepage.dev/widget.type: "qbittorrent"
     gethomepage.dev/widget.url: "http://qbittorrent.media.svc:8080"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=qbittorrent"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/media/radarr-internal.yaml
+++ b/kubernetes/clusters/live/config/media/radarr-internal.yaml
@@ -13,6 +13,7 @@ metadata:
     gethomepage.dev/widget.type: "radarr"
     gethomepage.dev/widget.url: "http://radarr.media.svc:7878"
     gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_RADARR_API_KEY}}"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=radarr"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/media/sonarr-internal.yaml
+++ b/kubernetes/clusters/live/config/media/sonarr-internal.yaml
@@ -13,6 +13,7 @@ metadata:
     gethomepage.dev/widget.type: "sonarr"
     gethomepage.dev/widget.url: "http://sonarr.media.svc:8989"
     gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_SONARR_API_KEY}}"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=sonarr"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/media/tdarr-internal.yaml
+++ b/kubernetes/clusters/live/config/media/tdarr-internal.yaml
@@ -12,6 +12,7 @@ metadata:
     gethomepage.dev/icon: "tdarr.svg"
     gethomepage.dev/widget.type: "tdarr"
     gethomepage.dev/widget.url: "http://tdarr.media.svc:8265"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=tdarr"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/paperless/internal-route.yaml
+++ b/kubernetes/clusters/live/config/paperless/internal-route.yaml
@@ -13,6 +13,7 @@ metadata:
     gethomepage.dev/widget.type: "paperlessngx"
     gethomepage.dev/widget.url: "http://paperless.paperless.svc:8000"
     gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_PAPERLESS_API_KEY}}"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=paperless"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/tandoor/internal-route.yaml
+++ b/kubernetes/clusters/live/config/tandoor/internal-route.yaml
@@ -10,6 +10,7 @@ metadata:
     gethomepage.dev/name: "Tandoor"
     gethomepage.dev/group: "Apps"
     gethomepage.dev/icon: "tandoor.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=tandoor"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/vaultwarden/internal-route.yaml
+++ b/kubernetes/clusters/live/config/vaultwarden/internal-route.yaml
@@ -10,6 +10,7 @@ metadata:
     gethomepage.dev/name: "Vaultwarden"
     gethomepage.dev/group: "Apps"
     gethomepage.dev/icon: "vaultwarden.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=vaultwarden"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/zipline/internal-route.yaml
+++ b/kubernetes/clusters/live/config/zipline/internal-route.yaml
@@ -10,6 +10,7 @@ metadata:
     gethomepage.dev/name: "Zipline"
     gethomepage.dev/group: "Apps"
     gethomepage.dev/icon: "zipline.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=zipline"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/platform/config/cilium/hubble-route.yaml
+++ b/kubernetes/platform/config/cilium/hubble-route.yaml
@@ -9,6 +9,7 @@ metadata:
     gethomepage.dev/name: "Hubble"
     gethomepage.dev/group: "Platform"
     gethomepage.dev/icon: "cilium.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=hubble-ui"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/platform/config/garage/garage-route.yaml
+++ b/kubernetes/platform/config/garage/garage-route.yaml
@@ -9,6 +9,7 @@ metadata:
     gethomepage.dev/name: "Garage"
     gethomepage.dev/group: "Platform"
     gethomepage.dev/icon: "minio.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=garage"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/platform/config/kromgo/internal-route.yaml
+++ b/kubernetes/platform/config/kromgo/internal-route.yaml
@@ -9,6 +9,7 @@ metadata:
     gethomepage.dev/name: "Kromgo"
     gethomepage.dev/group: "Platform"
     gethomepage.dev/icon: "json.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=kromgo"
 spec:
   parentRefs:
     - name: internal


### PR DESCRIPTION
## Summary
- Add `gethomepage.dev/pod-selector` annotations to 20 HTTPRoutes so Homepage can find pods for status badges (routes named `*-internal` caused NOT FOUND because pods use labels without the suffix)
- Fix GameDig widget DNS names — services are `minecraft`, `valheim`, `satisfactory`, `factorio` (not `minecraft-game`, `valheim-game`, `satisfactory-app`, `factorio-game`)

## Test plan
- [ ] Homepage shows RUNNING/green status badges instead of NOT FOUND on all services
- [ ] Gaming section shows GameDig widget data instead of JSON parse errors
- [ ] `task k8s:validate` passes