### PR TITLE
fix(renovate): split infrastructure versions into per-component groups

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -81,9 +81,28 @@
     // Platform version grouping (versions.env)
     // ============================================================
     {
-      // Infrastructure versions - NEVER automerge (cluster-critical)
-      "matchDepNames": ["talos", "kubernetes", "cilium", "gateway-api", "flux"],
-      "groupName": "infrastructure versions",
+      "matchDepNames": ["talos"],
+      "groupName": "talos",
+      "automerge": false
+    },
+    {
+      "matchDepNames": ["kubernetes"],
+      "groupName": "kubernetes",
+      "automerge": false
+    },
+    {
+      "matchDepNames": ["cilium"],
+      "groupName": "cilium",
+      "automerge": false
+    },
+    {
+      "matchDepNames": ["gateway-api"],
+      "groupName": "gateway-api",
+      "automerge": false
+    },
+    {
+      "matchDepNames": ["flux"],
+      "groupName": "flux",
       "automerge": false
     },
     {


### PR DESCRIPTION
## Summary

- Replaces the single `infrastructure versions` packageRule (which bundled `talos`, `kubernetes`, `cilium`, `gateway-api`, and `flux` into one PR) with five individual rules
- Each cluster-critical component now gets its own Renovate PR, reducing blast radius and making upgrades independently reviewable and reversible
- All five retain `automerge: false`

## Test plan

- [ ] `renovate-validate.yaml` CI passes (config validator)
- [ ] After next Renovate run, dependency dashboard shows separate entries per component instead of one grouped update