### PR TITLE
Add LLDAP bootstrap job and photos group access control

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -143,13 +143,20 @@ configMap:
             - name
             - groups
             - preferred_username
+      authorization_policies:
+        photos:
+          default_policy: deny
+          rules:
+            - policy: two_factor
+              subject:
+                - - "group:photos"
       clients:
         - client_id: "immich"
           client_name: Immich
           client_secret:
             path: /secrets/immich-oidc-client-secret/client-secret
           public: false
-          authorization_policy: two_factor
+          authorization_policy: photos
           require_pkce: true
           pkce_challenge_method: S256
           redirect_uris:

--- a/kubernetes/clusters/live/config/authelia/kustomization.yaml
+++ b/kubernetes/clusters/live/config/authelia/kustomization.yaml
@@ -10,3 +10,10 @@ resources:
   - authelia-canary.yaml
   - prometheus-rules.yaml
   - lldap-bootstrap-job.yaml
+configMapGenerator:
+  - name: lldap-bootstrap-scripts
+    namespace: authelia
+    files:
+      - bootstrap.sh=lldap-bootstrap.sh
+    options:
+      disableNameSuffixHash: true

--- a/kubernetes/clusters/live/config/authelia/kustomization.yaml
+++ b/kubernetes/clusters/live/config/authelia/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - network-policy.yaml
   - authelia-canary.yaml
   - prometheus-rules.yaml
+  - lldap-bootstrap-job.yaml

