### PR TITLE
fix(authelia): make jellyfin OIDC client public

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -238,9 +238,7 @@ configMap:
           token_endpoint_auth_method: client_secret_post
         - client_id: jellyfin
           client_name: Jellyfin
-          client_secret:
-            path: /secrets/jellyfin-oidc-client-secret/client-secret
-          public: false
+          public: true
           authorization_policy: two_factor
           require_pkce: true
           pkce_challenge_method: S256
@@ -257,7 +255,7 @@ configMap:
             - authorization_code
           access_token_signed_response_alg: none
           userinfo_signed_response_alg: none
-          token_endpoint_auth_method: client_secret_post
+          token_endpoint_auth_method: none
 
   regulation:
     max_retries: 3


### PR DESCRIPTION
## Summary

The Jellyfin SSO plugin uses `client_secret_basic` at the PAR endpoint but `client_secret_post` at the token endpoint. Authelia enforces a single `token_endpoint_auth_method` for both — there is no way to satisfy both methods simultaneously.

- Switch to `public: true` + `token_endpoint_auth_method: none` — Authelia skips credential validation at both endpoints
- Remove `client_secret` from client config (not used by public clients)
- PKCE (`S256`) remains enforced, providing auth code security without client secret

## Security

Public client + mandatory PKCE is the recommended pattern for apps that cannot securely store a client secret or where the auth library has inconsistent credential handling. The code challenge prevents auth code interception/replay attacks.