### PR TITLE
fix(ci): pin pluto to v5.24.0 and force github-releases datasource

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -203,6 +203,15 @@
         "gluetun"
       ],
       "allowedVersions": "!/^v3\\.41\\./"
+    },
+    {
+      // pluto aqua datasource diverges from GitHub releases - force github-releases
+      // to prevent phantom versions that 404 on install
+      "matchManagers": ["mise"],
+      "matchPackageNames": ["aqua:FairwindsOps/pluto"],
+      "datasource": "github-releases",
+      "packageName": "FairwindsOps/pluto",
+      "extractVersion": "^v(?<version>.+)$"
     }
   ]
 }

--- a/.mise.toml
+++ b/.mise.toml
@@ -7,7 +7,7 @@ terragrunt = "1.0.3"
 helm = "4.1.4"
 kustomize = "5.8.1"
 kubeconform = "0.7.0"
-"aqua:FairwindsOps/pluto" = "5.23.6"  # API deprecation checker
+"aqua:FairwindsOps/pluto" = "5.24.0"  # API deprecation checker
 yq = "4.53.2"
 yamllint = "1.38.0"
 


### PR DESCRIPTION
## Summary

- Renovate bumped `aqua:FairwindsOps/pluto` to `5.23.6` via the aqua datasource, but that tag does not exist on GitHub Releases — CI fails with HTTP 404 on every run
- Bumps pluto to `5.24.0` (confirmed existing tag: `v5.24.0`)
- Adds a `packageRule` in `renovate.json5` overriding the datasource to `github-releases` so renovate only ever proposes versions that actually exist as GitHub Release tags

## Test plan

- [ ] CI passes on this PR (mise installs pluto successfully)
- [ ] After merge, confirm renovate proposes only real GitHub release versions for pluto