--- a/kubernetes/clusters/live/config/authelia/lldap-bootstrap-job.yaml
+++ b/kubernetes/clusters/live/config/authelia/lldap-bootstrap-job.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lldap-bootstrap
+  namespace: authelia
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: Enabled
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: lldap-bootstrap
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: bootstrap
+          image: ghcr.io/lldap/lldap:v0.6.2
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+
+              echo "Waiting for LLDAP to be ready..."
+              until wget -q -O /dev/null "${LLDAP_URL}/health" 2>/dev/null; do
+                echo "LLDAP not ready, retrying in 5s..."
+                sleep 5
+              done
+              echo "LLDAP is ready"
+
+              LOGIN_RESPONSE=$(wget -q -O - \
+                --header="Content-Type: application/json" \
+                --post-data="{\"username\":\"${LLDAP_ADMIN_USERNAME}\",\"password\":\"${LLDAP_ADMIN_PASSWORD}\"}" \
+                "${LLDAP_URL}/auth/simple/login")
+
+              TOKEN=$(echo "$LOGIN_RESPONSE" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
+              if [ -z "$TOKEN" ]; then
+                echo "ERROR: Failed to authenticate with LLDAP"
+                exit 1
+              fi
+              echo "Authenticated successfully"
+
+              create_group() {
+                local name="$1"
+                RESPONSE=$(wget -q -O - \
+                  --header="Content-Type: application/json" \
+                  --header="Authorization: Bearer ${TOKEN}" \
+                  --post-data="{\"query\":\"mutation { createGroup(name: \\\"${name}\\\") { id displayName } }\"}" \
+                  "${LLDAP_URL}/api/graphql" 2>&1) || true
+
+                if echo "$RESPONSE" | grep -q "displayName"; then
+                  echo "Group '${name}' created"
+                elif echo "$RESPONSE" | grep -q "already exists"; then
+                  echo "Group '${name}' already exists"
+                else
+                  echo "Group '${name}': ${RESPONSE}"
+                fi
+              }
+
+              create_group "photos"
+              echo "Bootstrap complete"
+          env:
+            - name: LLDAP_URL
+              value: "http://lldap.authelia.svc.cluster.local:17170"
+            - name: LLDAP_ADMIN_USERNAME
+              value: admin
+            - name: LLDAP_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: lldap-secrets
+                  key: LLDAP_LDAP_USER_PASS
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi

--- a/kubernetes/clusters/live/config/authelia/lldap-bootstrap-job.yaml
+++ b/kubernetes/clusters/live/config/authelia/lldap-bootstrap-job.yaml
@@ -23,50 +23,7 @@ spec:
       containers:
         - name: bootstrap
           image: ghcr.io/lldap/lldap:v0.6.2
-          command:
-            - /bin/bash
-            - -c
-            - |
-              set -euo pipefail
-
-              echo "Waiting for LLDAP to be ready..."
-              until wget -q -O /dev/null "${LLDAP_URL}/health" 2>/dev/null; do
-                echo "LLDAP not ready, retrying in 5s..."
-                sleep 5
-              done
-              echo "LLDAP is ready"
-
-              LOGIN_RESPONSE=$(wget -q -O - \
-                --header="Content-Type: application/json" \
-                --post-data="{\"username\":\"${LLDAP_ADMIN_USERNAME}\",\"password\":\"${LLDAP_ADMIN_PASSWORD}\"}" \
-                "${LLDAP_URL}/auth/simple/login")
-
-              TOKEN=$(echo "$LOGIN_RESPONSE" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
-              if [ -z "$TOKEN" ]; then
-                echo "ERROR: Failed to authenticate with LLDAP"
-                exit 1
-              fi
-              echo "Authenticated successfully"
-
-              create_group() {
-                local name="$1"
-                RESPONSE=$(wget -q -O - \
-                  --header="Content-Type: application/json" \
-                  --header="Authorization: Bearer ${TOKEN}" \
-                  --post-data="{\"query\":\"mutation { createGroup(name: \\\"${name}\\\") { id displayName } }\"}" \
-                  "${LLDAP_URL}/api/graphql" 2>&1) || true
-
-                if echo "$RESPONSE" | grep -q "displayName"; then
-                  echo "Group '${name}' created"
-                elif echo "$RESPONSE" | grep -q "already exists"; then
-                  echo "Group '${name}' already exists"
-                else
-                  echo "Group '${name}': ${RESPONSE}"
-                fi
-              }
-
-              create_group "photos"
-              echo "Bootstrap complete"
+          command: ["/bin/bash", "/scripts/bootstrap.sh"]
           env:
             - name: LLDAP_URL
               value: "http://lldap.authelia.svc.cluster.local:17170"
@@ -77,6 +34,10 @@ spec:
                 secretKeyRef:
                   name: lldap-secrets
                   key: LLDAP_LDAP_USER_PASS
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -88,3 +49,8 @@ spec:
               memory: 32Mi
             limits:
               memory: 64Mi
+      volumes:
+        - name: scripts
+          configMap:
+            name: lldap-bootstrap-scripts
+            defaultMode: 0555

--- a/kubernetes/clusters/live/config/authelia/lldap-bootstrap.sh
+++ b/kubernetes/clusters/live/config/authelia/lldap-bootstrap.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+LLDAP_URL="${LLDAP_URL:?must be set}"
+LLDAP_ADMIN_USERNAME="${LLDAP_ADMIN_USERNAME:?must be set}"
+LLDAP_ADMIN_PASSWORD="${LLDAP_ADMIN_PASSWORD:?must be set}"
+
+GROUPS="photos"
+
+echo "Waiting for LLDAP to be ready..."
+until wget -q -O /dev/null "${LLDAP_URL}/health" 2>/dev/null; do
+  echo "LLDAP not ready, retrying in 5s..."
+  sleep 5
+done
+echo "LLDAP is ready"
+
+LOGIN_RESPONSE=$(wget -q -O - \
+  --header="Content-Type: application/json" \
+  --post-data="{\"username\":\"${LLDAP_ADMIN_USERNAME}\",\"password\":\"${LLDAP_ADMIN_PASSWORD}\"}" \
+  "${LLDAP_URL}/auth/simple/login")
+
+TOKEN=$(echo "$LOGIN_RESPONSE" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
+if [ -z "$TOKEN" ]; then
+  echo "ERROR: Failed to authenticate with LLDAP"
+  exit 1
+fi
+echo "Authenticated successfully"
+
+create_group() {
+  local name="$1"
+  RESPONSE=$(wget -q -O - \
+    --header="Content-Type: application/json" \
+    --header="Authorization: Bearer ${TOKEN}" \
+    --post-data="{\"query\":\"mutation { createGroup(name: \\\"${name}\\\") { id displayName } }\"}" \
+    "${LLDAP_URL}/api/graphql" 2>&1) || true
+
+  if echo "$RESPONSE" | grep -q "displayName"; then
+    echo "Group '${name}' created"
+  elif echo "$RESPONSE" | grep -q "already exists"; then
+    echo "Group '${name}' already exists"
+  else
+    echo "Group '${name}': ${RESPONSE}"
+  fi
+}
+
+for group in $GROUPS; do
+  create_group "$group"
+done
+
+echo "Bootstrap complete"

--- a/kubernetes/clusters/live/config/immich/canary.yaml
+++ b/kubernetes/clusters/live/config/immich/canary.yaml
@@ -9,7 +9,7 @@ spec:
   schedule: "@every 1m"
   http:
     - name: immich-gateway-health
-      url: https://immich.${external_domain}
+      url: https://photos.${external_domain}
       responseCodes: [200]
       maxSSLExpiry: 7
       thresholdMillis: 5000

--- a/kubernetes/clusters/live/config/immich/external-route.yaml
+++ b/kubernetes/clusters/live/config/immich/external-route.yaml
@@ -19,7 +19,7 @@ spec:
     - name: external
       namespace: istio-gateway
   hostnames:
-    - "immich.${external_domain}"
+    - "photos.${external_domain}"
   rules:
     - backendRefs:
         - name: immich-server


### PR DESCRIPTION
## Summary

- **LLDAP Bootstrap Job**: Replaces the init container approach with a Kubernetes Job in the `authelia-config` Kustomization (`dependsOn: [lldap]`), avoiding the replica deadlock on fresh deploys. Uses wget/bash against the LLDAP GraphQL API to create groups idempotently. The `kustomize.toolkit.fluxcd.io/force: Enabled` annotation enables Flux to recreate the Job only when the spec changes.
- **Authelia OIDC authorization policy**: Adds a `photos` policy (`default_policy: deny`, allow `group:photos` with 2FA) and assigns it to the immich OIDC client, restricting access to users in the `photos` LLDAP group.
- **Immich external route rename**: Changes the external hostname from `immich.<domain>` to `photos.<domain>` (HTTPRoute + canary health check). Wildcard TLS cert already covers the new hostname.

## Test plan

- [ ] Verify lldap-bootstrap Job runs successfully after lldap is healthy (`kubectl logs -n authelia job/lldap-bootstrap`)
- [ ] Confirm `photos` group exists in LLDAP web UI
- [ ] Add a user to the `photos` group, verify OIDC login to immich works
- [ ] Verify a user NOT in the `photos` group is denied at the Authelia OIDC authorization step
- [ ] Verify `photos.<domain>` resolves and routes to immich
- [ ] Verify canary health check passes on the new URL