### PR TITLE
feat(k8s): add Velero backup observability

### DIFF
--- a/kubernetes/platform/config/monitoring/kustomization.yaml
+++ b/kubernetes/platform/config/monitoring/kustomization.yaml
@@ -38,4 +38,6 @@ resources:
   - power-accounting-dashboard.yaml
   - hardware-health-dashboard.yaml
   - gpu-monitoring-alerts.yaml
+  - velero-alerts.yaml
+  - velero-dashboard.yaml
   - platform-home-dashboard.yaml

--- a/kubernetes/platform/config/monitoring/velero-alerts.yaml
+++ b/kubernetes/platform/config/monitoring/velero-alerts.yaml
@@ -1,0 +1,130 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: velero-alerts
+  labels:
+    app.kubernetes.io/name: velero
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: velero.backup
+      rules:
+        - alert: VeleroBackupStale
+          expr: |
+            (time() - velero_backup_last_successful_timestamp{schedule!=""}) > 108000
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Velero backup stale for schedule {{ $labels.schedule }}"
+            description: >-
+              No successful backup for schedule {{ $labels.schedule }} in the last
+              30 hours ({{ $value | humanizeDuration }}). Weekly schedules run at 02:00
+              on Sundays -- 30h buffer accounts for execution time and retry windows.
+              Check Velero logs and backup storage location connectivity.
+
+        - alert: VeleroBackupFailure
+          expr: |
+            increase(velero_backup_failure_total{schedule!=""}[1h]) > 0
+          for: 0m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Velero backup failed for schedule {{ $labels.schedule }}"
+            description: >-
+              A backup for schedule {{ $labels.schedule }} has failed in the last hour.
+              Run `velero backup describe --details` to investigate the failure reason.
+
+        - alert: VeleroBackupPartialFailure
+          expr: |
+            increase(velero_backup_partial_failure_total{schedule!=""}[1h]) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Velero backup partially failed for schedule {{ $labels.schedule }}"
+            description: >-
+              A backup for schedule {{ $labels.schedule }} completed with partial failures.
+              Some resources may not have been captured. Run `velero backup describe --details`
+              to identify which items failed.
+
+        - alert: VeleroBackupValidationFailure
+          expr: |
+            increase(velero_backup_validation_failure_total{schedule!=""}[1h]) > 0
+          for: 0m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Velero backup validation failed for schedule {{ $labels.schedule }}"
+            description: >-
+              A backup for schedule {{ $labels.schedule }} failed validation in the last hour.
+              The backup spec is malformed. Check the Schedule CR definition and Velero logs.
+
+    - name: velero.storage
+      rules:
+        - alert: VeleroBackupStorageLocationUnavailable
+          expr: |
+            velero_backup_location_status_gauge == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Velero BSL {{ $labels.backup_location_name }} is unavailable"
+            description: >-
+              Backup storage location {{ $labels.backup_location_name }} has been unavailable
+              for 5+ minutes. Backups cannot be created or restored. Check S3 endpoint
+              connectivity, credentials (velero-s3-credentials secret), and bucket existence.
+
+    - name: velero.restore
+      rules:
+        - alert: VeleroRestoreFailure
+          expr: |
+            increase(velero_restore_failed_total[1h]) > 0
+          for: 0m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Velero restore failed for schedule {{ $labels.schedule }}"
+            description: >-
+              A restore operation has failed in the last hour. Data may not have been
+              recovered. Check `velero restore describe --details` for failure details.
+
+        - alert: VeleroRestorePartialFailure
+          expr: |
+            increase(velero_restore_partial_failure_total[1h]) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Velero restore partially failed for schedule {{ $labels.schedule }}"
+            description: >-
+              A restore operation completed with partial failures. Some resources may
+              not have been restored. Check `velero restore describe --details`.
+
+    - name: velero.backup-size
+      rules:
+        - alert: VeleroBackupSizeAnomaly
+          expr: |
+            (
+              velero_backup_tarball_size_bytes{schedule!=""}
+              /
+              avg_over_time(velero_backup_tarball_size_bytes{schedule!=""}[7d])
+            ) > 3
+            or
+            (
+              velero_backup_tarball_size_bytes{schedule!=""}
+              /
+              avg_over_time(velero_backup_tarball_size_bytes{schedule!=""}[7d])
+            ) < 0.1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Velero backup size anomaly for schedule {{ $labels.schedule }}"
+            description: >-
+              Backup tarball size for schedule {{ $labels.schedule }} is
+              {{ printf "%.1f" $value }}x the 7-day average. A sudden increase may
+              indicate unexpected data growth; a sudden decrease may indicate missing
+              resources. Investigate with `velero backup describe`.

