### PR TITLE
feat(infra): add velero-storage module for S3 backup infrastructure

### DIFF
--- a/infrastructure/CLAUDE.md
+++ b/infrastructure/CLAUDE.md
@@ -138,7 +138,8 @@ Infrastructure is organized into stacks with different lifecycles:
 - Each cluster has its own S3 bucket managed by the storage stack
 
 **Storage stack provisions:**
-- S3 buckets: `homelab-longhorn-backup-{dev,integration,live}`
+- S3 buckets: `homelab-longhorn-backup-{dev,integration,live}` (Longhorn)
+- S3 buckets: `homelab-velero-backup-{dev,integration,live}` (Velero, with 90-day lifecycle expiration)
 - IAM users with scoped access per cluster
 - SSM parameters for credential injection
 

--- a/infrastructure/modules/CLAUDE.md
+++ b/infrastructure/modules/CLAUDE.md
@@ -17,6 +17,7 @@ For architectural context (units vs modules), see [infrastructure/CLAUDE.md](../
 | `pki` | Certificate authority generation and SSM storage | tls, aws | ✅ 1 test |
 | `aws-set-params` | AWS SSM parameter storage | aws | ✅ 1 test |
 | `longhorn-storage` | S3 backup infrastructure for Longhorn volumes | aws | ❌ |
+| `velero-storage` | S3 backup infrastructure for Velero | aws | ✅ 3 tests |
 
 ---
 

--- a/infrastructure/modules/velero-storage/main.tf
+++ b/infrastructure/modules/velero-storage/main.tf
@@ -1,0 +1,144 @@
+# Velero backup storage infrastructure for all clusters
+# This module provisions S3 buckets, IAM users, and SSM parameters for each cluster.
+#
+# Separate from longhorn-storage because they have different lifecycles:
+# - Velero backups are self-contained snapshots safe for age-based expiration
+# - Longhorn backups are incremental and share blocks (cannot use S3 lifecycle)
+# - longhorn-storage will be deleted once Velero fully replaces Longhorn backups
+
+# S3 buckets - one per cluster
+resource "aws_s3_bucket" "velero_backup" {
+  for_each = var.clusters
+  bucket   = "homelab-velero-backup-${each.key}"
+
+  tags = {
+    managed-by = "opentofu"
+    purpose    = "velero-backup"
+    cluster    = each.key
+  }
+}
+
+resource "aws_s3_bucket_versioning" "velero_backup" {
+  for_each = var.clusters
+  bucket   = aws_s3_bucket.velero_backup[each.key].id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "velero_backup" {
+  for_each = var.clusters
+  bucket   = aws_s3_bucket.velero_backup[each.key].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "velero_backup" {
+  for_each = var.clusters
+  bucket   = aws_s3_bucket.velero_backup[each.key].id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Lifecycle rule - expire backups after 90 days
+# Unlike Longhorn, Velero backups are self-contained tarballs. Deleting old
+# objects does not corrupt newer backups, making age-based expiration safe.
+resource "aws_s3_bucket_lifecycle_configuration" "velero_backup" {
+  for_each = var.clusters
+  bucket   = aws_s3_bucket.velero_backup[each.key].id
+
+  rule {
+    id     = "expire-old-backups"
+    status = "Enabled"
+
+    expiration {
+      days = 90
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
+# IAM users - one per cluster for isolated access
+resource "aws_iam_user" "velero_backup" {
+  for_each = var.clusters
+  name     = "velero-backup-${each.key}"
+
+  tags = {
+    managed-by = "opentofu"
+    purpose    = "velero-backup"
+    cluster    = each.key
+  }
+}
+
+resource "aws_iam_access_key" "velero_backup" {
+  for_each = var.clusters
+  user     = aws_iam_user.velero_backup[each.key].name
+}
+
+resource "aws_iam_user_policy" "velero_backup" {
+  for_each = var.clusters
+  name     = "velero-backup-${each.key}"
+  user     = aws_iam_user.velero_backup[each.key].name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "VeleroBackupAccess"
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:DeleteObject"
+        ]
+        Resource = [
+          aws_s3_bucket.velero_backup[each.key].arn,
+          "${aws_s3_bucket.velero_backup[each.key].arn}/*"
+        ]
+      }
+    ]
+  })
+}
+
+# SSM Parameters - store credentials at paths expected by Kubernetes ExternalSecrets
+resource "aws_ssm_parameter" "access_key_id" {
+  for_each = var.clusters
+
+  name        = "/homelab/kubernetes/${each.key}/velero-s3-backup/access-key-id"
+  description = "AWS access key ID for Velero S3 backup in cluster '${each.key}'."
+  type        = "SecureString"
+  value       = aws_iam_access_key.velero_backup[each.key].id
+
+  tags = {
+    managed-by = "opentofu"
+    purpose    = "velero-backup"
+    cluster    = each.key
+  }
+}
+
+resource "aws_ssm_parameter" "secret_access_key" {
+  for_each = var.clusters
+
+  name        = "/homelab/kubernetes/${each.key}/velero-s3-backup/secret-access-key"
+  description = "AWS secret access key for Velero S3 backup in cluster '${each.key}'."
+  type        = "SecureString"
+  value       = aws_iam_access_key.velero_backup[each.key].secret
+
+  tags = {
+    managed-by = "opentofu"
+    purpose    = "velero-backup"
+    cluster    = each.key
+  }
+}

--- a/infrastructure/modules/velero-storage/outputs.tf
+++ b/infrastructure/modules/velero-storage/outputs.tf
@@ -1,0 +1,20 @@
+output "buckets" {
+  description = "Map of cluster name to bucket details"
+  value = {
+    for cluster in var.clusters : cluster => {
+      name   = aws_s3_bucket.velero_backup[cluster].id
+      arn    = aws_s3_bucket.velero_backup[cluster].arn
+      region = var.region
+    }
+  }
+}
+
+output "ssm_parameters" {
+  description = "Map of cluster name to SSM parameter paths"
+  value = {
+    for cluster in var.clusters : cluster => {
+      access_key_id     = aws_ssm_parameter.access_key_id[cluster].name
+      secret_access_key = aws_ssm_parameter.secret_access_key[cluster].name
+    }
+  }
+}

--- a/infrastructure/modules/velero-storage/providers.tf
+++ b/infrastructure/modules/velero-storage/providers.tf
@@ -1,0 +1,1 @@
+provider "aws" {}

--- a/infrastructure/modules/velero-storage/tests/plan.tftest.hcl
+++ b/infrastructure/modules/velero-storage/tests/plan.tftest.hcl
@@ -1,0 +1,71 @@
+# Plan tests for velero-storage module - validates S3 buckets, IAM users, and SSM parameters
+
+mock_provider "aws" {
+  alias = "mock"
+}
+
+run "creates_s3_buckets" {
+  command = plan
+  providers = {
+    aws = aws.mock
+  }
+
+  variables {
+    clusters = ["dev", "live"]
+    region   = "us-east-2"
+  }
+
+  assert {
+    condition     = aws_s3_bucket.velero_backup["dev"].bucket == "homelab-velero-backup-dev"
+    error_message = "Dev bucket name should match naming convention"
+  }
+
+  assert {
+    condition     = aws_s3_bucket.velero_backup["live"].bucket == "homelab-velero-backup-live"
+    error_message = "Live bucket name should match naming convention"
+  }
+}
+
+run "creates_iam_users" {
+  command = plan
+  providers = {
+    aws = aws.mock
+  }
+
+  variables {
+    clusters = ["dev"]
+    region   = "us-east-2"
+  }
+
+  assert {
+    condition     = aws_iam_user.velero_backup["dev"].name == "velero-backup-dev"
+    error_message = "IAM user name should match naming convention"
+  }
+}
+
+run "stores_credentials_in_ssm" {
+  command = plan
+  providers = {
+    aws = aws.mock
+  }
+
+  variables {
+    clusters = ["dev"]
+    region   = "us-east-2"
+  }
+
+  assert {
+    condition     = aws_ssm_parameter.access_key_id["dev"].name == "/homelab/kubernetes/dev/velero-s3-backup/access-key-id"
+    error_message = "SSM access key path should match convention"
+  }
+
+  assert {
+    condition     = aws_ssm_parameter.secret_access_key["dev"].name == "/homelab/kubernetes/dev/velero-s3-backup/secret-access-key"
+    error_message = "SSM secret key path should match convention"
+  }
+
+  assert {
+    condition     = aws_ssm_parameter.access_key_id["dev"].type == "SecureString"
+    error_message = "SSM parameters should be SecureString"
+  }
+}

--- a/infrastructure/modules/velero-storage/variables.tf
+++ b/infrastructure/modules/velero-storage/variables.tf
@@ -1,0 +1,10 @@
+variable "clusters" {
+  description = "Set of cluster names to provision backup infrastructure for"
+  type        = set(string)
+}
+
+variable "region" {
+  description = "AWS region for S3 buckets"
+  type        = string
+  default     = "us-east-2"
+}

--- a/infrastructure/modules/velero-storage/versions.tf
+++ b/infrastructure/modules/velero-storage/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.8.8"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.30.0"
+    }
+  }
+}

