### PR TITLE
fix(descheduler): exclude velero namespace from eviction

### DIFF
--- a/kubernetes/platform/charts/descheduler.yaml
+++ b/kubernetes/platform/charts/descheduler.yaml
@@ -14,6 +14,9 @@ deschedulerPolicy:
             evictLocalStoragePods: true
             evictSystemCriticalPods: false
             nodeFit: true
+            namespaces:
+              exclude:
+                - velero
         - name: RemovePodsViolatingInterPodAntiAffinity
         - name: RemovePodsViolatingNodeAffinity
           args:


### PR DESCRIPTION
## Root Cause

Velero DataUploads for Garage PVCs were failing with `timeout on preparing data upload` every weekly backup. Previous investigations attributed this to cross-node Longhorn CSI provisioning latency or node saturation — both were incorrect.

**Actual root cause confirmed via Loki logs:**

The descheduler's `RemovePodsViolatingTopologySpreadConstraint` plugin was evicting Velero's backup expose pod mid-flight. Log evidence from `platform-20260412020029-8jqlt` (Apr 12 02:00–02:35 UTC):

```
02:03:57  Data upload accepted by node2, backup pod bound to node42
02:04:06  FailedAttachVolume count=1 — pvc-87bffed2 not ready for workloads
02:05:38  FailedAttachVolume count=9
02:05:42  sigs.k8s.io/descheduler evicts pod from node42 (RemovePodsViolatingTopologySpreadConstraint)
02:06–02:34  Zero activity — Velero waits for prepare timeout
02:34:04  30-minute prepare timeout fires, DataUpload marked Failed
```

Velero's data upload controller does not recreate evicted expose pods. Once evicted, the DataUpload is dead until timeout.

## Fix

Add `namespaces.exclude: [velero]` to the `DefaultEvictor` plugin config. The DefaultEvictor gates all descheduler plugins, so this single change prevents all plugins from evicting pods in the velero namespace.

## Impact

- Stops Garage backup failures that have occurred every weekly backup run since Velero was deployed
- No change to descheduler behavior for any other namespace