### PR TITLE
fix(authelia): use client_secret_basic for jellyfin OIDC client

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -256,7 +256,7 @@ configMap:
             - authorization_code
           access_token_signed_response_alg: none
           userinfo_signed_response_alg: none
-          token_endpoint_auth_method: client_secret_post
+          token_endpoint_auth_method: client_secret_basic
 
   regulation:
     max_retries: 3


### PR DESCRIPTION
## Summary

- Jellyfin SSO plugin sends credentials using `client_secret_basic` (HTTP Basic Auth) at the PAR endpoint
- Previous config set `client_secret_post`, causing Authelia to reject all auth attempts with "Unauthorized"
- Authelia docs recommend `client_secret_post` for Jellyfin but the plugin actually uses `client_secret_basic`

## Root Cause

Confirmed via Authelia logs:
```
The request was determined to be using 'token_endpoint_auth_method' method 'client_secret_basic',
however the OAuth 2.0 client registration does not allow this method.
```