### PR TITLE
Fix Dragonfly Lua key errors breaking Immich uploads

### DIFF
--- a/kubernetes/clusters/live/charts/homepage.yaml
+++ b/kubernetes/clusters/live/charts/homepage.yaml
@@ -26,7 +26,7 @@ controllers:
           readOnlyRootFilesystem: false
           runAsNonRoot: false
           capabilities:
-            drop: [ "ALL" ]
+            drop: ["ALL"]
         image:
           repository: ghcr.io/gethomepage/homepage
           tag: "${homepage_version}"

--- a/kubernetes/clusters/live/charts/lldap.yaml
+++ b/kubernetes/clusters/live/charts/lldap.yaml
@@ -35,7 +35,7 @@ controllers:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           capabilities:
-            drop: [ ALL ]
+            drop: [ALL]
 
     containers:
       app:
@@ -60,7 +60,7 @@ controllers:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           capabilities:
-            drop: [ ALL ]
+            drop: [ALL]
         resources:
           requests:
             cpu: 10m

--- a/kubernetes/clusters/live/charts/tandoor.yaml
+++ b/kubernetes/clusters/live/charts/tandoor.yaml
@@ -76,7 +76,7 @@ controllers:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
           capabilities:
-            drop: [ ALL ]
+            drop: [ALL]
         resources:
           requests:
             cpu: 50m

--- a/kubernetes/clusters/live/charts/zipline.yaml
+++ b/kubernetes/clusters/live/charts/zipline.yaml
@@ -63,7 +63,7 @@ controllers:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
           capabilities:
-            drop: [ ALL ]
+            drop: [ALL]
         resources:
           requests:
             cpu: 50m

--- a/kubernetes/platform/config/dragonfly/dragonfly-instance.yaml
+++ b/kubernetes/platform/config/dragonfly/dragonfly-instance.yaml
@@ -44,6 +44,7 @@ spec:
     - "--s3_endpoint"
     - "${garage_s3_endpoint}"
     - "--s3_use_https=false"
+    - "--default_lua_flags=allow-undeclared-keys"
 
   env:
     - name: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
## Summary

- Adds `--default_lua_flags=allow-undeclared-keys` to the Dragonfly instance args
- Fixes BullMQ compatibility issue where Immich background tasks fail with `ERR script tried accessing undeclared key`
- Resolves Immich upload failures caused by job queue errors

## Test plan

- [ ] Verify Dragonfly pods restart cleanly after reconciliation
- [ ] Confirm `immich_bull:backgroundTask` errors stop appearing in Immich server logs
- [ ] Test photo upload in Immich completes successfully