### PR TITLE
feat(authelia): register Zipline as OIDC client

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -215,6 +215,24 @@ configMap:
           grant_types:
             - authorization_code
           token_endpoint_auth_method: client_secret_basic
+        - client_id: zipline
+          client_name: Zipline
+          client_secret:
+            path: /secrets/zipline-oidc-client-secret/client-secret
+          public: false
+          authorization_policy: two_factor
+          require_pkce: false
+          redirect_uris:
+            - https://upload.${external_domain}/api/auth/oauth/oidc
+          scopes:
+            - openid
+            - profile
+            - email
+          response_types:
+            - code
+          grant_types:
+            - authorization_code
+          token_endpoint_auth_method: client_secret_basic
 
   regulation:
     max_retries: 3
@@ -235,4 +253,5 @@ secret:
     grafana-oidc-client-secret: { }
     open-webui-oidc-client-secret: { }
     immich-oidc-client-secret: { }
+    zipline-oidc-client-secret: { }
     authelia-smtp-credentials: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - authelia-db-credentials.yaml
   - immich-oidc-client-secret.yaml
   - grafana-oidc-client-secret.yaml
+  - zipline-oidc-client-secret.yaml
   - authelia-secrets.yaml
   - authelia-smtp-credentials.yaml
   - authelia-smtp-egress.yaml

--- a/kubernetes/clusters/live/config/authelia-prereqs/zipline-oidc-client-secret.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/zipline-oidc-client-secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: zipline-oidc-client-secret
+  namespace: authelia
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: client-secret
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "64"
+data: { }


### PR DESCRIPTION
## Summary

- Adds `zipline` OIDC client to Authelia's identity provider configuration
- Auto-generates client secret via `secret-generator` in the `authelia` namespace
- Redirect URI: `https://upload.tomnowak.work/api/auth/oauth/oidc`
- Scopes: `openid`, `profile`, `email`
- Auth method: `client_secret_basic`, PKCE not required

## Test plan

- [ ] Authelia pod restarts cleanly after merge
- [ ] `zipline-oidc-client-secret` Secret exists in `authelia` namespace with `client-secret` key populated
- [ ] Retrieve secret and configure Zipline OIDC settings in UI
- [ ] Verify OIDC login flow at `https://upload.tomnowak.work`