### PR TITLE
Fix Authelia SMTP username rendering

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -12,6 +12,11 @@ pod:
         secretKeyRef:
           name: authelia-smtp-credentials
           key: sender
+    - name: SMTP_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: authelia-smtp-credentials
+          key: username
   extraVolumeMounts:
     - name: oidc-jwk
       mountPath: /secrets/oidc-jwk
@@ -106,9 +111,7 @@ configMap:
       enabled: true
       address: submissions://smtp.gmail.com:465
       sender: '{{ env "SMTP_SENDER" }}'
-      username:
-        secret_name: authelia-smtp-credentials
-        path: username
+      username: '{{ env "SMTP_USERNAME" }}'
       password:
         secret_name: authelia-smtp-credentials
         path: password


### PR DESCRIPTION
## Summary
- Fix SMTP authentication failure caused by `username` being passed as a `secret_name`/`path` map instead of a plain string
- The Authelia chart renders `smtp.username` as a plain config value (`squote`), not via the `_FILE` secret pattern — passing a map caused it to render as `map[path:username secret_name:...]`
- Use the same env var + Go template approach (`{{ env "SMTP_USERNAME" }}`) as the sender field

## Context
Follow-up to #835. Gmail returned `535 5.7.8 Username and Password not accepted` because the username field contained a Go map literal instead of the email address.

## Test plan
- [ ] Authelia pods start without crash loop
- [ ] No SMTP auth errors in logs
- [ ] TOTP registration email arrives