### PR TITLE
fix(longhorn): reduce storage over-provisioning from 500% to 200%

### DIFF
--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -20,7 +20,7 @@ defaultSettings:
   createDefaultDiskLabeledNodes: true
   storageReservedPercentageForDefaultDisk: 0
   nodeDownPodDeletionPolicy: delete-both-statefulset-and-deployment-pod
-  storageOverProvisioningPercentage: 500
+  storageOverProvisioningPercentage: 200
   storageMinimalAvailablePercentage: 10
 csi:
   attacherReplicaCount: ${default_replica_count}


### PR DESCRIPTION
## Summary

- Reduce `storageOverProvisioningPercentage` from 500 to 200 in Longhorn Helm values

## Context

500% over-provisioning allowed Longhorn to schedule far more volume replicas than physical disk capacity could sustain. On the integration cluster (3 nodes, ~118GB each), this led to complete disk exhaustion — all disks fell below the 10% minimum available threshold, making them unschedulable. All 15 volumes faulted, 8 pods stuck for 19+ hours.

200% provides reasonable headroom for volume scheduling while preventing catastrophic over-commitment on minimal-provisioned clusters.

## Test plan

- [ ] `task k8s:validate` passes
- [ ] Review current live disk utilization to confirm 200% won't block legitimate scheduling