### PR TITLE
fix(authelia): disable PAR for jellyfin OIDC client

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -244,6 +244,7 @@ configMap:
           authorization_policy: two_factor
           require_pkce: true
           pkce_challenge_method: S256
+          require_pushed_authorization_requests: false
           redirect_uris:
             - https://jellyfin.${external_domain}/sso/OID/redirect/authelia
           scopes:
@@ -256,7 +257,7 @@ configMap:
             - authorization_code
           access_token_signed_response_alg: none
           userinfo_signed_response_alg: none
-          token_endpoint_auth_method: client_secret_basic
+          token_endpoint_auth_method: client_secret_post
 
   regulation:
     max_retries: 3


### PR DESCRIPTION
## Summary

- Jellyfin SSO plugin uses `client_secret_basic` at the PAR endpoint but `client_secret_post` at the token endpoint — inconsistent, cannot satisfy both with a single `token_endpoint_auth_method`
- Fix: add `require_pushed_authorization_requests: false` and use `client_secret_post` for the token endpoint
- Reverts the `client_secret_basic` change from #873

## Root Cause

Confirmed via Authelia logs — plugin sends different auth methods at each OAuth endpoint, making it impossible to satisfy both without disabling PAR.