### PR TITLE
Switch Authelia notifier to Gmail SMTP relay

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -33,7 +33,7 @@ pod:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
       capabilities:
-        drop: [ ALL ]
+        drop: [ALL]
 configMap:
   theme: dark
 
@@ -219,10 +219,10 @@ configMap:
 secret:
   existingSecret: "authelia-secrets"
   additionalSecrets:
-    lldap-secrets: {}
-    authelia-db-credentials: {}
-    dragonfly-auth: {}
-    grafana-oidc-client-secret: {}
-    open-webui-oidc-client-secret: {}
-    immich-oidc-client-secret: {}
-    authelia-smtp-credentials: {}
+    lldap-secrets: { }
+    authelia-db-credentials: { }
+    dragonfly-auth: { }
+    grafana-oidc-client-secret: { }
+    open-webui-oidc-client-secret: { }
+    immich-oidc-client-secret: { }
+    authelia-smtp-credentials: { }

--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -6,18 +6,20 @@ pod:
   replicas: 2
   annotations:
     reloader.stakater.com/auto: "true"
+  env:
+    - name: AUTHELIA_SMTP_SENDER
+      valueFrom:
+        secretKeyRef:
+          name: authelia-smtp-credentials
+          key: sender
   extraVolumeMounts:
     - name: oidc-jwk
       mountPath: /secrets/oidc-jwk
       readOnly: true
-    - name: notification
-      mountPath: /config
   extraVolumes:
     - name: oidc-jwk
       secret:
         secretName: authelia-oidc-jwk
-    - name: notification
-      emptyDir: {}
   securityContext:
     pod:
       runAsNonRoot: true
@@ -100,9 +102,16 @@ configMap:
         path: password
 
   notifier:
-    filesystem:
+    smtp:
       enabled: true
-      filename: /config/notification.txt
+      address: submissions://smtp.gmail.com:465
+      sender: '{{ env "AUTHELIA_SMTP_SENDER" }}'
+      username:
+        secret_name: authelia-smtp-credentials
+        path: username
+      password:
+        secret_name: authelia-smtp-credentials
+        path: password
 
   telemetry:
     metrics:
@@ -216,3 +225,4 @@ secret:
     grafana-oidc-client-secret: {}
     open-webui-oidc-client-secret: {}
     immich-oidc-client-secret: {}
+    authelia-smtp-credentials: {}

--- a/kubernetes/clusters/live/config/authelia-prereqs/authelia-smtp-credentials.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/authelia-smtp-credentials.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Pulls SMTP relay credentials from AWS SSM for Authelia email notifications.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authelia-smtp-credentials
+  namespace: authelia
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: authelia-smtp-credentials
+  data:
+    - secretKey: username
+      remoteRef:
+        key: /homelab/kubernetes/live/authelia-smtp-credentials
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: /homelab/kubernetes/live/authelia-smtp-credentials
+        property: password
+    - secretKey: sender
+      remoteRef:
+        key: /homelab/kubernetes/live/authelia-smtp-credentials
+        property: sender

--- a/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - authelia-db-credentials.yaml
   - grafana-oidc-client-secret.yaml
   - authelia-secrets.yaml
+  - authelia-smtp-credentials.yaml


### PR DESCRIPTION
## Summary
- Replace filesystem notifier with SMTP via `smtp.gmail.com` so TOTP registration and password reset emails are delivered directly
- Add ExternalSecret (`authelia-smtp-credentials`) pulling username, password, and sender from AWS SSM
- Inject sender address via env var + Authelia Go template filter to keep it out of git
- Remove unused notification emptyDir volume mount

## Test plan
- [ ] ExternalSecret syncs successfully: `kubectl --context live -n authelia get externalsecret authelia-smtp-credentials`
- [ ] Authelia pods restart cleanly with new SMTP config
- [ ] Trigger a TOTP registration or password reset and verify email arrives at the user's inbox