### PR TITLE
fix(k8s): update descheduler namespace filtering for v1alpha2 API

### DIFF
--- a/kubernetes/platform/charts/descheduler.yaml
+++ b/kubernetes/platform/charts/descheduler.yaml
@@ -14,9 +14,12 @@ deschedulerPolicy:
             evictLocalStoragePods: true
             evictSystemCriticalPods: false
             nodeFit: true
-            namespaces:
-              exclude:
-                - velero
+            namespaceLabelSelector:
+              matchExpressions:
+                - key: kubernetes.io/metadata.name
+                  operator: NotIn
+                  values:
+                    - velero
         - name: RemovePodsViolatingInterPodAntiAffinity
         - name: RemovePodsViolatingNodeAffinity
           args:


### PR DESCRIPTION
## Summary
- Replace invalid `namespaces.exclude` field with `namespaceLabelSelector` in DefaultEvictor plugin args
- Descheduler chart v0.35.1 uses `descheduler/v1alpha2` which enforces strict decoding and rejects the legacy `namespaces` field
- Uses `kubernetes.io/metadata.name NotIn [velero]` label selector — same behavior, correct API

## Test plan
- [ ] PR pipeline passes validation
- [ ] Integration cluster descheduler pods start without CrashLoopBackOff
- [ ] Live cluster descheduler pods become Ready