### PR TITLE
fix(tuppr): guard Dragonfly health check and add upgrade alerting

### DIFF
--- a/kubernetes/platform/config/monitoring/kustomization.yaml
+++ b/kubernetes/platform/config/monitoring/kustomization.yaml
@@ -38,6 +38,7 @@ resources:
   - hardware-health-dashboard.yaml
   - gpu-monitoring-alerts.yaml
   - velero-alerts.yaml
+  - tuppr-alerts.yaml
   - velero-dashboard.yaml
   - network-throughput-dashboard.yaml
   - platform-home-dashboard.yaml

--- a/kubernetes/platform/config/monitoring/tuppr-alerts.yaml
+++ b/kubernetes/platform/config/monitoring/tuppr-alerts.yaml
@@ -1,0 +1,107 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: tuppr-alerts
+  labels:
+    app.kubernetes.io/name: tuppr
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: tuppr.upgrades
+      rules:
+        - alert: TupprKubernetesUpgradeStuckPending
+          expr: |
+            tuppr_kubernetes_upgrade_phase{phase="Pending"}
+            unless on (name, namespace) tuppr_kubernetes_upgrade_phase{phase=~"InProgress|Completed|Failed"}
+          for: 2h
+          labels:
+            severity: warning
+          annotations:
+            summary: "KubernetesUpgrade {{ $labels.name }} stuck in Pending"
+            description: >-
+              KubernetesUpgrade {{ $labels.namespace }}/{{ $labels.name }} has been Pending for 2+ hours.
+              A healthCheck CEL expression is likely failing. Check
+              `kubectl -n system-upgrade logs deploy/tuppr` and inspect
+              `tuppr_health_check_failures_total{upgrade_type="kubernetes"}` by check_index.
+
+        - alert: TupprKubernetesUpgradeStuckPendingCritical
+          expr: |
+            tuppr_kubernetes_upgrade_phase{phase="Pending"}
+            unless on (name, namespace) tuppr_kubernetes_upgrade_phase{phase=~"InProgress|Completed|Failed"}
+          for: 24h
+          labels:
+            severity: critical
+          annotations:
+            summary: "KubernetesUpgrade {{ $labels.name }} stuck in Pending >24h"
+            description: >-
+              KubernetesUpgrade {{ $labels.namespace }}/{{ $labels.name }} has been Pending for 24+ hours.
+              A health check is persistently failing and blocking the upgrade. Investigate immediately.
+
+        - alert: TupprKubernetesUpgradeFailed
+          expr: |
+            tuppr_kubernetes_upgrade_phase{phase="Failed"}
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "KubernetesUpgrade {{ $labels.name }} failed"
+            description: >-
+              KubernetesUpgrade {{ $labels.namespace }}/{{ $labels.name }} entered the Failed phase.
+              Inspect the CR status and tuppr controller logs.
+
+        - alert: TupprTalosUpgradeStuckPending
+          expr: |
+            tuppr_talos_upgrade_phase{phase="Pending"}
+            unless on (name, namespace) tuppr_talos_upgrade_phase{phase=~"InProgress|Completed|Failed"}
+          for: 2h
+          labels:
+            severity: warning
+          annotations:
+            summary: "TalosUpgrade {{ $labels.name }} stuck in Pending"
+            description: >-
+              TalosUpgrade {{ $labels.namespace }}/{{ $labels.name }} has been Pending for 2+ hours.
+              A healthCheck CEL expression is likely failing. Check tuppr controller logs and
+              `tuppr_health_check_failures_total{upgrade_type="talos"}` by check_index.
+
+        - alert: TupprTalosUpgradeStuckPendingCritical
+          expr: |
+            tuppr_talos_upgrade_phase{phase="Pending"}
+            unless on (name, namespace) tuppr_talos_upgrade_phase{phase=~"InProgress|Completed|Failed"}
+          for: 24h
+          labels:
+            severity: critical
+          annotations:
+            summary: "TalosUpgrade {{ $labels.name }} stuck in Pending >24h"
+            description: >-
+              TalosUpgrade {{ $labels.namespace }}/{{ $labels.name }} has been Pending for 24+ hours.
+              A health check is persistently failing and blocking the upgrade. Investigate immediately.
+
+        - alert: TupprTalosUpgradeFailed
+          expr: |
+            tuppr_talos_upgrade_phase{phase="Failed"}
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "TalosUpgrade {{ $labels.name }} failed"
+            description: >-
+              TalosUpgrade {{ $labels.namespace }}/{{ $labels.name }} entered the Failed phase.
+              Inspect the CR status and tuppr controller logs.
+
+    - name: tuppr.controller
+      rules:
+        - alert: TupprControllerDown
+          expr: |
+            absent(up{job="tuppr-metrics-service"} == 1)
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Tuppr controller metrics endpoint is down"
+            description: >-
+              The tuppr controller metrics endpoint has been unreachable for 15+ minutes
+              (job=tuppr-metrics-service in system-upgrade). Upgrades cannot be observed or
+              executed while the controller is down. Check
+              `kubectl -n system-upgrade get pods -l app.kubernetes.io/name=tuppr`.