--- a/kubernetes/platform/config/monitoring/velero-dashboard.yaml
+++ b/kubernetes/platform/config/monitoring/velero-dashboard.yaml
@@ -1,0 +1,720 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-velero
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "true"
+  annotations:
+    grafana_folder: "Backup"
+data:
+  velero.json: |-
+    {
+      "annotations": { "list": [] },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+          "id": 10,
+          "title": "Backup Overview",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Current availability of each backup storage location. 1 = Available, 0 = Unavailable. Triggers VeleroBackupStorageLocationUnavailable alert when 0.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "green", "value": 1 }
+                ]
+              },
+              "mappings": [
+                {
+                  "type": "value",
+                  "options": {
+                    "0": { "text": "UNAVAILABLE", "color": "red" },
+                    "1": { "text": "AVAILABLE", "color": "green" }
+                  }
+                }
+              ],
+              "noValue": "N/A"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+          "id": 11,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": ["lastNotNull"],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "velero_backup_location_status_gauge",
+              "legendFormat": "{{ backup_location_name }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Backup Storage Location",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Total number of successful backups across all schedules.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null }
+                ]
+              },
+              "noValue": "0"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+          "id": 12,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": ["lastNotNull"],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "sum(velero_backup_success_total)",
+              "legendFormat": "Successes",
+              "refId": "A"
+            }
+          ],
+          "title": "Total Successful Backups",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Total number of failed backups across all schedules. Any value above 0 is concerning.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "red", "value": 1 }
+                ]
+              },
+              "noValue": "0"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+          "id": 13,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": ["lastNotNull"],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "sum(velero_backup_failure_total) + sum(velero_backup_partial_failure_total)",
+              "legendFormat": "Failures",
+              "refId": "A"
+            }
+          ],
+          "title": "Total Backup Failures",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Total number of successful restores. Useful for tracking disaster recovery exercises.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null }
+                ]
+              },
+              "noValue": "0"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+          "id": 14,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": ["lastNotNull"],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "sum(velero_restore_success_total) or vector(0)",
+              "legendFormat": "Restores",
+              "refId": "A"
+            }
+          ],
+          "title": "Total Successful Restores",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+          "id": 20,
+          "title": "Schedule Health",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Time since last successful backup per schedule. Above 30h triggers VeleroBackupStale alert. Weekly schedules run at 02:00 on Sundays.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "noValue": "Never backed up",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 86400 },
+                  { "color": "red", "value": 108000 }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 5, "w": 12, "x": 0, "y": 6 },
+          "id": 21,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": ["lastNotNull"],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "time() - velero_backup_last_successful_timestamp{schedule!=\"\"}",
+              "legendFormat": "{{ schedule }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Last Successful Backup Age",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Last backup status per schedule. 1=New, 2=FailedValidation, 3=InProgress, 4=WaitingForPluginOperations, 5=WaitingForPluginOperationsPartiallyFailed, 6=Finalizing, 7=FinalizingPartiallyFailed, 8=Completed, 9=PartiallyFailed, 10=Failed, 11=Deleting.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "noValue": "N/A",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "blue", "value": 1 },
+                  { "color": "orange", "value": 3 },
+                  { "color": "green", "value": 8 },
+                  { "color": "orange", "value": 9 },
+                  { "color": "red", "value": 10 }
+                ]
+              },
+              "mappings": [
+                {
+                  "type": "value",
+                  "options": {
+                    "1": { "text": "New", "color": "blue" },
+                    "2": { "text": "FailedValidation", "color": "red" },
+                    "3": { "text": "InProgress", "color": "blue" },
+                    "4": { "text": "WaitingPluginOps", "color": "blue" },
+                    "5": { "text": "WaitPluginPartial", "color": "orange" },
+                    "6": { "text": "Finalizing", "color": "blue" },
+                    "7": { "text": "FinalizingPartial", "color": "orange" },
+                    "8": { "text": "Completed", "color": "green" },
+                    "9": { "text": "PartiallyFailed", "color": "orange" },
+                    "10": { "text": "Failed", "color": "red" },
+                    "11": { "text": "Deleting", "color": "blue" }
+                  }
+                }
+              ]
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 5, "w": 12, "x": 12, "y": 6 },
+          "id": 22,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": ["lastNotNull"],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "velero_backup_last_status{schedule!=\"\"}",
+              "legendFormat": "{{ schedule }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Last Backup Status",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 11 },
+          "id": 30,
+          "title": "Backup Operations",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Rate of backup attempts, successes, and failures per schedule over time.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "scheme",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": { "id": "byRegexp", "options": ".*fail.*|.*Fail.*" },
+                "properties": [
+                  { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+                ]
+              },
+              {
+                "matcher": { "id": "byRegexp", "options": ".*success.*|.*Success.*" },
+                "properties": [
+                  { "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }
+                ]
+              }
+            ]
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+          "id": 31,
+          "options": {
+            "legend": {
+              "calcs": ["sum"],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "increase(velero_backup_success_total{schedule!=\"\"}[24h])",
+              "legendFormat": "{{ schedule }} success",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "increase(velero_backup_failure_total{schedule!=\"\"}[24h])",
+              "legendFormat": "{{ schedule }} failure",
+              "refId": "B"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "increase(velero_backup_partial_failure_total{schedule!=\"\"}[24h])",
+              "legendFormat": "{{ schedule }} partial failure",
+              "refId": "C"
+            }
+          ],
+          "title": "Backup Results (24h rolling)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Backup duration histogram showing p50 and p99 durations per schedule.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "scheme",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+          "id": 32,
+          "options": {
+            "legend": {
+              "calcs": ["mean", "max"],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "histogram_quantile(0.50, sum(rate(velero_backup_duration_seconds_bucket{schedule!=\"\"}[24h])) by (le, schedule))",
+              "legendFormat": "{{ schedule }} p50",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "histogram_quantile(0.99, sum(rate(velero_backup_duration_seconds_bucket{schedule!=\"\"}[24h])) by (le, schedule))",
+              "legendFormat": "{{ schedule }} p99",
+              "refId": "B"
+            }
+          ],
+          "title": "Backup Duration",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 20 },
+          "id": 40,
+          "title": "Backup Sizes",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Current backup tarball size per schedule. Sudden changes may indicate missing resources or unexpected data growth. Triggers VeleroBackupSizeAnomaly alert at 3x or 0.1x the 7-day average.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "scheme",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 21 },
+          "id": 41,
+          "options": {
+            "legend": {
+              "calcs": ["mean", "lastNotNull"],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "velero_backup_tarball_size_bytes{schedule!=\"\"}",
+              "legendFormat": "{{ schedule }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Backup Tarball Size Over Time",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 29 },
+          "id": 50,
+          "title": "Restore Operations",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Rate of restore operations over time -- successes, partial failures, and failures.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "scheme",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": { "id": "byRegexp", "options": ".*fail.*|.*Fail.*" },
+                "properties": [
+                  { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+                ]
+              },
+              {
+                "matcher": { "id": "byRegexp", "options": ".*success.*|.*Success.*" },
+                "properties": [
+                  { "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }
+                ]
+              }
+            ]
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 30 },
+          "id": 51,
+          "options": {
+            "legend": {
+              "calcs": ["sum"],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "increase(velero_restore_success_total[24h])",
+              "legendFormat": "{{ schedule }} success",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "increase(velero_restore_failed_total[24h])",
+              "legendFormat": "{{ schedule }} failure",
+              "refId": "B"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "increase(velero_restore_partial_failure_total[24h])",
+              "legendFormat": "{{ schedule }} partial failure",
+              "refId": "C"
+            }
+          ],
+          "title": "Restore Results (24h rolling)",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 38 },
+          "id": 60,
+          "title": "Volume Snapshots",
+          "type": "row"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "CSI volume snapshot operations over time. Failures indicate storage driver issues or quota exhaustion.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "scheme",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": { "id": "byRegexp", "options": ".*fail.*|.*Fail.*" },
+                "properties": [
+                  { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+                ]
+              },
+              {
+                "matcher": { "id": "byRegexp", "options": ".*success.*|.*Success.*" },
+                "properties": [
+                  { "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }
+                ]
+              }
+            ]
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 39 },
+          "id": 61,
+          "options": {
+            "legend": {
+              "calcs": ["sum"],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "increase(velero_csi_snapshot_success_total{schedule!=\"\"}[24h])",
+              "legendFormat": "{{ schedule }} success",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "increase(velero_csi_snapshot_failure_total{schedule!=\"\"}[24h])",
+              "legendFormat": "{{ schedule }} failure",
+              "refId": "B"
+            }
+          ],
+          "title": "CSI Snapshot Results (24h rolling)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Data upload (backup) and download (restore) operations on nodes. Failures indicate node agent issues.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "scheme",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": { "id": "byRegexp", "options": ".*fail.*|.*Fail.*" },
+                "properties": [
+                  { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+                ]
+              },
+              {
+                "matcher": { "id": "byRegexp", "options": ".*success.*|.*Success.*" },
+                "properties": [
+                  { "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }
+                ]
+              }
+            ]
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 39 },
+          "id": 62,
+          "options": {
+            "legend": {
+              "calcs": ["sum"],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "increase(velero_data_upload_success_total[24h])",
+              "legendFormat": "{{ node }} upload success",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "increase(velero_data_upload_failure_total[24h])",
+              "legendFormat": "{{ node }} upload failure",
+              "refId": "B"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "increase(velero_data_download_success_total[24h])",
+              "legendFormat": "{{ node }} download success",
+              "refId": "C"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "increase(velero_data_download_failure_total[24h])",
+              "legendFormat": "{{ node }} download failure",
+              "refId": "D"
+            }
+          ],
+          "title": "Node Data Transfer Operations (24h rolling)",
+          "type": "timeseries"
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": ["backup", "velero", "data-protection"],
+      "templating": { "list": [] },
+      "time": { "from": "now-7d", "to": "now" },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Velero Backup Health",
+      "uid": "velero",
+      "version": 1
+    }


### PR DESCRIPTION
## Summary
- Wire Velero's Prometheus metrics into the monitoring stack with 8 alert rules covering backup staleness, failures, BSL unavailability, restore failures, and size anomalies
- Add a Grafana dashboard in the Backup folder for at-a-glance backup health: schedule status, backup ages, sizes over time, restore history, and CSI snapshot operations
- ServiceMonitor was already enabled in the Velero Helm values -- no chart changes needed

Closes #608

## Test plan
- [ ] `task k8s:validate` passes (verified locally)
- [ ] Velero metrics visible in Prometheus (`velero_*` metrics present after deployment)
- [ ] PrometheusRule loaded by Prometheus (check `/api/v1/rules` for `velero.backup` group)
- [ ] Alerts fire when: backup age exceeds 30h threshold, backup fails, BSL unavailable
- [ ] Alerts resolve when conditions clear
- [ ] Grafana dashboard appears in Backup folder and renders panels
- [ ] No new alerts firing under normal operation (zero-alert baseline maintained)