### PR TITLE
fix(live): silence LonghornVolumeActualSpaceUsedWarning for Prometheus TSDB PVCs

### DIFF
--- a/kubernetes/clusters/live/config/silences/kustomization.yaml
+++ b/kubernetes/clusters/live/config/silences/kustomization.yaml
@@ -2,4 +2,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: []
+resources:
+  - prometheus-tsdb-volume-full.yaml

--- a/kubernetes/clusters/live/config/silences/prometheus-tsdb-volume-full.yaml
+++ b/kubernetes/clusters/live/config/silences/prometheus-tsdb-volume-full.yaml
@@ -1,0 +1,18 @@
+---
+# Prometheus self-manages TSDB storage via retentionSize: 50GB on a 50Gi PVC.
+# Sitting near capacity is expected steady-state behavior — Prometheus trims at
+# the size limit. The Longhorn 90% threshold fires before the retention ceiling
+# kicks in, producing a permanent false positive for these volumes.
+apiVersion: observability.giantswarm.io/v1alpha2
+kind: Silence
+metadata:
+  name: prometheus-tsdb-volume-full
+  namespace: monitoring
+spec:
+  matchers:
+    - name: alertname
+      matchType: "="
+      value: "LonghornVolumeActualSpaceUsedWarning"
+    - name: pvc
+      matchType: "=~"
+      value: "prometheus-kube-prometheus-stack-db-.*"


### PR DESCRIPTION
## Summary

- Adds a declarative Silence CR (prometheus-tsdb-volume-full) in the monitoring namespace targeting LonghornVolumeActualSpaceUsedWarning for PVCs matching prometheus-kube-prometheus-stack-db-.*
- Registers the new file in kubernetes/clusters/live/config/silences/kustomization.yaml

## Why

Prometheus is configured with retentionSize: 50GB on a 50Gi PVC. It self-manages storage by evicting old blocks at the size ceiling -- sitting near 90% capacity is expected, steady-state behavior, not a storage problem.

The Longhorn volume warning threshold fires at 90% utilization, which is reached before Prometheus retention ceiling kicks in. This creates a permanent false positive: the alert fires continuously, cannot be silenced by any operator action, and provides no actionable signal.

## Test plan

- PR merges cleanly and passes CI
- Promotion pipeline carries the change through integration to live
- Flux reconciles the silences Kustomization in monitoring namespace on live without errors
- LonghornVolumeActualSpaceUsedWarning for Prometheus TSDB PVCs no longer fires in Alertmanager