### PR TITLE
docs(claude): migrate cluster access from KUBECONFIG=~/ to --context pattern

### DIFF
--- a/.claude/skills/cnpg-database/scripts/check-connection.sh
+++ b/.claude/skills/cnpg-database/scripts/check-connection.sh
@@ -11,27 +11,27 @@ CLUSTER="${1:?Usage: check-connection.sh <cluster-name> <app-namespace> [app-nam
 APP_NS="${2:?Usage: check-connection.sh <cluster-name> <app-namespace> [app-name]}"
 APP_NAME="${3:-}"
 
-KUBECONFIG=~/.kube/"${CLUSTER}".yaml
+CONTEXT="${CLUSTER}"
 
 echo "=== CNPG Cluster Status ==="
-KUBECONFIG="${KUBECONFIG}" kubectl get clusters.postgresql.cnpg.io -n database
+kubectl --context "${CONTEXT}" get clusters.postgresql.cnpg.io -n database
 
 echo ""
 echo "=== Database Pods ==="
-KUBECONFIG="${KUBECONFIG}" kubectl get pods -n database -l cnpg.io/cluster=platform
+kubectl --context "${CONTEXT}" get pods -n database -l cnpg.io/cluster=platform
 
 echo ""
 echo "=== Managed Databases ==="
-KUBECONFIG="${KUBECONFIG}" kubectl get databases.postgresql.cnpg.io -n database
+kubectl --context "${CONTEXT}" get databases.postgresql.cnpg.io -n database
 
 echo ""
 echo "=== Pooler Status ==="
-KUBECONFIG="${KUBECONFIG}" kubectl get poolers.postgresql.cnpg.io -n database
+kubectl --context "${CONTEXT}" get poolers.postgresql.cnpg.io -n database
 
 if [[ -n "${APP_NAME}" ]]; then
   echo ""
   echo "=== Credential Secret in App Namespace (${APP_NS}) ==="
-  KUBECONFIG="${KUBECONFIG}" kubectl get secret "${APP_NAME}-db-credentials" -n "${APP_NS}" \
+  kubectl --context "${CONTEXT}" get secret "${APP_NAME}-db-credentials" -n "${APP_NS}" \
     -o jsonpath='{.data.username}' | base64 -d && echo " (username decoded)"
 
   echo ""
@@ -40,7 +40,7 @@ if [[ -n "${APP_NAME}" ]]; then
 
   echo ""
   echo "=== Test Connection (psql debug pod) ==="
-  echo "Run: KUBECONFIG=${KUBECONFIG} kubectl run -n ${APP_NS} pg-test --rm -it \\"
+  echo "Run: kubectl --context ${CONTEXT} run -n ${APP_NS} pg-test --rm -it \\"
   echo "  --image=postgres:17 -- psql \"postgresql://<user>:<pass>@platform-pooler-rw.database.svc:5432/<dbname>\""
 fi
 

--- a/.claude/skills/deploy-app/SKILL.md
+++ b/.claude/skills/deploy-app/SKILL.md
@@ -193,12 +193,12 @@ The dev cluster is a sandbox — iterate freely.
 **Deploy directly** (suspend Flux first if needed: `task k8s:flux-suspend -- <kustomization-name>`):
 
 ```bash
-KUBECONFIG=~/.kube/dev.yaml helm install <app-name> <repo>/<chart> \
+helm install <app-name> <repo>/<chart> \
   -n <namespace> --create-namespace \
   -f kubernetes/platform/charts/<app-name>.yaml \
   --version <version>
 
-KUBECONFIG=~/.kube/dev.yaml kubectl -n <namespace> \
+kubectl -n <namespace> \
   wait --for=condition=Ready pod -l app.kubernetes.io/name=<app-name> --timeout=300s
 ```
 
@@ -207,7 +207,7 @@ For OCI charts, use `oci://registry/<path>/<chart>`. For iteration, use `helm up
 **Verify network connectivity** (CRITICAL — network policies are enforced):
 
 ```bash
-KUBECONFIG=~/.kube/dev.yaml kubectl port-forward -n kube-system svc/hubble-relay 4245:80 &
+kubectl port-forward -n kube-system svc/hubble-relay 4245:80 &
 hubble observe --verdict DROPPED --namespace <namespace> --since 5m
 hubble observe --from-namespace istio-gateway --to-namespace <namespace> --since 2m
 hubble observe --from-namespace <namespace> --to-namespace database --since 2m
