### PR TITLE
feat(k8s): deploy draw.io diagramming tool

### DIFF
--- a/kubernetes/platform/charts/drawio.yaml
+++ b/kubernetes/platform/charts/drawio.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-4.6.0/charts/other/app-template/values.schema.json
+# https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+controllers:
+  drawio:
+    type: deployment
+    replicas: 1
+
+    containers:
+      app:
+        image:
+          repository: jgraph/drawio
+          # renovate: datasource=docker depName=jgraph/drawio
+          tag: v29.7.9
+        env:
+          DRAWIO_SELF_CONTAINED: "1"
+        securityContext:
+          readOnlyRootFilesystem: false
+        resources:
+          requests:
+            cpu: 10m
+            memory: 256Mi
+          limits:
+            memory: 1Gi
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: 8080
+              initialDelaySeconds: 15
+              periodSeconds: 30
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: 8080
+              initialDelaySeconds: 10
+              periodSeconds: 10
+
+service:
+  app:
+    controller: drawio
+    ports:
+      http:
+        port: 8080

--- a/kubernetes/platform/config.yaml
+++ b/kubernetes/platform/config.yaml
@@ -55,6 +55,10 @@ spec:
       namespace: cache
       path: kubernetes/platform/config/dragonfly
       dependsOn: [dragonfly-operator, garage-config, canary-checker]
+    - name: drawio-config
+      namespace: drawio
+      path: kubernetes/platform/config/drawio
+      dependsOn: [drawio]
     - name: kromgo-config
       namespace: kromgo
       path: kubernetes/platform/config/kromgo

--- a/kubernetes/platform/config/drawio/internal-route.yaml
+++ b/kubernetes/platform/config/drawio/internal-route.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: drawio-internal
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Draw.io"
+    gethomepage.dev/group: "Platform"
+    gethomepage.dev/icon: "drawio.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=drawio"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: istio-gateway
+  hostnames:
+    - "drawio.${internal_domain}"
+  rules:
+    - backendRefs:
+        - name: drawio
+          port: 8080

--- a/kubernetes/platform/config/drawio/kustomization.yaml
+++ b/kubernetes/platform/config/drawio/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - internal-route.yaml

--- a/kubernetes/platform/helm-charts.yaml
+++ b/kubernetes/platform/helm-charts.yaml
@@ -182,6 +182,13 @@ spec:
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
       dependsOn: [kube-prometheus-stack]
+    - name: drawio
+      namespace: drawio
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: [cilium]
     - name: spegel
       namespace: spegel
       chart:

--- a/kubernetes/platform/kustomization.yaml
+++ b/kubernetes/platform/kustomization.yaml
@@ -18,6 +18,7 @@ configMapGenerator:
       - cloudnative-pg.yaml=charts/cloudnative-pg.yaml
       - dragonfly-operator.yaml=charts/dragonfly-operator.yaml
       - descheduler.yaml=charts/descheduler.yaml
+      - drawio.yaml=charts/drawio.yaml
       - external-secrets.yaml=charts/external-secrets.yaml
       - garage-operator.yaml=charts/garage-operator.yaml
       - grafana-loki-single-binary.yaml=charts/grafana-loki-single-binary.yaml

--- a/kubernetes/platform/namespaces.yaml
+++ b/kubernetes/platform/namespaces.yaml
@@ -42,6 +42,12 @@ spec:
       dataplane: ambient
       security: restricted
       networkPolicy: false
+    - name: drawio
+      dataplane: ambient
+      security: baseline
+      networkPolicy:
+        profile: internal
+        enforcement: ""
     # --- baseline: require some elevated capabilities (e.g. NET_BIND_SERVICE) ---
     - name: cache
       dataplane: ambient

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -89,6 +89,10 @@ nvidia_device_plugin_version=0.19.0
 # renovate: datasource=helm depName=dcgm-exporter registryUrl=https://nvidia.github.io/dcgm-exporter/helm-charts
 dcgm_exporter_version=4.8.1
 
+# Draw.io (diagramming tool)
+# renovate: datasource=docker depName=drawio packageName=jgraph/drawio
+drawio_version=v29.7.9
+
 # Container image versions (Flux substitution into platform config CRs)
 # renovate: datasource=docker depName=garage packageName=dxflrs/garage
 garage_image_version=v2.3.0


### PR DESCRIPTION
## Summary
- Deploy Draw.io (`jgraph/drawio:v29.7.9`) as an internal-only web-based diagramming tool
- Uses bjw-s/app-template Helm chart pattern (stateless, no persistence needed)
- Exposed via internal gateway HTTPRoute at `drawio.${internal_domain}`
- Baseline PodSecurity with `internal` network policy profile

Closes #721

## Changes
- `versions.env`: add `drawio_version=v29.7.9` with Renovate docker datasource annotation
- `namespaces.yaml`: add `drawio` namespace (baseline security, internal network profile)
- `helm-charts.yaml`: add drawio HelmRelease using app-template
- `charts/drawio.yaml`: app-template values (port 8080, health probes, resource limits)
- `config/drawio/`: internal HTTPRoute with homepage annotations
- `kustomization.yaml`: register drawio values file
- `config.yaml`: register drawio-config Kustomization

## Test plan
- [ ] Verify `task k8s:validate` passes (confirmed locally)
- [ ] Verify `task renovate:validate` passes (confirmed locally)
- [ ] Pipeline promotes through integration cluster
- [ ] Draw.io pod starts and passes health checks
- [ ] HTTPRoute resolves at `drawio.${internal_domain}`
- [ ] Network policy allows internal gateway traffic only