### PR TITLE
fix(waf): exempt Zipline /api/server/settings from Coraza WAF

### DIFF
--- a/kubernetes/platform/config/gateway/coraza-config.yaml
+++ b/kubernetes/platform/config/gateway/coraza-config.yaml
@@ -19,6 +19,11 @@ data:
     #
     # Custom rules below tune the CRS behavior:
 
+    # Immich admin config endpoint: OIDC URLs in body cause RFI false positives.
+    # SecRule REQUEST_URI "@beginsWith /api/system-config" "id:9000001,..."
+    # Zipline server settings endpoint: OIDC URLs in body cause RFI false positives.
+    # SecRule REQUEST_URI "@beginsWith /api/server/settings" "id:9000002,..."
+
     # Paranoia level 1 (lowest, fewer false positives)
     SecAction "id:900000,phase:1,pass,t:none,nolog,setvar:tx.blocking_paranoia_level=1"
 

--- a/kubernetes/platform/config/gateway/coraza-wasm-plugin.yaml
+++ b/kubernetes/platform/config/gateway/coraza-wasm-plugin.yaml
@@ -22,6 +22,9 @@ spec:
         # Immich admin config endpoint: OIDC URLs in body cause RFI false positives.
         - SecRule REQUEST_URI "@beginsWith /api/system-config"
           "id:9000001,phase:1,pass,nolog,ctl:ruleEngine=Off"
+        # Zipline server settings endpoint: OIDC URLs in body cause RFI false positives.
+        - SecRule REQUEST_URI "@beginsWith /api/server/settings"
+          "id:9000002,phase:1,pass,nolog,ctl:ruleEngine=Off"
         - Include @recommended-conf
         - Include @crs-setup-conf
         - Include @owasp_crs/*.conf


### PR DESCRIPTION
## Summary

- Exempts Zipline's `/api/server/settings` endpoint from Coraza WAF inspection
- Same root cause as #865 (Immich) — OIDC URLs in request body trigger RFI false positives
- Updates reference ConfigMap to document the exemption

## Test plan

- [ ] WAF plugin reconciles on external gateway pods
- [ ] Zipline OIDC settings save successfully via UI