### PR TITLE
fix(k8s): remove duplicate ENABLE_WEBSOCKET_SUPPORT from open-webui

### DIFF
--- a/kubernetes/clusters/live/charts/open-webui.yaml
+++ b/kubernetes/clusters/live/charts/open-webui.yaml
@@ -32,8 +32,6 @@ extraEnvVars:
         key: password
   - name: DATABASE_URL
     value: "postgresql://open-webui:$(DB_PASSWORD)@platform-pooler-rw.database.svc.cluster.local:5432/open-webui"
-  - name: ENABLE_WEBSOCKET_SUPPORT
-    value: "True"
   - name: WEBSOCKET_MANAGER
     value: "redis"
   - name: DRAGONFLY_PASS


### PR DESCRIPTION
## Summary
- Remove duplicate `ENABLE_WEBSOCKET_SUPPORT` env var from open-webui HelmRelease values
- The open-webui Helm chart v13.3.1 now natively sets this variable, causing a duplicate key conflict
- Error: `failed to create typed patch object: .spec.template.spec.containers[name="open-webui"].env: duplicate entries for key [name="ENABLE_WEBSOCKET_SUPPORT"]`

## Test plan
- [ ] PR pipeline passes validation
- [ ] Integration cluster reconciles open-webui HelmRelease successfully
- [ ] Live cluster open-webui exits retry loop and becomes Ready