### PR TITLE
fix: add namespace to longhorn snapshot-frequent RecurringJob

### DIFF
--- a/kubernetes/clusters/live/config/longhorn-snapshots/snapshot-frequent.yaml
+++ b/kubernetes/clusters/live/config/longhorn-snapshots/snapshot-frequent.yaml
@@ -4,6 +4,7 @@ apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:
   name: &name snapshot-frequent
+  namespace: longhorn-system
 spec:
   name: *name
   cron: "0 1 * * *"


### PR DESCRIPTION
## Problem

`cluster-config` on the live cluster has been stuck at revision `0.1.448` since March 27 (9 days, 4657 reconciliation failures) with:

```
RecurringJob/snapshot-frequent namespace not specified: the server could not find the requested resource (patch recurringjobs.longhorn.io snapshot-frequent)
```

`RecurringJob` is namespace-scoped in Longhorn v1beta2 but `snapshot-frequent.yaml` was missing `namespace: longhorn-system` in its metadata.

## Fix

Add `namespace: longhorn-system` to the manifest metadata.

## Impact

Once this reaches `live`, `cluster-config` will unblock and advance to `0.1.530`, which will also prune the `backup-daily` and `backup-frequent` RecurringJobs removed in #764.