### PR TITLE
fix(authelia): revert jellyfin OIDC client to client_secret_post

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -238,9 +238,7 @@ configMap:
           token_endpoint_auth_method: client_secret_post
         - client_id: jellyfin
           client_name: Jellyfin
-          client_secret:
-            path: /secrets/jellyfin-oidc-client-secret/client-secret
-          public: false
+          public: true
           authorization_policy: two_factor
           require_pkce: true
           pkce_challenge_method: S256
@@ -257,7 +255,7 @@ configMap:
             - authorization_code
           access_token_signed_response_alg: none
           userinfo_signed_response_alg: none
-          token_endpoint_auth_method: client_secret_post
+          token_endpoint_auth_method: none
 
   regulation:
     max_retries: 3

--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -238,11 +238,12 @@ configMap:
           token_endpoint_auth_method: client_secret_post
         - client_id: jellyfin
           client_name: Jellyfin
-          public: true
+          client_secret:
+            path: /secrets/jellyfin-oidc-client-secret/client-secret
+          public: false
           authorization_policy: two_factor
           require_pkce: true
           pkce_challenge_method: S256
-          require_pushed_authorization_requests: false
           redirect_uris:
             - https://jellyfin.${external_domain}/sso/OID/redirect/authelia
           scopes:
@@ -255,7 +256,7 @@ configMap:
             - authorization_code
           access_token_signed_response_alg: none
           userinfo_signed_response_alg: none
-          token_endpoint_auth_method: none
+          token_endpoint_auth_method: client_secret_post
 
   regulation:
     max_retries: 3


### PR DESCRIPTION
## Summary

Revert to `client_secret_post` with a confidential client. PAR is disabled on the plugin side via `DisablePushedAuthorization: true` in the Jellyfin SSO plugin config — no Authelia-side workaround needed.

Closes the detour through #873 and #874.