### PR TITLE
fix(k8s): move proxyVarsAsSecrets to top-level in oauth2-proxy values

### DIFF
--- a/kubernetes/platform/charts/oauth2-proxy.yaml
+++ b/kubernetes/platform/charts/oauth2-proxy.yaml
@@ -6,8 +6,9 @@ priorityClassName: platform
 podAnnotations:
   reloader.stakater.com/auto: "true"
 
+proxyVarsAsSecrets: false
+
 config:
-  proxyVarsAsSecrets: false
   configFile: |
     provider = "github"
     github_users = ["ionfury"]


### PR DESCRIPTION
## Summary
- Fix oauth2-proxy HelmRelease failure caused by `proxyVarsAsSecrets: false` being incorrectly nested under `config:` instead of being a top-level key
- At the wrong nesting level, the chart ignored it, defaulted to `true`, and generated duplicate env vars (`OAUTH2_PROXY_CLIENT_ID`, `CLIENT_SECRET`, `COOKIE_SECRET`) that conflicted with `extraEnv`

## Test plan
- [x] Validated with `task k8s:validate` (all 35 charts templated successfully)
- [ ] oauth2-proxy HelmRelease reconciles without duplicate env var errors on dev/integration