### PR TITLE
feat(authelia): add Jellyfin OIDC client

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -38,7 +38,7 @@ pod:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
       capabilities:
-        drop: [ ALL ]
+        drop: [ALL]
 configMap:
   theme: dark
 
@@ -271,12 +271,12 @@ configMap:
 secret:
   existingSecret: "authelia-secrets"
   additionalSecrets:
-    lldap-secrets: {}
-    authelia-db-credentials: {}
-    dragonfly-auth: {}
-    grafana-oidc-client-secret: {}
-    open-webui-oidc-client-secret: {}
-    immich-oidc-client-secret: {}
-    jellyfin-oidc-client-secret: {}
-    zipline-oidc-client-secret: {}
-    authelia-smtp-credentials: {}
+    lldap-secrets: { }
+    authelia-db-credentials: { }
+    dragonfly-auth: { }
+    grafana-oidc-client-secret: { }
+    open-webui-oidc-client-secret: { }
+    immich-oidc-client-secret: { }
+    jellyfin-oidc-client-secret: { }
+    zipline-oidc-client-secret: { }
+    authelia-smtp-credentials: { }

--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -236,6 +236,27 @@ configMap:
             - authorization_code
             - refresh_token
           token_endpoint_auth_method: client_secret_post
+        - client_id: jellyfin
+          client_name: Jellyfin
+          client_secret:
+            path: /secrets/jellyfin-oidc-client-secret/client-secret
+          public: false
+          authorization_policy: two_factor
+          require_pkce: true
+          pkce_challenge_method: S256
+          redirect_uris:
+            - https://jellyfin.${external_domain}/sso/OID/redirect/authelia
+          scopes:
+            - openid
+            - profile
+            - groups
+          response_types:
+            - code
+          grant_types:
+            - authorization_code
+          access_token_signed_response_alg: none
+          userinfo_signed_response_alg: none
+          token_endpoint_auth_method: client_secret_post
 
   regulation:
     max_retries: 3
@@ -256,5 +277,6 @@ secret:
     grafana-oidc-client-secret: {}
     open-webui-oidc-client-secret: {}
     immich-oidc-client-secret: {}
+    jellyfin-oidc-client-secret: {}
     zipline-oidc-client-secret: {}
     authelia-smtp-credentials: {}

--- a/kubernetes/clusters/live/config/authelia-prereqs/jellyfin-oidc-client-secret.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/jellyfin-oidc-client-secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jellyfin-oidc-client-secret
+  namespace: authelia
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: client-secret
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "64"
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "media"
+data: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - lldap-db-credentials.yaml
   - authelia-db-credentials.yaml
   - immich-oidc-client-secret.yaml
+  - jellyfin-oidc-client-secret.yaml
   - grafana-oidc-client-secret.yaml
   - zipline-oidc-client-secret.yaml
   - authelia-secrets.yaml

--- a/kubernetes/platform/config/tuppr/kubernetes-upgrade.yaml
+++ b/kubernetes/platform/config/tuppr/kubernetes-upgrade.yaml
@@ -8,7 +8,7 @@ spec:
     version: v${kubernetes_version}
   maintenance:
     windows:
-      - start: "0 2 * * 0" # Every Sunday at 2:00 AM
+      - start: "0 2 * * 0"  # Every Sunday at 2:00 AM
         duration: 4h
         timezone: EST
   healthChecks:

--- a/kubernetes/platform/config/tuppr/talos-upgrade.yaml
+++ b/kubernetes/platform/config/tuppr/talos-upgrade.yaml
@@ -8,7 +8,7 @@ spec:
     version: ${talos_version}
   maintenance:
     windows:
-      - start: "0 2 * * 0" # Every Sunday at 2:00 AM
+      - start: "0 2 * * 0"  # Every Sunday at 2:00 AM
         duration: 4h
         timezone: EST
   policy:


### PR DESCRIPTION
## Summary

- Adds `jellyfin-oidc-client-secret` Secret in the `authelia` namespace, auto-generated by secret-generator (64-byte hex), and replication-allowed to the `media` namespace
- Registers the new secret in `authelia-prereqs/kustomization.yaml` (alphabetical order: after immich, before zipline)
- Adds the Jellyfin OIDC client to Authelia's `identity_providers.oidc.clients` list (two_factor policy, PKCE S256, `client_secret_post` auth)
- Mounts the secret via `secret.additionalSecrets` so Authelia can read it at `/secrets/jellyfin-oidc-client-secret/client-secret`

This is the Authelia side only. Jellyfin application-side SSO configuration (plugin install, client ID/secret wiring) is a separate task.

## Test plan

- [ ] Flux reconciles `authelia-prereqs` Kustomization without errors
- [ ] `jellyfin-oidc-client-secret` Secret is created in `authelia` namespace with a populated `client-secret` key
- [ ] Authelia pod restarts cleanly (reloader annotation triggers on secret creation)
- [ ] Authelia OIDC discovery endpoint lists `jellyfin` as a registered client