### PR TITLE
feat(vaultwarden): enable OIDC SSO via Authelia

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -209,7 +209,6 @@
       // to prevent phantom versions that 404 on install
       "matchManagers": ["mise"],
       "matchPackageNames": ["aqua:FairwindsOps/pluto"],
-      "datasource": "github-releases",
       "packageName": "FairwindsOps/pluto",
       "extractVersion": "^v(?<version>.+)$"
     }

--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -150,6 +150,12 @@ configMap:
             - policy: two_factor
               subject:
                 - "group:photos"
+        vaultwarden:
+          default_policy: deny
+          rules:
+            - policy: two_factor
+              subject:
+                - "group:vaultwarden"
       clients:
         - client_id: "immich"
           client_name: Immich
@@ -263,7 +269,7 @@ configMap:
           client_secret:
             path: /secrets/vaultwarden-oidc-client-secret/client-secret
           public: false
-          authorization_policy: two_factor
+          authorization_policy: vaultwarden
           require_pkce: true
           pkce_challenge_method: S256
           redirect_uris:

--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -38,7 +38,7 @@ pod:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
       capabilities:
-        drop: [ ALL ]
+        drop: [ALL]
 configMap:
   theme: dark
 
@@ -258,6 +258,29 @@ configMap:
           access_token_signed_response_alg: none
           userinfo_signed_response_alg: none
           token_endpoint_auth_method: client_secret_post
+        - client_id: vaultwarden
+          client_name: Vaultwarden
+          client_secret:
+            path: /secrets/vaultwarden-oidc-client-secret/client-secret
+          public: false
+          authorization_policy: two_factor
+          require_pkce: true
+          pkce_challenge_method: S256
+          redirect_uris:
+            - https://vault.${external_domain}/identity/connect/oidc-signin
+          scopes:
+            - openid
+            - profile
+            - email
+            - offline_access
+          response_types:
+            - code
+          grant_types:
+            - authorization_code
+            - refresh_token
+          access_token_signed_response_alg: none
+          userinfo_signed_response_alg: none
+          token_endpoint_auth_method: client_secret_basic
 
   regulation:
     max_retries: 3
@@ -272,12 +295,13 @@ configMap:
 secret:
   existingSecret: "authelia-secrets"
   additionalSecrets:
-    lldap-secrets: {}
-    authelia-db-credentials: {}
-    dragonfly-auth: {}
-    grafana-oidc-client-secret: {}
-    open-webui-oidc-client-secret: {}
-    immich-oidc-client-secret: {}
-    jellyfin-oidc-client-secret: {}
-    zipline-oidc-client-secret: {}
-    authelia-smtp-credentials: {}
+    lldap-secrets: { }
+    authelia-db-credentials: { }
+    dragonfly-auth: { }
+    grafana-oidc-client-secret: { }
+    open-webui-oidc-client-secret: { }
+    immich-oidc-client-secret: { }
+    jellyfin-oidc-client-secret: { }
+    zipline-oidc-client-secret: { }
+    vaultwarden-oidc-client-secret: { }
+    authelia-smtp-credentials: { }

--- a/kubernetes/clusters/live/charts/vaultwarden.yaml
+++ b/kubernetes/clusters/live/charts/vaultwarden.yaml
@@ -47,6 +47,18 @@ controllers:
             value: "postgresql://vaultwarden:$(DATABASE_PASSWORD)@platform-pooler-rw.database.svc.cluster.local:5432/vaultwarden"
           # Websocket notifications (enabled by default in recent versions)
           ENABLE_WEBSOCKET: "true"
+          # SSO via Authelia OIDC
+          SSO_ENABLED: "true"
+          SSO_ONLY: "true"
+          SSO_PKCE: "true"
+          SSO_AUTHORITY: "https://auth.${external_domain}"
+          SSO_CLIENT_ID: "vaultwarden"
+          SSO_CLIENT_SECRET:
+            valueFrom:
+              secretKeyRef:
+                name: vaultwarden-oidc-client-secret
+                key: client-secret
+          SSO_SCOPES: "openid profile email offline_access"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false

--- a/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - jellyfin-oidc-client-secret.yaml
   - grafana-oidc-client-secret.yaml
   - zipline-oidc-client-secret.yaml
+  - vaultwarden-oidc-client-secret.yaml
   - authelia-secrets.yaml
   - authelia-smtp-credentials.yaml
   - authelia-smtp-egress.yaml

--- a/kubernetes/clusters/live/config/authelia-prereqs/vaultwarden-oidc-client-secret.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/vaultwarden-oidc-client-secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vaultwarden-oidc-client-secret
+  namespace: authelia
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: client-secret
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "64"
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "vaultwarden"
+data: { }

--- a/kubernetes/clusters/live/config/media/canary-jellyfin.yaml
+++ b/kubernetes/clusters/live/config/media/canary-jellyfin.yaml
@@ -10,6 +10,6 @@ spec:
   http:
     - name: external-gateway-health
       url: https://watch.${external_domain}/health
-      responseCodes: [ 200 ]
+      responseCodes: [200]
       maxSSLExpiry: 7
       thresholdMillis: 5000

--- a/kubernetes/clusters/live/config/vaultwarden/kustomization.yaml
+++ b/kubernetes/clusters/live/config/vaultwarden/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - internal-route.yaml
   - external-route.yaml
   - canary.yaml
+  - vaultwarden-oidc-client-secret.yaml

--- a/kubernetes/clusters/live/config/vaultwarden/vaultwarden-oidc-client-secret.yaml
+++ b/kubernetes/clusters/live/config/vaultwarden/vaultwarden-oidc-client-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vaultwarden-oidc-client-secret
+  namespace: vaultwarden
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: authelia/vaultwarden-oidc-client-secret
+data: { }


### PR DESCRIPTION
## Summary

- Add Vaultwarden as Authelia OIDC client with PKCE + `offline_access` (refresh tokens)
- Configure `SSO_ONLY=true` — all auth routes through Authelia two-factor
- Secret auto-generated in `authelia` namespace, replicated to `vaultwarden` namespace via mittwald replicator

## Changes

- `authelia.yaml`: add `vaultwarden` OIDC client, mount secret, fix pre-existing yamllint violations (`{}` → `{ }`, `[ ALL ]` → `[ALL]`)
- `vaultwarden.yaml`: add `SSO_*` env vars, reference replicated client secret
- `authelia-prereqs/vaultwarden-oidc-client-secret.yaml`: secret-generator source secret
- `vaultwarden/vaultwarden-oidc-client-secret.yaml`: replicator target in vaultwarden namespace
- `renovate.json5`: remove invalid `datasource` field from packageRule (pre-existing error)
- `canary-jellyfin.yaml`: fix pre-existing yamllint bracket style

## Test plan

- [ ] Authelia reconciles cleanly after merge
- [ ] Vaultwarden pod restarts and picks up `SSO_*` env vars
- [ ] Login at `vault.<domain>` redirects to Authelia
- [ ] After Authelia 2FA, redirected back and logged in to Vaultwarden
- [ ] Password-based login is blocked (`SSO_ONLY=true`)