### PR TITLE
fix(dragonfly): atomic rename dragonfly-password secret to dragonfly-auth

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -85,7 +85,7 @@ configMap:
       host: dragonfly.cache.svc.cluster.local
       port: 6379
       password:
-        secret_name: dragonfly-password
+        secret_name: dragonfly-auth
         path: password
 
   storage:
@@ -188,6 +188,6 @@ secret:
   additionalSecrets:
     lldap-secrets: { }
     authelia-db-credentials: { }
-    dragonfly-password: { }
+    dragonfly-auth: { }
     grafana-oidc-client-secret: { }
     open-webui-oidc-client-secret: { }

--- a/kubernetes/clusters/live/charts/immich.yaml
+++ b/kubernetes/clusters/live/charts/immich.yaml
@@ -25,7 +25,7 @@ controllers:
           REDIS_PASSWORD:
             valueFrom:
               secretKeyRef:
-                name: dragonfly-password
+                name: dragonfly-auth
                 key: password
         resources:
           requests:

--- a/kubernetes/clusters/live/charts/open-webui.yaml
+++ b/kubernetes/clusters/live/charts/open-webui.yaml
@@ -39,7 +39,7 @@ extraEnvVars:
   - name: DRAGONFLY_PASS
     valueFrom:
       secretKeyRef:
-        name: dragonfly-password
+        name: dragonfly-auth
         key: password
   - name: REDIS_URL
     value: "redis://:$(DRAGONFLY_PASS)@dragonfly.cache.svc.cluster.local:6379/0"

--- a/kubernetes/clusters/live/charts/paperless.yaml
+++ b/kubernetes/clusters/live/charts/paperless.yaml
@@ -76,7 +76,7 @@ controllers:
           DRAGONFLY_PASSWORD:
             valueFrom:
               secretKeyRef:
-                name: dragonfly-password
+                name: dragonfly-auth
                 key: password
           PAPERLESS_REDIS:
             dependsOn: DRAGONFLY_PASSWORD

--- a/kubernetes/clusters/live/config/ai-prereqs/dragonfly-secret-replication.yaml
+++ b/kubernetes/clusters/live/config/ai-prereqs/dragonfly-secret-replication.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: dragonfly-password
+  name: dragonfly-auth
   namespace: ai
   annotations:
-    replicator.v1.mittwald.de/replicate-from: cache/dragonfly-password
+    replicator.v1.mittwald.de/replicate-from: cache/dragonfly-auth
 data: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/dragonfly-secret-replication.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/dragonfly-secret-replication.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: dragonfly-password
+  name: dragonfly-auth
   namespace: authelia
   annotations:
-    replicator.v1.mittwald.de/replicate-from: cache/dragonfly-password
+    replicator.v1.mittwald.de/replicate-from: cache/dragonfly-auth
 data: { }

--- a/kubernetes/clusters/live/config/immich/dragonfly-secret-replication.yaml
+++ b/kubernetes/clusters/live/config/immich/dragonfly-secret-replication.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: dragonfly-password
+  name: dragonfly-auth
   namespace: immich
   annotations:
-    replicator.v1.mittwald.de/replicate-from: cache/dragonfly-password
+    replicator.v1.mittwald.de/replicate-from: cache/dragonfly-auth
 data: { }

--- a/kubernetes/clusters/live/config/paperless/dragonfly-password-replica.yaml
+++ b/kubernetes/clusters/live/config/paperless/dragonfly-password-replica.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: dragonfly-password
+  name: dragonfly-auth
   namespace: paperless
   annotations:
-    replicator.v1.mittwald.de/replicate-from: cache/dragonfly-password
+    replicator.v1.mittwald.de/replicate-from: cache/dragonfly-auth
 data: { }

--- a/kubernetes/platform/config/dragonfly/dragonfly-instance.yaml
+++ b/kubernetes/platform/config/dragonfly/dragonfly-instance.yaml
@@ -23,7 +23,7 @@ spec:
 
   authentication:
     passwordFromSecret:
-      name: dragonfly-password
+      name: dragonfly-auth
       key: password
 
   resources:

--- a/kubernetes/platform/config/dragonfly/password-secret.yaml
+++ b/kubernetes/platform/config/dragonfly/password-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: dragonfly-password
+  name: dragonfly-auth
   annotations:
     secret-generator.v1.mittwald.de/autogenerate: password
     secret-generator.v1.mittwald.de/length: "32"


### PR DESCRIPTION
## Summary

The live `dragonfly-password` secret contains URL-special characters (e.g. `+`, `/`) that broke Redis URL construction in open-webui and paperless, causing CrashLoopBackOff when the password is embedded in a Redis URL (`redis://:PASSWORD@host`).

This PR performs an atomic rename from `dragonfly-password` to `dragonfly-auth`, which forces Flux to garbage-collect the old secret and create a new one. The `secret-generator` already has `encoding: hex` set, so the fresh secret will be URL-safe. `kubernetes-replicator` propagates the new secret to all consumer namespaces automatically.

Split out from PR #679, which merged only the tdarr-node and recyclarr fixes.

Changes:
- Add then remove `regenerate: "true"` annotation (superseded by the rename — keeping the commit history for auditability)
- Rename source Secret from `dragonfly-password` to `dragonfly-auth` in `kubernetes/platform/config/dragonfly/`
- Update `passwordFromSecret.name` in the Dragonfly CR
- Update `replicate-from` annotations in all consumer namespace replicas (`ai`, `authelia`, `immich`, `paperless`)
- Update `secretKeyRef.name` in open-webui, immich, and paperless chart values
- Update `secret_name` and `additionalSecrets` key in authelia chart values

## Test plan

- [ ] Verify `dragonfly-auth` secret is created in `cache` namespace with hex-only value after promotion to live
- [ ] Verify `dragonfly-password` secret is garbage-collected by Flux
- [ ] Verify dragonfly-auth replication propagates to `ai`, `authelia`, `immich`, `paperless` namespaces
- [ ] Verify open-webui and paperless pods connect to Dragonfly successfully
- [ ] Verify authelia connects to Dragonfly successfully