### PR TITLE
feat(k8s): deploy draw.io to live cluster

### DIFF
--- a/kubernetes/clusters/live/charts/drawio.yaml
+++ b/kubernetes/clusters/live/charts/drawio.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+# https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+controllers:
+  drawio:
+    type: deployment
+    replicas: 1
+
+    containers:
+      app:
+        image:
+          repository: jgraph/drawio
+          tag: "${drawio_version}"
+        env:
+          DRAWIO_SELF_CONTAINED: "1"
+        securityContext:
+          readOnlyRootFilesystem: false
+        resources:
+          requests:
+            cpu: 10m
+            memory: 256Mi
+          limits:
+            memory: 1Gi
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: 8080
+              initialDelaySeconds: 15
+              periodSeconds: 30
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: 8080
+              initialDelaySeconds: 10
+              periodSeconds: 10
+
+service:
+  app:
+    controller: drawio
+    ports:
+      http:
+        port: 8080

--- a/kubernetes/clusters/live/charts/kustomization.yaml
+++ b/kubernetes/clusters/live/charts/kustomization.yaml
@@ -11,6 +11,7 @@ configMapGenerator:
     files:
       - authelia.yaml
       - bazarr.yaml
+      - drawio.yaml
       - exportarr.yaml
       - factorio.yaml
       - homepage.yaml

--- a/kubernetes/clusters/live/config/drawio/internal-route.yaml
+++ b/kubernetes/clusters/live/config/drawio/internal-route.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: drawio-internal
+  namespace: drawio
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Draw.io"
+    gethomepage.dev/group: "Apps"
+    gethomepage.dev/icon: "drawio.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=drawio"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: istio-gateway
+  hostnames:
+    - "drawio.${internal_domain}"
+  rules:
+    - backendRefs:
+        - name: drawio
+          port: 8080

--- a/kubernetes/clusters/live/config/drawio/kustomization.yaml
+++ b/kubernetes/clusters/live/config/drawio/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - internal-route.yaml

--- a/kubernetes/clusters/live/config/drawio/namespace.yaml
+++ b/kubernetes/clusters/live/config/drawio/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: drawio
+  labels:
+    istio.io/dataplane-mode: ambient
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+    network-policy.homelab/profile: internal

--- a/kubernetes/clusters/live/config/kustomization.yaml
+++ b/kubernetes/clusters/live/config/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - drawio
   - zipline
   - vaultwarden
   - immich

--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -57,6 +57,13 @@ spec:
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
       dependsOn: [secret-generator]
+    - name: drawio
+      namespace: drawio
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: []
     - name: factorio
       namespace: factorio
       chart:
@@ -204,6 +211,13 @@ spec:
         version: "${open_webui_version}"
         url: "https://helm.openwebui.com"
       dependsOn: [ollama, cloudnative-pg, secret-generator]
+    - name: drawio
+      namespace: drawio
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: []
   resourcesTemplate: |
     ---
     apiVersion: source.toolkit.fluxcd.io/v1

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -11,6 +11,9 @@ authelia_version=0.10.58
 # renovate: datasource=helm depName=open-webui registryUrl=https://helm.openwebui.com
 open_webui_version=13.3.1
 
+# renovate: datasource=docker depName=drawio packageName=jgraph/drawio
+drawio_version=v29.7.9
+
 # Container image versions (Flux substitution into chart values)
 # renovate: datasource=docker depName=ghcr.io/immich-app/immich-machine-learning versioning=regex:^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-cuda$
 immich_ml_cuda_tag=v2.7.2-cuda
@@ -56,6 +59,8 @@ homepage_version=v1.10.1
 ollama_version=0.21.0
 # renovate: datasource=docker depName=exportarr packageName=ghcr.io/onedr0p/exportarr
 exportarr_version=v2.3.0
+# renovate: datasource=docker depName=drawio packageName=jgraph/drawio
+drawio_version=v29.7.9
 # renovate: datasource=docker depName=gluetun packageName=ghcr.io/qdm12/gluetun
 gluetun_version=v3.40.4
 


### PR DESCRIPTION
## Summary

- Deploy [Draw.io](https://github.com/jgraph/docker-drawio) as a live cluster-specific app using app-template
- Exposes at `drawio.${internal_domain}` via internal gateway HTTPRoute
- Creates `drawio` namespace with `baseline` PodSecurity and `internal` network policy profile
- Container image `jgraph/drawio:v29.7.9` with Renovate tracking
- Self-contained mode (`DRAWIO_SELF_CONTAINED=1`) disables external service calls

Closes #721

## Test plan

- [ ] Verify `task k8s:validate` passes
- [ ] Confirm pod starts and becomes Ready in live
- [ ] Confirm `drawio.${internal_domain}` resolves and serves the UI
- [ ] Confirm no Hubble drops for the `drawio` namespace