### PR TITLE
fix(alloy): drop log entries older than 7d to prevent AlloyDroppedEntries alert

### DIFF
--- a/kubernetes/platform/charts/alloy.yaml
+++ b/kubernetes/platform/charts/alloy.yaml
@@ -61,11 +61,21 @@ alloy:
           selector = "{app=\"loki\"}"
           action   = "drop"
         }
-        forward_to = [loki.write.default.receiver]
+        forward_to = [loki.process.drop_old_entries.receiver]
       }
 
       // Collect Kubernetes events (new capability beyond Promtail)
       loki.source.kubernetes_events "events" {
+        forward_to = [loki.process.drop_old_entries.receiver]
+      }
+
+      // Drop entries older than 7 days to prevent Loki 400 rejections after mass pod recycles
+      // (e.g., Helm upgrades that leave stale tail positions replayed on Alloy resync)
+      loki.process "drop_old_entries" {
+        stage.drop {
+          older_than          = "168h"
+          drop_counter_reason = "too_old"
+        }
         forward_to = [loki.write.default.receiver]
       }
 


### PR DESCRIPTION
## Summary

- Adds a `loki.process "drop_old_entries"` component with `stage.drop { older_than = "168h" }` to the Alloy River config
- Inserts the drop stage between all log sources (`loki.source.kubernetes` pod logs and `loki.source.kubernetes_events` Kubernetes events) and `loki.write`
- Uses `drop_counter_reason = "too_old"` to distinguish age-based drops in metrics from other causes

**Root cause:** The Longhorn v1.11.1 upgrade on 2026-03-17 recycled all pods, leaving Alloy's position files pointing to log offsets from before the 7-day Loki ingestion window. On resync, Alloy replayed stale entries which Loki rejected with HTTP 400, incrementing `loki_write_dropped_entries_total` and firing the `AlloyDroppedEntries` critical alert.

**Fix rationale:** Dropping at the pipeline edge prevents Loki from ever seeing the out-of-window entries. The same pattern applies to future mass pod recycle events (other Helm upgrades, node reboots, etc.).

## Test plan

- [ ] Validate passed locally: `task k8s:validate` — exit 0, 0 invalid, 0 errors
- [ ] After merge, confirm `AlloyDroppedEntries` does not re-fire during normal operation
- [ ] After next mass pod recycle event, confirm the alert stays silent