### PR TITLE
fix(k8s): remove duplicate oauth2-proxy env var injection

### DIFF
--- a/kubernetes/platform/charts/oauth2-proxy.yaml
+++ b/kubernetes/platform/charts/oauth2-proxy.yaml
@@ -7,9 +7,7 @@ podAnnotations:
   reloader.stakater.com/auto: "true"
 
 config:
-  clientID: "override-me"
-  clientSecret: "override-me"
-  cookieSecret: "override-me"
+  proxyVarsAsSecrets: false
   configFile: |
     provider = "github"
     github_users = ["ionfury"]


### PR DESCRIPTION
## Summary
- Disable the chart's built-in `proxyVarsAsSecrets` mechanism which was generating env vars from dummy placeholder values, conflicting with the `extraEnv` entries that reference the actual ExternalSecrets

## Test plan
- [ ] `task k8s:validate` passes
- [ ] On dev: oauth2-proxy pods start without duplicate env var warnings
- [ ] On dev: OAuth login flow works end-to-end