### PR TITLE
fix(authelia): correct Zipline OIDC client auth method and enable PKCE

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -221,7 +221,8 @@ configMap:
             path: /secrets/zipline-oidc-client-secret/client-secret
           public: false
           authorization_policy: two_factor
-          require_pkce: false
+          require_pkce: true
+          pkce_challenge_method: S256
           redirect_uris:
             - https://upload.${external_domain}/api/auth/oauth/oidc
           scopes:
@@ -234,7 +235,7 @@ configMap:
           grant_types:
             - authorization_code
             - refresh_token
-          token_endpoint_auth_method: client_secret_basic
+          token_endpoint_auth_method: client_secret_post
 
   regulation:
     max_retries: 3


### PR DESCRIPTION
## Summary

- Changes `token_endpoint_auth_method` from `client_secret_basic` to `client_secret_post` — Zipline posts credentials in the request body, not the Authorization header
- Enables `require_pkce: true` + `pkce_challenge_method: S256` — Zipline always generates a PKCE challenge

Fixes "Failed to fetch access token" error during OIDC token exchange.

## Test plan

- [ ] Authelia reconciles cleanly
- [ ] OIDC login flow at `https://upload.tomnowak.work` completes successfully