### PR TITLE
fix(k8s): add restricted PSS security contexts to Velero chart

### DIFF
--- a/kubernetes/platform/charts/velero.yaml
+++ b/kubernetes/platform/charts/velero.yaml
@@ -6,6 +6,15 @@ initContainers:
     # renovate: datasource=docker depName=velero/velero-plugin-for-aws
     image: velero/velero-plugin-for-aws:v1.13.2
     imagePullPolicy: IfNotPresent
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 65534
+      seccompProfile:
+        type: RuntimeDefault
     volumeMounts:
       - mountPath: /target
         name: plugins
@@ -52,6 +61,25 @@ containerSecurityContext:
   runAsUser: 65534
   seccompProfile:
     type: RuntimeDefault
+
+kubectl:
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 65534
+    seccompProfile:
+      type: RuntimeDefault
+
+upgradeCRDsJob:
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
 
 metrics:
   enabled: true


### PR DESCRIPTION
## Summary
- Velero's upgrade-crds Job and AWS plugin init container ship without security contexts, causing PodSecurity admission rejection in the `restricted` velero namespace
- Adds compliant contexts to all three gaps: init container (raw YAML passthrough), kubectl container (`kubectl.containerSecurityContext`), and upgrade Job pod (`upgradeCRDsJob.podSecurityContext`)

## Test plan
- [ ] `task k8s:validate` passes (verified locally)
- [ ] `helm template` confirms all containers in the upgrade-crds Job and Deployment have restricted-compliant security contexts
- [ ] Velero HelmRelease reconciles successfully on dev cluster
- [ ] `velero backup-location get` shows BSL Available