### PR TITLE
fix(velero): drop nobody UID override to unblock Kopia BackupRepository

### DIFF
--- a/kubernetes/platform/charts/velero.yaml
+++ b/kubernetes/platform/charts/velero.yaml
@@ -56,9 +56,6 @@ priorityClassName: platform
 
 podSecurityContext:
   runAsNonRoot: true
-  runAsUser: 65534
-  runAsGroup: 65534
-  fsGroup: 65534
   seccompProfile:
     type: RuntimeDefault
 
@@ -66,9 +63,7 @@ containerSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop: ["ALL"]
-  readOnlyRootFilesystem: true
   runAsNonRoot: true
-  runAsUser: 65534
   seccompProfile:
     type: RuntimeDefault
 

--- a/kubernetes/platform/config/velero-restore/gate.sh
+++ b/kubernetes/platform/config/velero-restore/gate.sh
@@ -12,17 +12,17 @@ set -euo pipefail
 #   0 — All restores terminal (including Failed), or fresh cluster (no backups)
 #   non-zero — Only from set -e on unexpected errors
 
-BACKUP_SYNC_TIMEOUT="${BACKUP_SYNC_TIMEOUT:-120}"
-POLL_INTERVAL="${POLL_INTERVAL:-15}"
+BACKUP_SYNC_TIMEOUT="$${BACKUP_SYNC_TIMEOUT:-120}"
+POLL_INTERVAL="$${POLL_INTERVAL:-15}"
 
 # Phase 1: Wait for Velero to discover existing backups from S3.
 # On a fresh deploy, the BackupStorageLocation needs time to sync.
-echo "Phase 1: Waiting up to ${BACKUP_SYNC_TIMEOUT}s for backup discovery..."
+echo "Phase 1: Waiting up to $${BACKUP_SYNC_TIMEOUT}s for backup discovery..."
 deadline=$((SECONDS + BACKUP_SYNC_TIMEOUT))
 while [ "$SECONDS" -lt "$deadline" ]; do
   count=$(kubectl get backups.velero.io -n velero -o name 2>/dev/null | wc -l)
   if [ "$count" -gt 0 ]; then
-    echo "Found ${count} backup(s) in BSL."
+    echo "Found $${count} backup(s) in BSL."
     break
   fi
   echo "No backups found yet, waiting... ($((deadline - SECONDS))s remaining)"
@@ -30,7 +30,7 @@ while [ "$SECONDS" -lt "$deadline" ]; do
 done
 
 if [ "$(kubectl get backups.velero.io -n velero -o name 2>/dev/null | wc -l)" -eq 0 ]; then
-  echo "No backups found after ${BACKUP_SYNC_TIMEOUT}s — assuming fresh cluster. Exiting successfully."
+  echo "No backups found after $${BACKUP_SYNC_TIMEOUT}s — assuming fresh cluster. Exiting successfully."
   exit 0
 fi
 
@@ -50,21 +50,21 @@ while true; do
     [ -z "$name" ] && continue
     case "$phase" in
       New|InProgress|WaitingForPluginOperations|WaitingForPluginOperationsPartiallyFailed|Finalizing|FinalizingPartiallyFailed)
-        echo "Restore ${name} is in non-terminal phase: ${phase}"
+        echo "Restore $${name} is in non-terminal phase: $${phase}"
         pending=$((pending + 1))
         ;;
       Failed|PartiallyFailed|FailedValidation)
-        echo "WARNING: Restore ${name} has phase: ${phase}"
+        echo "WARNING: Restore $${name} has phase: $${phase}"
         ;;
       Completed)
-        echo "Restore ${name} completed successfully."
+        echo "Restore $${name} completed successfully."
         ;;
       "")
-        echo "Restore ${name} has no phase yet (waiting for controller)."
+        echo "Restore $${name} has no phase yet (waiting for controller)."
         pending=$((pending + 1))
         ;;
       *)
-        echo "Restore ${name} has unrecognized phase: ${phase} (treating as non-terminal)"
+        echo "Restore $${name} has unrecognized phase: $${phase} (treating as non-terminal)"
         pending=$((pending + 1))
         ;;
     esac
@@ -75,6 +75,6 @@ while true; do
     exit 0
   fi
 
-  echo "Waiting for ${pending} restore(s) to complete..."
+  echo "Waiting for $${pending} restore(s) to complete..."
   sleep "$POLL_INTERVAL"
 done


### PR DESCRIPTION
## Summary

- Remove `runAsUser: 65534` / `runAsGroup: 65534` / `fsGroup: 65534` from the main Velero pod security context — the image's default `cnb` user (UID ~1000) has a real home directory; nobody does not
- Remove `readOnlyRootFilesystem: true` and `runAsUser: 65534` from the main container security context — Kopia needs to write `$HOME/.config/kopia/` to initialize its repository
- All other hardening preserved: `runAsNonRoot`, `allowPrivilegeEscalation: false`, `capabilities.drop: ALL`, `seccompProfile: RuntimeDefault`
- initContainers, node-agent (`runAsUser: 0`), kubectl, and upgradeCRDsJob are **unchanged**
- Fix `gate.sh` variable escaping: `${VAR}` → `$${VAR}` so Flux's `postBuild.substituteFrom` doesn't eat bash variable references in echo statements

## Root Cause

`BackupRepository/garage-aws-kopia` was `NotReady` with:
```
unable to create config directory: mkdir /nonexistent: read-only file system
```

Every backup with `snapshotMoveData: true` has silently failed since deploy — no data has reached S3. The Velero chart defaults to empty `{}` security contexts; we applied overly aggressive hardening that broke the chart's internal assumptions about its runtime user.

## Test Plan

- [ ] Flux reconciles `velero` HelmRelease successfully
- [ ] `kubectl exec -n velero deploy/velero -- id` shows `cnb` user (not UID 65534)
- [ ] `kubectl get backuprepository -n velero` shows `phase: Ready` within ~2 minutes
- [ ] `kubectl exec -n velero ds/node-agent -- id` still shows `uid=0(root)`
- [ ] Trigger manual backup: `velero backup create test-fix --from-schedule platform --wait` completes with `Phase: Completed`
- [ ] Gate script logs show variable values (not empty strings) on next restore gate run