### PR TITLE
fix(k8s): fix authelia OIDC authorization policy subject schema

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -149,7 +149,7 @@ configMap:
           rules:
             - policy: two_factor
               subject:
-                - - "group:photos"
+                - "group:photos"
       clients:
         - client_id: "immich"
           client_name: Immich


### PR DESCRIPTION
## Summary

- Fix authelia HelmRelease schema validation failure caused by chart upgrade from v0.11.0 to v0.11.4
- The `subject` field in the OIDC `authorization_policies.photos` rule used a legacy nested array format (`- - "group:photos"`) which the v0.11.4 schema rejects
- Changed to a flat array of strings (`- "group:photos"`) which matches the chart's `anyOf` schema expecting either `string` or `array of strings`

## Test plan

- [x] `task k8s:validate-live` passes with 0 invalid resources
- [ ] After merge, verify the authelia HelmRelease reconciles successfully on integration and live clusters