### PR TITLE
feat(database): enable CNPG recovery code path for live cluster

### DIFF
--- a/.taskfiles/dr/RECOVERY.md
+++ b/.taskfiles/dr/RECOVERY.md
@@ -386,9 +386,11 @@ code path active, this section becomes historical reference.
 ### Post-activation
 
 After successful activation, live is carrying real data. The recovery-patch
-remains in the codebase permanently — CNPG ignores `spec.bootstrap` after
-initial cluster creation, so it has no effect during normal operation but
-ensures the recovery path is ready for any future rebuild.
+remains in the codebase permanently — CNPG rejects `spec.bootstrap` changes
+on an initialized cluster (webhook validation), so Flux will fail to apply
+the patch during normal operation. This is expected: `database-config` will
+show reconciliation errors until the next rebuild, at which point the
+recovery path activates correctly on the fresh cluster.
 
 ---
 

--- a/.taskfiles/dr/RECOVERY.md
+++ b/.taskfiles/dr/RECOVERY.md
@@ -277,6 +277,121 @@ looked like at the time of failure.
 
 ---
 
+## Live cluster activation (inauguration)
+
+**Purpose**: Get live onto the CNPG recovery code path. After this procedure,
+live carries real user data and any future rebuild automatically recovers
+databases from Barman S3 archives.
+
+This is a **one-time event** — once live has been rebuilt with the recovery
+code path active, this section becomes historical reference.
+
+### Pre-flight
+
+1. **Verify backups are healthy**:
+
+   ```
+   velero --kubecontext live backup get --sort-by=.metadata.creationTimestamp | tail -5
+   ```
+
+   The most recent `platform` and `default` backups must show `Completed`
+   (not `PartiallyFailed`). If stale or failed, trigger fresh backups:
+
+   ```
+   velero --kubecontext live backup create --from-schedule platform
+   velero --kubecontext live backup create --from-schedule default
+   ```
+
+2. **Verify CNPG Barman archives exist**:
+
+   ```
+   kubectl --context live get cluster platform -n database \
+     -o jsonpath='{.status.firstRecoverabilityPoint}{"\t"}{.status.lastSuccessfulBackup}{"\n"}'
+   ```
+
+   Both timestamps must be recent and the recoverability window must span
+   at least one base backup.
+
+3. **Verify the PR is merged and promoted**. The `validated-*` OCI artifact
+   must contain the recovery-patch and excludedResources changes:
+
+   ```
+   flux --context live get source oci platform -n flux-system
+   ```
+
+   Cross-reference the artifact revision with the merge commit.
+
+### Execution
+
+4. **Destroy and recreate the live cluster** via Terragrunt:
+
+   ```
+   task tg:apply-live
+   ```
+
+   This destroys the existing nodes and provisions fresh ones (~10 min).
+   **Requires explicit human approval.**
+
+### Post-rebuild validation
+
+5. **Watch Flux bootstrap**. The cluster pulls the `validated-*` OCI
+   artifact and begins reconciliation:
+
+   ```
+   flux --context live get kustomizations -A -w
+   ```
+
+6. **Verify Velero restore completes**. The `velero-restore` Kustomization
+   should become Ready after the gate Job succeeds:
+
+   ```
+   kubectl --context live get restore -n velero
+   kubectl --context live logs -n velero job/velero-restore-gate --tail=50
+   ```
+
+   Confirm `restore-platform` shows `Completed` and that Garage PVCs are
+   restored (check `kubectl --context live get pvc -n garage`).
+
+7. **Verify CNPG recovery**. The platform Cluster CR should bootstrap via
+   `recovery` (not `initdb`):
+
+   ```
+   kubectl --context live get cluster platform -n database -o jsonpath='{.status.phase}{"\n"}'
+   kubectl --context live get pods -n database -l cnpg.io/cluster=platform
+   ```
+
+   Expected: `Cluster in healthy state`, all pods Ready. Check logs for
+   recovery confirmation:
+
+   ```
+   kubectl --context live logs -n database platform-1 -c postgres --tail=50 | grep -i "recovery\|restore"
+   ```
+
+8. **Verify application connectivity**. Spot-check that apps can reach
+   their databases via the pooler:
+
+   ```
+   kubectl --context live get pooler -n database
+   kubectl --context live get pods -n database -l cnpg.io/poolerName=platform-pooler-rw
+   ```
+
+9. **Verify zero firing alerts**:
+
+   ```
+   kubectl --context live get prometheusrule -A
+   ```
+
+   Check Alertmanager UI or API for any firing alerts.
+
+### Post-activation
+
+After successful activation, live is carrying real data. The recovery-patch
+remains in the codebase permanently — CNPG ignores `spec.bootstrap` after
+initial cluster creation, so it has no effect during normal operation but
+ensures the recovery path is ready for any future rebuild.
+
+---
+
 ## When to extend this runbook
 
 Add a new section when:

