### PR TITLE
Fix Authelia SMTP: network policy + env var rename

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -7,7 +7,7 @@ pod:
   annotations:
     reloader.stakater.com/auto: "true"
   env:
-    - name: AUTHELIA_SMTP_SENDER
+    - name: SMTP_SENDER
       valueFrom:
         secretKeyRef:
           name: authelia-smtp-credentials
@@ -105,7 +105,7 @@ configMap:
     smtp:
       enabled: true
       address: submissions://smtp.gmail.com:465
-      sender: '{{ env "AUTHELIA_SMTP_SENDER" }}'
+      sender: '{{ env "SMTP_SENDER" }}'
       username:
         secret_name: authelia-smtp-credentials
         path: username

--- a/kubernetes/clusters/live/config/authelia-prereqs/authelia-smtp-egress.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/authelia-smtp-egress.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+# Allows Authelia to reach Gmail SMTP for sending notification emails
+# (TOTP registration, password reset). The standard profile only permits
+# egress to port 443; SMTPS uses port 465.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: authelia-smtp-egress
+  namespace: authelia
+spec:
+  description: "Allow Authelia SMTP egress to Gmail (port 465)"
+  endpointSelector: { }
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "465"
+              protocol: TCP

--- a/kubernetes/clusters/live/config/authelia-prereqs/immich-oidc-client-secret.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/immich-oidc-client-secret.yaml
@@ -10,4 +10,4 @@ metadata:
     secret-generator.v1.mittwald.de/length: "64"
     replicator.v1.mittwald.de/replication-allowed: "true"
     replicator.v1.mittwald.de/replication-allowed-namespaces: "monitoring"
-data: {}
+data: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - grafana-oidc-client-secret.yaml
   - authelia-secrets.yaml
   - authelia-smtp-credentials.yaml
+  - authelia-smtp-egress.yaml


### PR DESCRIPTION
## Summary
- Add `CiliumNetworkPolicy` allowing egress to port 465 (SMTPS) from the authelia namespace — the `standard` profile only permits port 443
- Rename env var from `AUTHELIA_SMTP_SENDER` to `SMTP_SENDER` to prevent Authelia from interpreting the `AUTHELIA_` prefix as a config override

## Context
Follow-up to #834. Authelia pods were crash-looping with `failed to dial connection: EOF` because the network policy blocked outbound SMTP traffic to `smtp.gmail.com:465`.

## Test plan
- [ ] Authelia pods start without crash loop
- [ ] No `configuration environment variable not expected` warning in logs
- [ ] TOTP registration email arrives successfully