### PR TITLE
fix(k8s): use hex encoding for all secret-generator secrets

### DIFF
--- a/kubernetes/clusters/live/config/paperless/paperless-secret.yaml
+++ b/kubernetes/clusters/live/config/paperless/paperless-secret.yaml
@@ -7,5 +7,5 @@ metadata:
   annotations:
     secret-generator.v1.mittwald.de/autogenerate: secret-key
     secret-generator.v1.mittwald.de/length: "64"
-    secret-generator.v1.mittwald.de/encoding: base64
+    secret-generator.v1.mittwald.de/encoding: hex
 data: { }

--- a/kubernetes/clusters/live/config/vaultwarden/vaultwarden-admin-token.yaml
+++ b/kubernetes/clusters/live/config/vaultwarden/vaultwarden-admin-token.yaml
@@ -7,5 +7,5 @@ metadata:
   annotations:
     secret-generator.v1.mittwald.de/autogenerate: ADMIN_TOKEN
     secret-generator.v1.mittwald.de/length: "48"
-    secret-generator.v1.mittwald.de/encoding: base64
+    secret-generator.v1.mittwald.de/encoding: hex
 data: { }

--- a/kubernetes/clusters/live/config/zipline/secret.yaml
+++ b/kubernetes/clusters/live/config/zipline/secret.yaml
@@ -7,5 +7,5 @@ metadata:
   annotations:
     secret-generator.v1.mittwald.de/autogenerate: CORE_SECRET
     secret-generator.v1.mittwald.de/length: "32"
-    secret-generator.v1.mittwald.de/encoding: base64
+    secret-generator.v1.mittwald.de/encoding: hex
 data: { }

--- a/kubernetes/platform/config/database/superuser-secret.yaml
+++ b/kubernetes/platform/config/database/superuser-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     secret-generator.v1.mittwald.de/autogenerate: password
     secret-generator.v1.mittwald.de/length: "32"
-    secret-generator.v1.mittwald.de/encoding: base64
+    secret-generator.v1.mittwald.de/encoding: hex
 type: kubernetes.io/basic-auth
 stringData:
   username: postgres

--- a/kubernetes/platform/config/dragonfly/password-secret.yaml
+++ b/kubernetes/platform/config/dragonfly/password-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     secret-generator.v1.mittwald.de/autogenerate: password
     secret-generator.v1.mittwald.de/length: "32"
-    secret-generator.v1.mittwald.de/encoding: base64
+    secret-generator.v1.mittwald.de/encoding: hex
     replicator.v1.mittwald.de/replication-allowed: "true"
     replicator.v1.mittwald.de/replication-allowed-namespaces: "ai,immich,authelia,paperless"
 type: Opaque


### PR DESCRIPTION
## Summary
- Change `encoding: base64` to `encoding: hex` on all 5 remaining secret-generator secrets
- base64 encoding produces URL-unsafe characters (`+`, `/`, `=`) that break Redis connection strings -- the `+` in Dragonfly passwords gets misinterpreted as a port separator, causing CrashLoopBackOff on open-webui and paperless
- All other secret-generator secrets in the repo already use `hex` encoding

## Post-merge action
Delete the affected secrets from each cluster so secret-generator regenerates them with the new encoding:

```bash
# Platform secrets (all clusters)
kubectl delete secret dragonfly-password -n database
kubectl delete secret cnpg-platform-superuser -n database

# Live cluster app secrets
KUBECONFIG=~/.kube/live.yaml kubectl delete secret paperless-secret -n paperless
KUBECONFIG=~/.kube/live.yaml kubectl delete secret zipline-secret -n zipline
KUBECONFIG=~/.kube/live.yaml kubectl delete secret vaultwarden-admin-token -n vaultwarden
```

## Test plan
- [x] Validated with `task k8s:validate` (0 invalid, 0 errors)
- [ ] After merge, verify secrets are regenerated with hex-only characters (0-9, a-f)
- [ ] Verify open-webui and paperless pods recover from CrashLoopBackOff
- [ ] Verify Dragonfly password no longer contains `+`, `/`, or `=`