@@ -233,7 +233,7 @@ Iterate until all checks pass. AskUserQuestion to report status and confirm proc
 Uninstall direct helm install → reconcile via Flux → validate clean convergence:
 
 ```bash
-KUBECONFIG=~/.kube/dev.yaml helm uninstall <app-name> -n <namespace>
+helm uninstall <app-name> -n <namespace>
 task k8s:reconcile-validate
 ```
 

--- a/.claude/skills/deploy-app/scripts/check-canary.sh
+++ b/.claude/skills/deploy-app/scripts/check-canary.sh
@@ -13,8 +13,7 @@ if [[ -z "$APP_NAME" ]]; then
     exit 1
 fi
 
-KUBECONFIG="${KUBECONFIG:-$HOME/.kube/dev.yaml}"
-export KUBECONFIG
+CONTEXT="${CONTEXT:-dev}"
 
 echo "=== Canary Health Check: $APP_NAME ==="
 echo ""

--- a/.claude/skills/deploy-app/scripts/check-deployment-health.sh
+++ b/.claude/skills/deploy-app/scripts/check-deployment-health.sh
@@ -14,8 +14,7 @@ if [[ -z "$NAMESPACE" || -z "$APP_NAME" ]]; then
     exit 1
 fi
 
-KUBECONFIG="${KUBECONFIG:-$HOME/.kube/dev.yaml}"
-export KUBECONFIG
+CONTEXT="${CONTEXT:-dev}"
 
 echo "=== Deployment Health Check: $APP_NAME in $NAMESPACE ==="
 echo ""

--- a/.claude/skills/gateway-routing/SKILL.md
+++ b/.claude/skills/gateway-routing/SKILL.md
@@ -91,7 +91,7 @@ The WAF runs as an Istio WasmPlugin on the external gateway with OWASP CRS at Pa
 **Testing WAF endpoints** — Istio matches on SNI, so raw IP requests are rejected. Use `--resolve`:
 
 ```bash
-GATEWAY_IP=$(KUBECONFIG=~/.kube/<cluster>.yaml kubectl get gateway external -n istio-gateway -o jsonpath='{.metadata.annotations.lbipam\.cilium\.io/ips}')
+GATEWAY_IP=$(kubectl --context <cluster> get gateway external -n istio-gateway -o jsonpath='{.metadata.annotations.lbipam\.cilium\.io/ips}')
 curl -kI --resolve "app.${external_domain}:443:${GATEWAY_IP}" "https://app.${external_domain}/"
 ```
 

--- a/.claude/skills/gateway-routing/scripts/validate-tls.sh
+++ b/.claude/skills/gateway-routing/scripts/validate-tls.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Usage: CLUSTER=live ./validate-tls.sh [gateway-name]
 # Validates TLS certificate status for the given gateway (default: external).
-# Requires CLUSTER env var or pass kubeconfig path via KUBECONFIG.
+# Requires CLUSTER env var (dev, integration, or live).
 #
 # Example:
 #   CLUSTER=live ./validate-tls.sh external
@@ -10,36 +10,36 @@
 set -euo pipefail
 
 GATEWAY="${1:-external}"
-KUBECONFIG="${KUBECONFIG:-$HOME/.kube/${CLUSTER:-live}.yaml}"
+CONTEXT="${CLUSTER:-live}"
 
 echo "=== Certificate status (istio-gateway namespace) ==="
-KUBECONFIG="$KUBECONFIG" kubectl get certificates -n istio-gateway
+kubectl --context "$CONTEXT" get certificates -n istio-gateway
 
 echo ""
 echo "=== Certificate detail: $GATEWAY ==="
-KUBECONFIG="$KUBECONFIG" kubectl describe certificate "$GATEWAY" -n istio-gateway
+kubectl --context "$CONTEXT" describe certificate "$GATEWAY" -n istio-gateway
 
 echo ""
 echo "=== ClusterIssuer health ==="
-KUBECONFIG="$KUBECONFIG" kubectl get clusterissuers
+kubectl --context "$CONTEXT" get clusterissuers
 
 echo ""
 echo "=== CertificateRequests (recent issuance attempts) ==="
-KUBECONFIG="$KUBECONFIG" kubectl get certificaterequests -n istio-gateway
+kubectl --context "$CONTEXT" get certificaterequests -n istio-gateway
 
 echo ""
 echo "=== TLS secret certificate details ==="