--- a/.taskfiles/dr/RECOVERY.md
+++ b/.taskfiles/dr/RECOVERY.md
@@ -323,25 +323,33 @@ code path active, this section becomes historical reference.
 
 ### Execution
 
-4. **Destroy and recreate the live cluster** via Terragrunt:
+4. **Destroy the live cluster**:
+
+   ```
+   task tg:destroy-live
+   ```
+
+5. **Merge the recovery-path PR** to main. Wait for OCI promotion to
+   produce a `validated-*` artifact containing the changes.
+
+6. **Rebuild the live cluster**:
 
    ```
    task tg:apply-live
    ```
 
-   This destroys the existing nodes and provisions fresh ones (~10 min).
-   **Requires explicit human approval.**
+   Both operations require explicit human approval.
 
 ### Post-rebuild validation
 
-5. **Watch Flux bootstrap**. The cluster pulls the `validated-*` OCI
+7. **Watch Flux bootstrap**. The cluster pulls the `validated-*` OCI
    artifact and begins reconciliation:
 
    ```
    flux --context live get kustomizations -A -w
    ```
 
-6. **Verify Velero restore completes**. The `velero-restore` Kustomization
+8. **Verify Velero restore completes**. The `velero-restore` Kustomization
    should become Ready after the gate Job succeeds:
 
    ```
@@ -352,7 +360,7 @@ code path active, this section becomes historical reference.
    Confirm `restore-platform` shows `Completed` and that Garage PVCs are
    restored (check `kubectl --context live get pvc -n garage`).
 
-7. **Verify CNPG recovery**. The platform Cluster CR should bootstrap via
+9. **Verify CNPG recovery**. The platform Cluster CR should bootstrap via
    `recovery` (not `initdb`):
 
    ```
@@ -367,7 +375,7 @@ code path active, this section becomes historical reference.
    kubectl --context live logs -n database platform-1 -c postgres --tail=50 | grep -i "recovery\|restore"
    ```
 
-8. **Verify application connectivity**. Spot-check that apps can reach
+10. **Verify application connectivity**. Spot-check that apps can reach
    their databases via the pooler:
 
    ```
@@ -375,7 +383,7 @@ code path active, this section becomes historical reference.
    kubectl --context live get pods -n database -l cnpg.io/poolerName=platform-pooler-rw
    ```
 
-9. **Verify zero firing alerts**:
+11. **Verify zero firing alerts**:
 
    ```
    kubectl --context live get prometheusrule -A

--- a/.taskfiles/dr/RECOVERY.md
+++ b/.taskfiles/dr/RECOVERY.md
@@ -291,7 +291,7 @@ code path active, this section becomes historical reference.
 1. **Verify backups are healthy**:
 
    ```
-   velero --kubecontext live backup get --sort-by=.metadata.creationTimestamp | tail -5
+   velero --kubecontext live backup get
    ```
 
    The most recent `platform` and `default` backups must show `Completed`

--- a/.taskfiles/dr/RECOVERY.md
+++ b/.taskfiles/dr/RECOVERY.md
@@ -316,7 +316,7 @@ code path active, this section becomes historical reference.
    must contain the recovery-patch and excludedResources changes:
 
    ```
-   flux --context live get source oci platform -n flux-system
+   kubectl --context live get ocirepository -n flux-system
    ```
 
    Cross-reference the artifact revision with the merge commit.

