### PR TITLE
fix(monitoring): correct network throughput dashboard queries and units

### DIFF
--- a/kubernetes/platform/config/monitoring/network-throughput-dashboard.yaml
+++ b/kubernetes/platform/config/monitoring/network-throughput-dashboard.yaml
@@ -65,7 +65,7 @@ data:
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
-              "expr": "max by (instance) (\n  rate(node_network_receive_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m]),\n  rate(node_network_transmit_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])\n) / (10 * 1000 * 1000 * 1000 / 8) * 100",
+              "expr": "max by (instance) (\n  label_replace(sum by (instance) (rate(node_network_receive_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])), \"__dir__\", \"rx\", \"\", \"\")\n  or\n  label_replace(sum by (instance) (rate(node_network_transmit_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])), \"__dir__\", \"tx\", \"\", \"\")\n) * 8 / (10 * 1000 * 1000 * 1000) * 100",
               "legendFormat": "{{ instance }}",
               "refId": "A"
             }
@@ -111,10 +111,10 @@ data:
                 "mode": "absolute",
                 "steps": [
                   { "color": "green", "value": null },
-                  { "color": "red", "value": 1250000000 }
+                  { "color": "red", "value": 10000000000 }
                 ]
               },
-              "unit": "Bps",
+              "unit": "bps",
               "min": 0
             },
             "overrides": []
@@ -128,7 +128,7 @@ data:
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
-              "expr": "sum by (instance) (\n  rate(node_network_receive_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])\n  + rate(node_network_transmit_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])\n)",
+              "expr": "sum by (instance) (\n  rate(node_network_receive_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])\n  + rate(node_network_transmit_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])\n) * 8",
               "legendFormat": "{{ instance }}",
               "refId": "A"
             }
@@ -167,10 +167,10 @@ data:
                 "mode": "absolute",
                 "steps": [
                   { "color": "green", "value": null },
-                  { "color": "red", "value": 1250000000 }
+                  { "color": "red", "value": 10000000000 }
                 ]
               },
-              "unit": "Bps",
+              "unit": "bps",
               "min": 0
             },
             "overrides": []
@@ -184,7 +184,7 @@ data:
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
-              "expr": "sum by (instance) (\n  rate(node_network_receive_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])\n)",
+              "expr": "sum by (instance) (\n  rate(node_network_receive_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])\n) * 8",
               "legendFormat": "{{ instance }}",
               "refId": "A"
             }
@@ -223,10 +223,10 @@ data:
                 "mode": "absolute",
                 "steps": [
                   { "color": "green", "value": null },
-                  { "color": "red", "value": 1250000000 }
+                  { "color": "red", "value": 10000000000 }
                 ]
               },
-              "unit": "Bps",
+              "unit": "bps",
               "min": 0
             },
             "overrides": []
@@ -240,7 +240,7 @@ data:
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
-              "expr": "sum by (instance) (\n  rate(node_network_transmit_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])\n)",
+              "expr": "sum by (instance) (\n  rate(node_network_transmit_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])\n) * 8",
               "legendFormat": "{{ instance }}",
               "refId": "A"
             }
@@ -282,7 +282,7 @@ data:
                 "stacking": { "group": "A", "mode": "normal" },
                 "thresholdsStyle": { "mode": "off" }
               },
-              "unit": "Bps",
+              "unit": "bps",
               "min": 0
             },
             "overrides": []
@@ -296,7 +296,7 @@ data:
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
-              "expr": "sum by (instance) (\n  rate(node_network_receive_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])\n  + rate(node_network_transmit_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])\n)",
+              "expr": "sum by (instance) (\n  rate(node_network_receive_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])\n  + rate(node_network_transmit_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])\n) * 8",
               "legendFormat": "{{ instance }}",
               "refId": "A"
             }
@@ -345,7 +345,7 @@ data:
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
-              "expr": "max by (instance) (\n  rate(node_network_receive_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m]),\n  rate(node_network_transmit_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])\n) / (10 * 1000 * 1000 * 1000 / 8) * 100",
+              "expr": "max by (instance) (\n  label_replace(sum by (instance) (rate(node_network_receive_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])), \"__dir__\", \"rx\", \"\", \"\")\n  or\n  label_replace(sum by (instance) (rate(node_network_transmit_bytes_total{device!~\"lo|cni.*|veth.*|lxc.*|flannel.*|cilium.*|istioin|istioout\"}[5m])), \"__dir__\", \"tx\", \"\", \"\")\n) * 8 / (10 * 1000 * 1000 * 1000) * 100",
               "legendFormat": "{{ instance }}",
               "refId": "A"
             }


### PR DESCRIPTION
## Summary
- Fix parse error on NIC Utilization gauge and Peak Utilization bar gauge — `max by (instance)` was receiving two comma-separated vectors, but PromQL aggregation only accepts one
- Convert all throughput panels from bytes/sec (GB/s) to bits/sec (Gbps) to match the 10 GbE capacity framing

## Changes
- **Broken `max` queries** (panels 2, 9): Replaced `max by (instance)(rate(...), rate(...))` with `label_replace` + `or` to create a union vector that `max by` can correctly reduce
- **Unit conversion**: All throughput queries now multiply by 8 (`* 8`), unit changed from `Bps` to `bps`, threshold lines updated from 1,250,000,000 to 10,000,000,000

## Test plan
- [ ] NIC Utilization gauge no longer shows parse error and displays percentage values
- [ ] Throughput panels display in Gbps/Mbps instead of GB/s/MB/s
- [ ] Threshold dashed lines appear at 10 Gbps on time-series panels
- [ ] Peak NIC Utilization bar gauge renders correctly