-KUBECONFIG="$KUBECONFIG" kubectl get secret "${GATEWAY}-tls" -n istio-gateway \
+kubectl --context "$CONTEXT" get secret "${GATEWAY}-tls" -n istio-gateway \
   -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -text | \
   grep -E '(Subject:|Issuer:|Not Before|Not After|DNS:)'
 
 echo ""
 echo "=== WAF endpoint test (external gateway only) ==="
 if [ "$GATEWAY" = "external" ]; then
-  GATEWAY_IP=$(KUBECONFIG="$KUBECONFIG" kubectl get gateway external -n istio-gateway \
+  GATEWAY_IP=$(kubectl --context "$CONTEXT" get gateway external -n istio-gateway \
     -o jsonpath='{.metadata.annotations.lbipam\.cilium\.io/ips}' 2>/dev/null || echo "")
   if [ -n "$GATEWAY_IP" ]; then
-    EXTERNAL_DOMAIN=$(KUBECONFIG="$KUBECONFIG" kubectl get cm -n flux-system cluster-vars \
+    EXTERNAL_DOMAIN=$(kubectl --context "$CONTEXT" get cm -n flux-system cluster-vars \
       -o jsonpath='{.data.external_domain}' 2>/dev/null || echo "UNKNOWN")
     echo "Gateway IP: $GATEWAY_IP"
     echo "Testing SNI routing (expect HTTP 200/301/302, not connection reset):"

--- a/.claude/skills/instruction-eval/references/test-cases.md
+++ b/.claude/skills/instruction-eval/references/test-cases.md
@@ -80,8 +80,8 @@ These verify that removing redundant CLAUDE.md content didn't break skill invoca
 
 ### R-06: Cluster access
 **Prompt:** `How do I connect to the dev cluster?`
-**Expected:** Invokes `k8s` skill; kubeconfig path, KUBECONFIG env var pattern
-**Keywords:** `~/.kube`, `KUBECONFIG`, `kubeconfig`, `k8s`
+**Expected:** Invokes `k8s` skill; combined kubeconfig at `~/.kube/config`, `--context dev` pattern
+**Keywords:** `--context`, `dev`, `kubeconfig`, `k8s`
 **Regression risk:** cluster access section removed from clusters/CLAUDE.md; k8s skill not triggered
 
 ### R-07: Terragrunt operations
@@ -158,8 +158,8 @@ These verify that content removed from one CLAUDE.md still surfaces correctly fr
 
 ### D-04: Cluster access method
 **Prompt:** `I'm working in the clusters/ directory. How do I access the integration cluster?`
-**Expected:** KUBECONFIG=~/.kube/integration.yaml; read-only access only
-**Keywords:** `integration`, `~/.kube`, `read-only`, `KUBECONFIG`
+**Expected:** `kubectl --context integration`; read-only access only
+**Keywords:** `integration`, `--context`, `read-only`
 **Regression risk:** Cluster access section removed from clusters/CLAUDE.md; k8s skill must cover this
 
 ### D-05: WAF testing

--- a/.claude/skills/k8s/SKILL.md
+++ b/.claude/skills/k8s/SKILL.md
@@ -37,14 +37,14 @@ The available clusters are `dev`, `integration`, and `live`.  Use the corespondi
 
 ```bash
 # Check status
-KUBECONFIG=~/.kube/<cluster>.yaml flux get all
-KUBECONFIG=~/.kube/<cluster>.yaml flux get kustomizations
-KUBECONFIG=~/.kube/<cluster>.yaml flux get helmreleases -A
+flux --context <cluster> get all
+flux --context <cluster> get kustomizations
+flux --context <cluster> get helmreleases -A
 
 # Trigger reconciliation
-KUBECONFIG=~/.kube/<cluster>.yaml flux reconcile source git flux-system
-KUBECONFIG=~/.kube/<cluster>.yaml flux reconcile kustomization <name>
-KUBECONFIG=~/.kube/<cluster>.yaml flux reconcile helmrelease <name> -n <namespace>
+flux --context <cluster> reconcile source git flux-system
+flux --context <cluster> reconcile kustomization <name>
+flux --context <cluster> reconcile helmrelease <name> -n <namespace>
 ```
 
 ## Flux Status Interpretation

--- a/.claude/skills/k8s/tests.yaml
+++ b/.claude/skills/k8s/tests.yaml
@@ -3,7 +3,7 @@ skill: k8s
 description: "Verify cluster access patterns, Flux reconciliation commands, and common operational kubectl anti-patterns surface correctly"
 tests:
   - id: K8S-01
-    description: "Surfaces KUBECONFIG=~/.kube/<cluster>.yaml pattern for cluster access"
+    description: "Surfaces kubectl --context <cluster> pattern for cluster access"
     category: coverage
     severity: high
     prompt: |
@@ -12,33 +12,31 @@ tests:
       mode: both
       keywords:
         required:
-          - KUBECONFIG
+          - --context
           - live
-          - ~/.kube/
         any_of:
-          - live.yaml
           - kubectl get pods
           - -n monitoring
         forbidden:
           - kubectl config use-context
-          - kube-context
+          - KUBECONFIG=~/
           - kubeadm
       judge_criteria: |
         Score 0-10 on correctness of cluster access pattern:
-        - 0-2: Does not mention KUBECONFIG or uses wrong access method (e.g., kubectl config use-context)
-        - 3-5: Mentions KUBECONFIG but gives wrong path format (not ~/.kube/<cluster>.yaml)
-        - 6-7: Correct KUBECONFIG=~/.kube/live.yaml pattern with the kubectl command
-        - 8-10: Full example with KUBECONFIG=~/.kube/live.yaml kubectl get pods -n monitoring, and mentions all three cluster names (dev, integration, live) to show the pattern generalizes
+        - 0-2: Uses KUBECONFIG=~/.kube/live.yaml prefix or kubectl config use-context (old patterns)
+        - 3-5: Mentions --context but uses wrong cluster name or wrong command structure
+        - 6-7: Correct kubectl --context live get pods -n monitoring pattern
+        - 8-10: Full example with kubectl --context live get pods -n monitoring, and mentions all three cluster names (dev, integration, live) to show the pattern generalizes
     expect_refusal: false
     manual_review: false
     expected_behavior: |
-      Should show the KUBECONFIG=~/.kube/live.yaml prefix pattern for cluster access, not kubectl config use-context or context switching. Should include the full command: KUBECONFIG=~/.kube/live.yaml kubectl get pods -n monitoring.
+      Should show the kubectl --context live get pods -n monitoring pattern using the combined kubeconfig. Must NOT use KUBECONFIG=~/.kube/live.yaml prefix or kubectl config use-context.
     tags:
       - trimmed-2026-03-22
       - k8s-skill
 
   - id: K8S-02
-    description: "Surfaces Flux reconciliation commands with correct KUBECONFIG prefix"
+    description: "Surfaces Flux reconciliation commands with correct --context flag"
     category: coverage
     severity: high
     prompt: |
@@ -48,26 +46,26 @@ tests:
       keywords:
         required:
           - flux reconcile helmrelease
-          - KUBECONFIG
+          - --context
           - integration
         any_of:
-          - integration.yaml
           - -n monitoring
           - flux-system
         forbidden:
           - helm upgrade
           - kubectl apply
           - helm list
+          - KUBECONFIG=~/
       judge_criteria: |
         Score 0-10 on completeness of the reconciliation approach:
-        - 0-2: Uses helm CLI instead of flux CLI, or omits KUBECONFIG prefix entirely
-        - 3-5: Uses flux reconcile but with wrong KUBECONFIG pattern or wrong cluster name
-        - 6-7: Correct command: KUBECONFIG=~/.kube/integration.yaml flux reconcile helmrelease grafana -n monitoring
-        - 8-10: Correct command plus a follow-up check command (e.g., flux get helmreleases -A or kubectl describe helmrelease grafana -n monitoring) and an explanation of when to use reconcile kustomization vs reconcile helmrelease
+        - 0-2: Uses helm CLI instead of flux CLI, or uses KUBECONFIG=~/.kube/integration.yaml prefix (old pattern)
+        - 3-5: Uses flux reconcile but with wrong context flag or wrong cluster name
+        - 6-7: Correct command: flux --context integration reconcile helmrelease grafana -n monitoring
+        - 8-10: Correct command plus a follow-up check command (e.g., flux --context integration get helmreleases -A or kubectl --context integration describe helmrelease grafana -n monitoring) and an explanation of when to use reconcile kustomization vs reconcile helmrelease
     expect_refusal: false
     manual_review: false
     expected_behavior: |
-      Should provide: KUBECONFIG=~/.kube/integration.yaml flux reconcile helmrelease grafana -n monitoring. Must use flux CLI not helm CLI. Should use the KUBECONFIG=~/.kube/<cluster>.yaml pattern, not context switching.
+      Should provide: flux --context integration reconcile helmrelease grafana -n monitoring. Must use flux CLI not helm CLI. Should use the --context <cluster> pattern, not KUBECONFIG=~/.kube/ prefix.
     tags:
       - trimmed-2026-03-22
       - k8s-skill
@@ -161,11 +159,11 @@ tests:
         - 0-2: Only mentions one or two commands, all at the same layer (e.g., only pod-level)
         - 3-5: Covers two layers (e.g., HelmRelease status + pod logs) but misses Flux source/kustomization checks
         - 6-7: Covers at least three layers: ResourceSet/Kustomization → HelmRelease → Pod-level events/logs
-        - 8-10: Full top-down sequence: (1) flux get kustomizations / kubectl get resourcesets, (2) kubectl describe helmrelease, (3) kubectl get pods -n <namespace>, (4) kubectl describe pod, (5) kubectl logs — each with KUBECONFIG prefix and correct namespace flags
+        - 8-10: Full top-down sequence: (1) flux get kustomizations / kubectl get resourcesets, (2) kubectl describe helmrelease, (3) kubectl get pods -n <namespace>, (4) kubectl describe pod, (5) kubectl logs — each with --context <cluster> flag and correct namespace flags
     expect_refusal: false
     manual_review: false
     expected_behavior: |
-      Should walk through a layered diagnosis: start with flux get kustomizations or kubectl get resourcesets -n flux-system, then kubectl describe helmrelease, then kubectl get pods -n <namespace>, then kubectl describe pod and kubectl logs. All commands should use the KUBECONFIG=~/.kube/<cluster>.yaml prefix pattern.
+      Should walk through a layered diagnosis: start with flux get kustomizations or kubectl get resourcesets -n flux-system, then kubectl describe helmrelease, then kubectl get pods -n <namespace>, then kubectl describe pod and kubectl logs. All commands should use the --context <cluster> flag pattern.
     tags:
       - trimmed-2026-03-22
       - k8s-skill

--- a/.claude/skills/loki/SKILL.md
+++ b/.claude/skills/loki/SKILL.md
@@ -17,7 +17,7 @@ user-invocable: false
 Loki does **not** have an HTTPRoute on the internal ingress gateway, so it requires port-forward access (unlike Prometheus and Grafana which are available via DNS).
 
 ```bash
-KUBECONFIG=~/.kube/<cluster>.yaml kubectl port-forward -n monitoring svc/loki-headless 3100:3100 &
+kubectl --context <cluster> port-forward -n monitoring svc/loki-headless 3100:3100 &
 export LOKI_URL=http://localhost:3100
 ```
 

--- a/.claude/skills/monitoring-authoring/SKILL.md
+++ b/.claude/skills/monitoring-authoring/SKILL.md
@@ -166,12 +166,12 @@ Check if the chart provides monitoring via Helm values first (`kubesearch <chart
 
 ```bash
 # Check ServiceMonitor is discovered
-KUBECONFIG=~/.kube/<cluster>.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+kubectl --context <cluster> exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
   wget -qO- 'http://localhost:9090/api/v1/targets' | \
   jq '.data.activeTargets[] | select(.labels.job | contains("<component>"))'
 
 # Check alert rules are loaded
-KUBECONFIG=~/.kube/<cluster>.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+kubectl --context <cluster> exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
   wget -qO- 'http://localhost:9090/api/v1/rules' | \
   jq '.data.groups[] | select(.name | contains("<component>"))'
 ```

--- a/.claude/skills/prometheus/SKILL.md
+++ b/.claude/skills/prometheus/SKILL.md
@@ -16,18 +16,18 @@ Prometheus and Alertmanager are behind **OAuth2 Proxy** on the internal gateway.
 
 ```bash
 # Query Prometheus API directly inside the pod
-KUBECONFIG=~/.kube/<cluster>.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+kubectl --context <cluster> exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
   wget -qO- 'http://localhost:9090/api/v1/query?query=up' | jq '.data.result'
 
 # Query Alertmanager API
-KUBECONFIG=~/.kube/<cluster>.yaml kubectl exec -n monitoring alertmanager-kube-prometheus-stack-0 -c alertmanager -- \
+kubectl --context <cluster> exec -n monitoring alertmanager-kube-prometheus-stack-0 -c alertmanager -- \
   wget -qO- 'http://localhost:9093/api/v2/alerts' | jq .
 ```
 
 **Option 2: Port-forward (for scripts and repeated queries)**
 
 ```bash
-KUBECONFIG=~/.kube/<cluster>.yaml kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090 &
+kubectl --context <cluster> port-forward -n monitoring svc/prometheus-operated 9090:9090 &
 export PROMETHEUS_URL=http://localhost:9090
 ```
 
@@ -39,7 +39,7 @@ Use the bundled script at `.claude/skills/prometheus/scripts/promql.sh`:
 
 ```bash
 # Start port-forward first (script defaults to http://localhost:9090)
-KUBECONFIG=~/.kube/<cluster>.yaml kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090 &
+kubectl --context <cluster> port-forward -n monitoring svc/prometheus-operated 9090:9090 &
 
 # Instant query
 ./scripts/promql.sh query 'up'

--- a/.claude/skills/promotion-pipeline/SKILL.md
+++ b/.claude/skills/promotion-pipeline/SKILL.md
@@ -58,7 +58,7 @@ See [references/pipeline-reference.md](references/pipeline-reference.md) for art
 
 ## Tracing a Change End-to-End
 
-Prefix cluster commands with `KUBECONFIG=~/.kube/<cluster>.yaml`. The build triggers on push to `main` when `kubernetes/**` files change only.
+Use `--context <cluster>` for cluster-specific kubectl/flux commands. The build triggers on push to `main` when `kubernetes/**` files change only.
 
 | Stage | Check | Command |
 |-------|-------|---------|
@@ -110,8 +110,8 @@ Artifact tagged with stable X.Y.Z?
 The `platform-validation` Canary in `monitoring` runs every 60s: `kubernetes-api` (HTTP, expects 200/401) and `flux-pods-healthy` (all Flux pods Running+Ready).
 
 ```bash
-# Check canary status (prefix with KUBECONFIG=~/.kube/integration.yaml)
-kubectl get canaries -n monitoring
+# Check canary status
+kubectl --context integration get canaries -n monitoring
 kubectl describe canary platform-validation -n monitoring
 # canary_check{name="platform-validation"} == 0 means healthy
 ```
@@ -133,7 +133,7 @@ gh workflow run tag-validated-artifact.yaml -f artifact_sha=<7char-sha>
 **Option 1 — Pin OCIRepository** (immediate, must revert pin later):
 ```bash
 flux list artifact oci://ghcr.io/<owner>/homelab/platform | grep -E '^\d+\.\d+\.\d+$'
-KUBECONFIG=~/.kube/live.yaml kubectl patch ocirepository flux-system -n flux-system \
+kubectl --context live patch ocirepository flux-system -n flux-system \
   --type=merge -p '{"spec":{"ref":{"tag":"<previous-stable-tag>"}}}'
 ```
 

--- a/.claude/skills/promotion-pipeline/scripts/manual-promote.sh
+++ b/.claude/skills/promotion-pipeline/scripts/manual-promote.sh
@@ -40,4 +40,4 @@ flux tag artifact \
   --tag "${VERSION}"
 
 echo "Done. Live cluster will pick up ${VERSION} on next OCIRepository poll."
-echo "Verify: KUBECONFIG=~/.kube/live.yaml kubectl get ocirepository flux-system -n flux-system -o jsonpath='{.status.artifact.revision}'"
+echo "Verify: kubectl --context live get ocirepository flux-system -n flux-system -o jsonpath='{.status.artifact.revision}'"

--- a/.claude/skills/secrets/scripts/check-secret-sync.sh
+++ b/.claude/skills/secrets/scripts/check-secret-sync.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Check ExternalSecret sync status for a given secret and namespace
-# Usage: KUBECONFIG=~/.kube/<cluster>.yaml ./check-secret-sync.sh <name> <namespace>
-# Example: KUBECONFIG=~/.kube/live.yaml ./check-secret-sync.sh lldap-secrets authelia
+# Usage: CONTEXT=<cluster> ./check-secret-sync.sh <name> <namespace>
+# Example: CONTEXT=live ./check-secret-sync.sh lldap-secrets authelia
 
 set -euo pipefail
 

--- a/.claude/skills/security-testing/SKILL.md
+++ b/.claude/skills/security-testing/SKILL.md
@@ -70,10 +70,10 @@ Commands: see [references/test-commands.md#phase-5-supply-chain](references/test
 Run after every test session:
 
 ```bash
-KUBECONFIG=~/.kube/dev.yaml kubectl delete pod sectest fake-prom -n <ns> --ignore-not-found
-KUBECONFIG=~/.kube/dev.yaml kubectl delete httproute sectest-route-injection -n <ns> --ignore-not-found
-KUBECONFIG=~/.kube/dev.yaml kubectl label namespace <ns> network-policy.homelab/enforcement- 2>/dev/null
-KUBECONFIG=~/.kube/dev.yaml kubectl get pods -A | grep sectest
+kubectl --context dev delete pod sectest fake-prom -n <ns> --ignore-not-found
+kubectl --context dev delete httproute sectest-route-injection -n <ns> --ignore-not-found
+kubectl --context dev label namespace <ns> network-policy.homelab/enforcement- 2>/dev/null
+kubectl --context dev get pods -A | grep sectest
 ```
 
 ---

--- a/.claude/skills/security-testing/references/test-commands.md
+++ b/.claude/skills/security-testing/references/test-commands.md
@@ -1,6 +1,6 @@
 # Security Testing Commands
 
-All commands target the dev cluster. Prefix with `KUBECONFIG=~/.kube/dev.yaml`.
+All commands target the dev cluster. Use `kubectl --context dev` (or `flux --context dev` for Flux commands).
 
 ---
 

--- a/.claude/skills/sre/SKILL.md
+++ b/.claude/skills/sre/SKILL.md
@@ -18,7 +18,7 @@ description: |
 user-invocable: false
 ---
 
-> **Cluster access, KUBECONFIG patterns, and internal service URLs** are in the `k8s` skill.
+> **Cluster access (`--context` patterns) and internal service URLs** are in the `k8s` skill.
 
 # Debugging Kubernetes Incidents
 
@@ -74,7 +74,7 @@ Metrics and alerts (Prometheus is behind OAuth2 Proxy — DNS URLs won't work fo
 
 ```bash
 # Check firing alerts
-KUBECONFIG=~/.kube/<cluster>.yaml kubectl exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
+kubectl --context <cluster> exec -n monitoring prometheus-kube-prometheus-stack-0 -c prometheus -- \
   wget -qO- 'http://localhost:9090/api/v1/alerts' | jq '.data.alerts[] | select(.state == "firing")'
 ```
 
@@ -95,7 +95,7 @@ All traffic is implicitly denied. Missing labels are the most common cause of bl
 
 ```bash
 # Setup Hubble access (run once per session)
-KUBECONFIG=~/.kube/<cluster>.yaml kubectl port-forward -n kube-system svc/hubble-relay 4245:80 &
+kubectl --context <cluster> port-forward -n kube-system svc/hubble-relay 4245:80 &
 
 # See dropped traffic in a namespace
 hubble observe --verdict DROPPED --namespace <namespace> --since 5m
@@ -106,16 +106,16 @@ hubble observe --from-namespace <source> --to-namespace <dest> --since 5m
 
 Check namespace labels:
 ```bash
-KUBECONFIG=~/.kube/<cluster>.yaml kubectl get ns <namespace> -o jsonpath='{.metadata.labels}' | jq
+kubectl --context <cluster> get ns <namespace> -o jsonpath='{.metadata.labels}' | jq
 # Required: network-policy.homelab/profile: standard|internal|internal-egress|isolated
 # Optional: access.network-policy.homelab/postgres|garage-s3|kube-api: "true"
 ```
 
 Emergency escape hatch (triggers alert after 5m):
 ```bash
-KUBECONFIG=~/.kube/<cluster>.yaml kubectl label namespace <ns> network-policy.homelab/enforcement=disabled
+kubectl --context <cluster> label namespace <ns> network-policy.homelab/enforcement=disabled
 # Re-enable after fixing:
-KUBECONFIG=~/.kube/<cluster>.yaml kubectl label namespace <ns> network-policy.homelab/enforcement-
+kubectl --context <cluster> label namespace <ns> network-policy.homelab/enforcement-
 ```
 
 See `docs/runbooks/network-policy-escape-hatch.md` for full procedure.
@@ -126,8 +126,8 @@ HelmReleases can get stuck in `Stalled/RetriesExceeded` even after the underlyin
 resolved. Suspend and resume to reset the failure counter:
 
 ```bash
-KUBECONFIG=~/.kube/<cluster>.yaml flux suspend helmrelease <name> -n flux-system
-KUBECONFIG=~/.kube/<cluster>.yaml flux resume helmrelease <name> -n flux-system
+flux --context <cluster> suspend helmrelease <name> -n flux-system
+flux --context <cluster> resume helmrelease <name> -n flux-system
 ```
 
 Common self-healed causes: missing Secret/ConfigMap (ExternalSecret eventually created it),
@@ -149,20 +149,20 @@ the failure mode table. Quick diagnostic flow:
    └─ flux list artifact oci://ghcr.io/<repo>/platform | grep integration
 
 3. Integration OCIRepository seeing new version?
-   └─ KUBECONFIG=~/.kube/integration.yaml kubectl get ocirepository -n flux-system
+   └─ kubectl --context integration get ocirepository -n flux-system
    └─ Semver constraint must be ">= 0.0.0-0" to accept RCs
 
 4. Integration Kustomization healthy?
-   └─ KUBECONFIG=~/.kube/integration.yaml flux get kustomizations -n flux-system
+   └─ flux --context integration get kustomizations -n flux-system
 
 5. Flux Alert fired repository_dispatch?
-   └─ KUBECONFIG=~/.kube/integration.yaml kubectl describe alert validation-success -n flux-system
+   └─ kubectl --context integration describe alert validation-success -n flux-system
 
 6. tag-validated-artifact.yaml ran?
    └─ GitHub Actions → "Tag Validated Artifact" workflow
 
 7. Live OCIRepository seeing stable semver?
-   └─ KUBECONFIG=~/.kube/live.yaml kubectl get ocirepository -n flux-system
+   └─ kubectl --context live get ocirepository -n flux-system
    └─ Semver constraint must be ">= 0.0.0" (stable only, no RCs)
 ```
 

--- a/kubernetes/clusters/CLAUDE.md
+++ b/kubernetes/clusters/CLAUDE.md
@@ -138,7 +138,7 @@ See `references/silences.md` for the full CRD structure, matcher reference, and 
 
 ## Available Clusters
 
-Kubeconfig files are at `~/.kube/<cluster>.yaml`. Always specify `KUBECONFIG=` per command — do not rely on `kubectl config use-context`.
+A combined kubeconfig is at `~/.kube/config` with all three clusters registered. Use `kubectl --context <cluster>` to target a specific cluster — do not switch contexts globally with `kubectl config use-context`.
 
 | Name | Purpose | Hardware | Notes |
 |------|---------|----------|-------|


### PR DESCRIPTION
## Summary

- Replaces all `KUBECONFIG=~/.kube/<cluster>.yaml` per-command prefixes with `kubectl --context <cluster>` and `flux --context <cluster>` across all Claude skills, CLAUDE.md docs, scripts, and test fixtures
- Updates `kubernetes/clusters/CLAUDE.md` to describe the combined kubeconfig at `~/.kube/config` and explicitly forbid the old per-command `KUBECONFIG=` pattern
- Updates `k8s/tests.yaml` K8S-01 and K8S-02 to require `--context` and forbid `KUBECONFIG=~/` in scored responses

## Files changed

| Area | Files |
|------|-------|
| Core docs | `kubernetes/clusters/CLAUDE.md` |
| Skills | `k8s`, `sre`, `prometheus`, `loki`, `monitoring-authoring`, `gateway-routing`, `promotion-pipeline`, `security-testing` |
| Scripts | `cnpg-database`, `deploy-app` (x2), `gateway-routing`, `secrets`, `promotion-pipeline` |
| Tests/refs | `k8s/tests.yaml`, `instruction-eval/references/test-cases.md`, `security-testing/references/test-commands.md` |

## Test plan

- [x] Verify `KUBECONFIG=~/` no longer appears in any skill or CLAUDE.md (only in `forbidden:` test rubrics and historical runbooks)
- [x] Spot-check `k8s/tests.yaml` K8S-01 and K8S-02 scoring criteria reflect the new `--context` pattern
- [x] Confirm scripts accept `CLUSTER=<name>` env var and use `kubectl --context "${CLUSTER}"` correctly