### PR TITLE
fix(authelia): add offline_access scope to Zipline OIDC client

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -228,10 +228,12 @@ configMap:
             - openid
             - profile
             - email
+            - offline_access
           response_types:
             - code
           grant_types:
             - authorization_code
+            - refresh_token
           token_endpoint_auth_method: client_secret_basic
 
   regulation:


### PR DESCRIPTION
## Summary

- Adds `offline_access` scope and `refresh_token` grant type to Zipline's Authelia OIDC client
- Zipline requests `offline_access` for refresh tokens; Authelia was rejecting with `invalid_scope`

## Test plan

- [ ] Authelia reconciles cleanly
- [ ] OIDC login flow at `https://upload.tomnowak.work` completes without scope error