### PR TITLE
fix(ci): pass --repo to gh release create

### DIFF
--- a/.github/workflows/tag-validated-artifact.yaml
+++ b/.github/workflows/tag-validated-artifact.yaml
@@ -158,6 +158,7 @@ jobs:
         run: |
           TAG="v${STABLE}"
           gh release create "${TAG}" \
+            --repo "${{ github.repository }}" \
             --target "${FULL_SHA}" \
             --title "${TAG}" \
             --generate-notes \


### PR DESCRIPTION
## Summary
- Fixes `gh release create` failing with "not a git repository" in the tag-validated-artifact workflow
- The workflow has no `actions/checkout` step (it only uses Flux CLI for OCI tagging), so `gh` can't infer the repo from `.git/config`
- Adds `--repo ${{ github.repository }}` to explicitly target the repo

## Test plan
- [ ] Trigger `tag-validated-artifact` via `workflow_dispatch` and verify a GitHub Release is created successfully