### PR TITLE
feat(secrets): persist authelia encryption keys in AWS SSM

### DIFF
--- a/infrastructure/stacks/global/terragrunt.stack.hcl
+++ b/infrastructure/stacks/global/terragrunt.stack.hcl
@@ -29,3 +29,8 @@ unit "lldap_secrets" {
   source = "../../units/lldap-secrets"
   path   = "lldap-secrets"
 }
+
+unit "authelia_secrets" {
+  source = "../../units/authelia-secrets"
+  path   = "authelia-secrets"
+}

--- a/infrastructure/units/authelia-secrets/terragrunt.hcl
+++ b/infrastructure/units/authelia-secrets/terragrunt.hcl
@@ -1,0 +1,21 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../../.././/modules/app-secrets"
+}
+
+inputs = {
+  name = "authelia"
+
+  secrets = {
+    STORAGE_ENCRYPTION_KEY = { length = 64, special = false }
+    SESSION_ENCRYPTION_KEY = { length = 64, special = false }
+    JWT_TOKEN              = { length = 64, special = false }
+  }
+
+  ssm_parameter_path = "/homelab/kubernetes/live/authelia-secrets"
+
+  local_backup_path = pathexpand("~/.secrets/homelab/authelia-secrets.json")
+}

--- a/infrastructure/units/authelia-secrets/terragrunt.hcl
+++ b/infrastructure/units/authelia-secrets/terragrunt.hcl
@@ -10,9 +10,10 @@ inputs = {
   name = "authelia"
 
   secrets = {
-    STORAGE_ENCRYPTION_KEY = { length = 64, special = false }
-    SESSION_ENCRYPTION_KEY = { length = 64, special = false }
-    JWT_TOKEN              = { length = 64, special = false }
+    storage_encryption_key = { length = 64, special = false }
+    session_encryption_key = { length = 64, special = false }
+    jwt_hmac_key           = { length = 64, special = false }
+    oidc_hmac_key          = { length = 64, special = false }
   }
 
   ssm_parameter_path = "/homelab/kubernetes/live/authelia-secrets"

--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -184,7 +184,7 @@ configMap:
         - ForwardAuth
 
 secret:
-  existingSecret: ''
+  existingSecret: 'authelia-secrets'
   additionalSecrets:
     lldap-secrets: { }
     authelia-db-credentials: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/authelia-secrets.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/authelia-secrets.yaml
@@ -1,7 +1,7 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
 # Pulls Authelia core secrets from AWS SSM. These must be persistent because
-# STORAGE_ENCRYPTION_KEY encrypts data at rest in PostgreSQL and must match
+# storage.encryption.key encrypts data at rest in PostgreSQL and must match
 # across cluster restores.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -16,15 +16,19 @@ spec:
   target:
     name: authelia-secrets
   data:
-    - secretKey: STORAGE_ENCRYPTION_KEY
+    - secretKey: storage.encryption.key
       remoteRef:
         key: /homelab/kubernetes/live/authelia-secrets
-        property: STORAGE_ENCRYPTION_KEY
-    - secretKey: SESSION_ENCRYPTION_KEY
+        property: storage_encryption_key
+    - secretKey: session.encryption.key
       remoteRef:
         key: /homelab/kubernetes/live/authelia-secrets
-        property: SESSION_ENCRYPTION_KEY
-    - secretKey: JWT_TOKEN
+        property: session_encryption_key
+    - secretKey: identity_validation.reset_password.jwt.hmac.key
       remoteRef:
         key: /homelab/kubernetes/live/authelia-secrets
-        property: JWT_TOKEN
+        property: jwt_hmac_key
+    - secretKey: identity_providers.oidc.hmac.key
+      remoteRef:
+        key: /homelab/kubernetes/live/authelia-secrets
+        property: oidc_hmac_key

--- a/kubernetes/clusters/live/config/authelia-prereqs/authelia-secrets.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/authelia-secrets.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Pulls Authelia core secrets from AWS SSM. These must be persistent because
+# STORAGE_ENCRYPTION_KEY encrypts data at rest in PostgreSQL and must match
+# across cluster restores.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authelia-secrets
+  namespace: authelia
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: authelia-secrets
+  data:
+    - secretKey: STORAGE_ENCRYPTION_KEY
+      remoteRef:
+        key: /homelab/kubernetes/live/authelia-secrets
+        property: STORAGE_ENCRYPTION_KEY
+    - secretKey: SESSION_ENCRYPTION_KEY
+      remoteRef:
+        key: /homelab/kubernetes/live/authelia-secrets
+        property: SESSION_ENCRYPTION_KEY
+    - secretKey: JWT_TOKEN
+      remoteRef:
+        key: /homelab/kubernetes/live/authelia-secrets
+        property: JWT_TOKEN

--- a/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - lldap-db-credentials.yaml
   - authelia-db-credentials.yaml
   - grafana-oidc-client-secret.yaml
+  - authelia-secrets.yaml


### PR DESCRIPTION
## Summary
- Persist Authelia core secrets (`STORAGE_ENCRYPTION_KEY`, `SESSION_ENCRYPTION_KEY`, `JWT_TOKEN`) in AWS SSM via the `app-secrets` Terragrunt module
- Add ExternalSecret to pull keys from SSM into the `authelia-secrets` Kubernetes Secret
- Set `existingSecret: authelia-secrets` in Authelia HelmRelease so the chart uses externally-managed keys instead of auto-generating them
- Prevents crash-loops after Velero cluster restore due to encryption key / database mismatch

## Pre-merge steps
Before merging, the SSM parameter must be seeded with the current encryption keys from the live cluster:
1. `task tg:apply-global` to create the SSM parameter
2. Extract current keys: `kubectl --context live -n authelia get secret authelia -o jsonpath='{.data.STORAGE_ENCRYPTION_KEY}' | base64 -d`
3. Overwrite SSM parameter with extracted values via AWS CLI

## Test plan
- [x] `task tg:validate-global` passes
- [x] `task k8s:validate` passes
- [ ] SSM parameter seeded with current live cluster keys
- [ ] After merge: ExternalSecret syncs successfully
- [ ] After merge: Authelia pods start without encryption key mismatch