### PR TITLE
fix(k8s): pin Velero kubectl image to last published bitnamilegacy tag

### DIFF
--- a/kubernetes/platform/charts/velero.yaml
+++ b/kubernetes/platform/charts/velero.yaml
@@ -63,6 +63,11 @@ containerSecurityContext:
     type: RuntimeDefault
 
 kubectl:
+  # Pin to last published bitnamilegacy tag -- upstream dropped kubectl images for K8s >= 1.34
+  # https://github.com/vmware-tanzu/helm-charts/issues/698
+  image:
+    repository: docker.io/bitnamilegacy/kubectl
+    tag: "1.33"
   containerSecurityContext:
     allowPrivilegeEscalation: false
     capabilities:


### PR DESCRIPTION
## Summary
- The Velero chart auto-detects kubectl image tag from cluster K8s version (1.35), but `bitnamilegacy/kubectl` stopped publishing at 1.33
- Pins to `bitnamilegacy/kubectl:1.33` which is within kubectl's ±1 minor version skew policy
- Upstream tracking: https://github.com/vmware-tanzu/helm-charts/issues/698

## Test plan
- [ ] `task k8s:validate` passes
- [ ] `velero-upgrade-crds` Job pod starts (no `ErrImagePull`)
- [ ] Velero HelmRelease reconciles successfully on dev