--- a/infrastructure/stacks/CLAUDE.md
+++ b/infrastructure/stacks/CLAUDE.md
@@ -10,7 +10,7 @@ For architecture context (units vs modules), see [infrastructure/CLAUDE.md](../C
 
 | Stack | Lifecycle | Purpose | Units |
 |-------|-----------|---------|-------|
-| `global` | **Persistent** | Cross-cluster infrastructure (S3 backups, PKI) | longhorn-storage, pki, ingress-pki |
+| `global` | **Persistent** | Cross-cluster infrastructure (S3 backups, PKI) | longhorn-storage, velero-storage, pki, ingress-pki |
 | `dev` | Ephemeral | Development cluster | config, unifi, talos, bootstrap, aws-set-params |
 | `integration` | Ephemeral | Integration/validation cluster | config, unifi, talos, bootstrap, aws-set-params |
 | `live` | Ephemeral | Production cluster | config, unifi, talos, bootstrap, aws-set-params |
@@ -64,6 +64,15 @@ locals {
 unit "longhorn_storage" {
   source = "../../units/longhorn-storage"
   path   = "longhorn-storage"
+
+  values = {
+    clusters = local.clusters
+  }
+}
+
+unit "velero_storage" {
+  source = "../../units/velero-storage"
+  path   = "velero-storage"
 
   values = {
     clusters = local.clusters

--- a/infrastructure/stacks/global/terragrunt.stack.hcl
+++ b/infrastructure/stacks/global/terragrunt.stack.hcl
@@ -15,6 +15,15 @@ unit "longhorn_storage" {
   }
 }
 
+unit "velero_storage" {
+  source = "../../units/velero-storage"
+  path   = "velero-storage"
+
+  values = {
+    clusters = local.clusters
+  }
+}
+
 unit "pki" {
   source = "../../units/pki"
   path   = "pki"

--- a/infrastructure/units/CLAUDE.md
+++ b/infrastructure/units/CLAUDE.md
@@ -17,7 +17,8 @@ For architectural context and the separation of concerns between units and modul
 | `aws-set-params` | `modules/aws-set-params` | Stores kubeconfig/talosconfig in AWS SSM | `config`, `talos` |
 | `pki` | `modules/pki` | Generates PKI certificates (Istio mesh CA) | None |
 | `ingress-pki` | `modules/pki` | Generates PKI certificates (ingress CA) | None |
-| `longhorn-storage` | `modules/longhorn-storage` | Provisions S3 backup buckets for all clusters | None |
+| `longhorn-storage` | `modules/longhorn-storage` | Provisions S3 backup buckets for all clusters (Longhorn) | None |
+| `velero-storage` | `modules/velero-storage` | Provisions S3 backup buckets for all clusters (Velero) | None |
 
 ---
 

--- a/infrastructure/units/velero-storage/terragrunt.hcl
+++ b/infrastructure/units/velero-storage/terragrunt.hcl
@@ -1,0 +1,12 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../../.././/modules/velero-storage"
+}
+
+inputs = {
+  clusters = values.clusters
+  region   = "us-east-2"
+}


### PR DESCRIPTION
## Summary
- Add `velero-storage` OpenTofu module provisioning per-cluster S3 buckets, IAM users, and SSM parameters for Velero backup storage
- Separate from `longhorn-storage` to enable independent lifecycle management during migration from Longhorn-native to Velero-managed backups
- 90-day S3 lifecycle expiration (unlike Longhorn's incremental backups, Velero backups are self-contained)

Part of the Velero backup platform migration (project/velero-backup). Resolves Phase 0 prerequisites — requires `task tg:apply-global` after merge.

## Test plan
- [x] `task tg:fmt` — no formatting changes needed
- [x] `task tg:test-velero-storage` — 3/3 tests pass (bucket naming, IAM users, SSM paths)
- [x] `task tg:validate-global` — 5/5 units validate successfully
- [ ] `task tg:plan-global` — review plan output before apply
- [ ] `task tg:apply-global` — human-approved apply after merge