### PR TITLE
fix(waf): exempt Immich /api/system-config from Coraza WAF

### DIFF
--- a/kubernetes/platform/config/gateway/coraza-wasm-plugin.yaml
+++ b/kubernetes/platform/config/gateway/coraza-wasm-plugin.yaml
@@ -30,4 +30,6 @@ spec:
         - SecRequestBodyNoFilesLimit 131072
         # Response body inspection disabled (performance)
         - SecResponseBodyAccess Off
+        # Immich admin config endpoint: OIDC URLs in body cause RFI false positives
+        - SecRule REQUEST_URI "@beginsWith /api/system-config" "id:9000001,phase:1,pass,nolog,ctl:ruleEngine=Off"
     default_directives: default


### PR DESCRIPTION
## Summary

- `PUT /api/system-config` was being blocked by Coraza WAF with 403 before reaching Immich
- Root cause: OIDC issuer URLs in the request body trigger CRS rule 931130 (Remote File Inclusion false positive)
- Fix: disable WAF rule engine for requests to `/api/system-config` — this endpoint is admin-auth-gated in Immich, so bypass is low risk

## Test plan

- [ ] Merge and allow Flux to reconcile the WasmPlugin
- [ ] Save OAuth config in Immich Administration → OAuth settings
- [ ] Verify save succeeds (no 403)
- [ ] Verify WAF still blocks attack patterns on other Immich endpoints