--- a/kubernetes/platform/config/tuppr/kubernetes-upgrade.yaml
+++ b/kubernetes/platform/config/tuppr/kubernetes-upgrade.yaml
@@ -47,5 +47,5 @@ spec:
       description: Dragonfly must be ready and not in a rolling update
       expr: |
         status.phase == 'ready' &&
-          !status.isRollingUpdate
+          (!has(status.isRollingUpdate) || !status.isRollingUpdate)
       timeout: 10m

--- a/kubernetes/platform/config/tuppr/talos-upgrade.yaml
+++ b/kubernetes/platform/config/tuppr/talos-upgrade.yaml
@@ -50,5 +50,5 @@ spec:
       description: Dragonfly must be ready and not in a rolling update
       expr: |
         status.phase == 'ready' &&
-          !status.isRollingUpdate
+          (!has(status.isRollingUpdate) || !status.isRollingUpdate)
       timeout: 10m


### PR DESCRIPTION
## Summary

- Fix CEL expression in `KubernetesUpgrade`/`TalosUpgrade` Dragonfly health checks. dragonfly-operator v1.5.0 dropped `status.isRollingUpdate` while idle, so `!status.isRollingUpdate` errors on the absent field. Wrap with `has()` macro so the check passes when absent (idle = not rolling) and still works when present. Both upgrades have been stuck in `Pending` for 7d17h as a result.
- Add `tuppr-alerts.yaml` PrometheusRule with 7 alerts so a future stuck upgrade is caught in hours, not days:
  - `Tuppr{Kubernetes,Talos}UpgradeStuckPending` — warning, `for: 2h`
  - `Tuppr{Kubernetes,Talos}UpgradeStuckPendingCritical` — critical, `for: 24h`
  - `Tuppr{Kubernetes,Talos}UpgradeFailed` — critical, `for: 5m`
  - `TupprControllerDown` — critical, `for: 15m` on `absent(up{job="tuppr-metrics-service"} == 1)`

## Test plan

- [x] `task k8s:validate` clean (yamllint, ResourceSet expand, Helm templating, pluto deprecation scan)
- [ ] After Flux reconcile: `kubectl -n system-upgrade get kubernetesupgrade,talosupgrade` shows progression past Pending
- [ ] Rules loaded: `kubectl -n monitoring exec prometheus-kube-prometheus-stack-0 -c prometheus -- wget -qO- 'http://localhost:9090/api/v1/rules' | jq '.data.groups[] | select(.name | startswith("tuppr"))'`
- [ ] Smoke test: at moment alerts load (before CEL fix reconciles), the 7-day-stuck `talos` upgrade should fire `TupprTalosUpgradeStuckPending` + `TupprTalosUpgradeStuckPendingCritical` immediately. After CEL fix reconciles, both should clear.
- [ ] Alertmanager UI at `https://alertmanager.${internal_domain}` reflects expected state.