--- a/kubernetes/clusters/live/config/database/kustomization.yaml
+++ b/kubernetes/clusters/live/config/database/kustomization.yaml
@@ -8,3 +8,7 @@ resources:
   - role-secrets.yaml
 patches:
   - path: cluster-roles-patch.yaml
+  - path: recovery-patch.yaml
+    target:
+      kind: Cluster
+      name: platform

--- a/kubernetes/clusters/live/config/database/recovery-patch.yaml
+++ b/kubernetes/clusters/live/config/database/recovery-patch.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: platform
+spec:
+  bootstrap:
+    recovery:
+      source: platform-backup
+  externalClusters:
+    - name: platform-backup
+      barmanObjectStore:
+        destinationPath: s3://cnpg-platform-backups/
+        endpointURL: http://${garage_s3_endpoint}
+        s3Credentials:
+          accessKeyId:
+            name: cnpg-platform-s3-credentials
+            key: access-key-id
+          secretAccessKey:
+            name: cnpg-platform-s3-credentials
+            key: secret-access-key
+        wal:
+          compression: gzip
+        data:
+          compression: gzip

--- a/kubernetes/clusters/live/config/velero-restore/restore-default.yaml
+++ b/kubernetes/clusters/live/config/velero-restore/restore-default.yaml
@@ -9,6 +9,8 @@ spec:
   scheduleName: default
   restorePVs: true
   existingResourcePolicy: none
+  excludedResources:
+    - clusters.postgresql.cnpg.io
   includedNamespaces:
     - immich
     - satisfactory

--- a/kubernetes/clusters/live/config/velero-restore/restore-platform.yaml
+++ b/kubernetes/clusters/live/config/velero-restore/restore-platform.yaml
@@ -9,10 +9,12 @@ spec:
   scheduleName: platform
   restorePVs: true
   existingResourcePolicy: none
+  # Exclude CNPG Cluster CR -- Flux manages it via recovery-patch.yaml overlay.
+  # Restoring the backed-up CR would apply an initdb spec, overriding recovery.
+  excludedResources:
+    - clusters.postgresql.cnpg.io
   # garage: PVC restore recovers object storage (including CNPG Barman archives)
-  # database: PVC restore alone does NOT recover CNPG databases -- the operator
-  #   runs initdb regardless. Full DB recovery requires bootstrap.recovery with
-  #   barmanObjectStore pointing at the restored Garage S3 (follow-up work).
+  # database: PVC restore recovers CNPG data PVCs (Barman recovery reads WALs from Garage)
   includedNamespaces:
     - garage
     - database


### PR DESCRIPTION
## Summary

Closes #725

Establishes the CNPG recovery bootstrap path for the live cluster so that any future rebuild automatically recovers databases from Barman S3 archives instead of running `initdb`. This is the prerequisite for the live cluster inauguration — after this PR is merged and live is rebuilt, the cluster begins carrying real user data.

- **Velero restore exclusion**: `restore-platform.yaml` now excludes `clusters.postgresql.cnpg.io` so the backed-up Cluster CR (with `initdb`) is not restored, allowing Flux to apply the recovery-patched version instead
- **Recovery patch**: Kustomize strategic merge patch adds `spec.bootstrap.recovery` with `externalClusters` pointing at Barman archives in Garage S3 — composes cleanly with the existing `cluster-roles-patch.yaml` (12 managed roles)
- **Activation runbook**: Documents the full live inauguration procedure (pre-flight backup verification, cluster rebuild, post-rebuild validation)

All changes mirror the working dev cluster implementation that was validated during the DR exercise.

## Test plan

- [x] `kustomize build` confirms recovery-patch and cluster-roles-patch compose correctly on the Cluster CR
- [x] `kustomize build` confirms `excludedResources` present in Velero Restore
- [x] `task k8s:validate` passes (YAML lint, ResourceSet expansion, Helm templating, kubeconform, API deprecation)
- [ ] After merge + OCI promotion: follow activation runbook to rebuild live and verify CNPG recovery