### PR TITLE
fix(k8s): use regex versioning for longhorn instance manager Renovate tracking

### DIFF
--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -30,7 +30,7 @@ descheduler_version=0.35.0
 metrics_server_version=3.13.0
 # renovate: datasource=helm depName=longhorn registryUrl=https://charts.longhorn.io
 longhorn_version=1.11.0
-# renovate: datasource=docker depName=longhorn-instance-manager packageName=docker.io/longhornio/longhorn-instance-manager versioning=loose
+# renovate: datasource=docker depName=longhorn-instance-manager packageName=docker.io/longhornio/longhorn-instance-manager versioning=regex:^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-hotfix-(?<build>\d+))?$
 longhorn_instance_manager_tag=v1.11.0-hotfix-2
 # renovate: datasource=helm depName=reloader registryUrl=https://stakater.github.io/stakater-charts
 reloader_version=2.2.8


### PR DESCRIPTION
## Summary
- Replace `versioning=loose` with a strict regex for the longhorn-instance-manager Renovate annotation
- `versioning=loose` was too permissive, matching non-release Docker Hub tags like `v3_20221117-s390x` and architecture-specific suffixes (see PR #592)
- The regex `^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-hotfix-(?<build>\d+))?$` matches only legitimate release tags and orders hotfix versions correctly

## Test plan
- [x] `task k8s:validate` passes
- [x] `task renovate:validate` passes
- [ ] Verify Renovate dependency dashboard no longer proposes `v3_20221117-s390x` after merge