### PR TITLE
fix(k8s): remove longhorn-instance-manager version hold

### DIFF
--- a/.github/version-holds.yaml
+++ b/.github/version-holds.yaml
@@ -9,8 +9,3 @@ holds:
     reason: "v3.41.x healthcheck regression blocks DNS queries to kube-dns after VPN tunnel establishment"
     upstream_issue: https://github.com/qdm12/gluetun/issues/3132
     created: "2026-02-18"
-  - dep: longhorn-instance-manager
-    constraint: n/a
-    reason: "v1.11.0 instance manager memory leak; using hotfix image override until v1.11.1+ includes the fix in chart defaults"
-    upstream_issue: https://github.com/longhorn/longhorn/issues/12705
-    created: "2026-03-03"

--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -1,11 +1,5 @@
 ---
 # https://raw.githubusercontent.com/longhorn/charts/master/charts/longhorn/values.yaml
-# Temporary instance manager image override for v1.11.0 memory leak hotfix
-# https://github.com/longhorn/longhorn/issues/12573
-image:
-  longhorn:
-    instanceManager:
-      tag: ${longhorn_instance_manager_tag}
 longhornManager:
   priorityClass: infrastructure-critical
 longhornDriver:

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -30,8 +30,6 @@ descheduler_version=0.35.1
 metrics_server_version=3.13.0
 # renovate: datasource=helm depName=longhorn registryUrl=https://charts.longhorn.io
 longhorn_version=1.11.1
-# renovate: datasource=docker depName=longhorn-instance-manager packageName=docker.io/longhornio/longhorn-instance-manager versioning=regex:^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-hotfix-(?<build>\d+))?$
-longhorn_instance_manager_tag=v1.11.1
 # renovate: datasource=helm depName=reloader registryUrl=https://stakater.github.io/stakater-charts
 reloader_version=2.2.11
 # renovate: datasource=helm depName=kubernetes-replicator registryUrl=https://helm.mittwald.de


### PR DESCRIPTION
## Summary
- Remove the `longhorn-instance-manager` entry from `.github/version-holds.yaml` (upstream issue longhorn/longhorn#12705 is closed)
- Remove the hotfix image tag override from `kubernetes/platform/charts/longhorn.yaml` (v1.11.1 chart defaults include the fix)
- Remove the `longhorn_instance_manager_tag` version entry and Renovate annotation from `kubernetes/platform/versions.env`

## Test plan
- [x] `task k8s:validate` passes (ResourceSet expansion, Helm templating, schema validation, deprecation checks)
- [x] `task renovate:validate` passes
- [ ] After merge, verify longhorn instance-manager pods use the chart-default image tag

Closes #745