### PR TITLE
fix(loki): migrate Helm chart source to OSS community registry

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -38,7 +38,7 @@ pod:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
       capabilities:
-        drop: [ ALL ]
+        drop: [ALL]
 configMap:
   theme: dark
 
@@ -272,12 +272,12 @@ configMap:
 secret:
   existingSecret: "authelia-secrets"
   additionalSecrets:
-    lldap-secrets: {}
-    authelia-db-credentials: {}
-    dragonfly-auth: {}
-    grafana-oidc-client-secret: {}
-    open-webui-oidc-client-secret: {}
-    immich-oidc-client-secret: {}
-    jellyfin-oidc-client-secret: {}
-    zipline-oidc-client-secret: {}
-    authelia-smtp-credentials: {}
+    lldap-secrets: { }
+    authelia-db-credentials: { }
+    dragonfly-auth: { }
+    grafana-oidc-client-secret: { }
+    open-webui-oidc-client-secret: { }
+    immich-oidc-client-secret: { }
+    jellyfin-oidc-client-secret: { }
+    zipline-oidc-client-secret: { }
+    authelia-smtp-credentials: { }

--- a/kubernetes/clusters/live/config/media/canary-jellyfin.yaml
+++ b/kubernetes/clusters/live/config/media/canary-jellyfin.yaml
@@ -10,6 +10,6 @@ spec:
   http:
     - name: external-gateway-health
       url: https://watch.${external_domain}/health
-      responseCodes: [ 200 ]
+      responseCodes: [200]
       maxSSLExpiry: 7
       thresholdMillis: 5000

--- a/kubernetes/platform/helm-charts.yaml
+++ b/kubernetes/platform/helm-charts.yaml
@@ -96,7 +96,7 @@ spec:
       chart:
         name: "loki"
         version: "${loki_version}"
-        url: "https://grafana.github.io/helm-charts"
+        url: "https://grafana-community.github.io/helm-charts"
       dependsOn: [cilium, longhorn]
     - name: alloy
       namespace: monitoring

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -40,7 +40,7 @@ secret_generator_version=3.4.1
 canary_checker_version=1.1.2
 # renovate: datasource=helm depName=kube-prometheus-stack registryUrl=https://prometheus-community.github.io/helm-charts
 kube_prometheus_stack_version=84.4.0
-# renovate: datasource=helm depName=loki registryUrl=https://grafana.github.io/helm-charts
+# renovate: datasource=helm depName=loki registryUrl=https://grafana-community.github.io/helm-charts
 loki_version=6.55.0
 # renovate: datasource=helm depName=alloy registryUrl=https://grafana.github.io/helm-charts
 alloy_version=1.8.0


### PR DESCRIPTION
## Summary

- Updates `helm-charts.yaml` to pull the `loki` chart from `https://grafana-community.github.io/helm-charts` instead of `https://grafana.github.io/helm-charts`
- Updates the matching Renovate annotation in `versions.env` to the same URL

## Why

Grafana split their Helm chart repository at v6.55.0. The official `grafana.github.io/helm-charts` registry now serves **Enterprise Logs (GEL) only**. OSS Loki moved to `grafana-community.github.io/helm-charts`. Without this change, Renovate would propose upgrades that pull an Enterprise chart into an OSS installation, breaking the deployment on next version bump.

The pinned version `loki_version=6.55.0` is unchanged — that is the fork point and the last version available on both registries.

## Test plan

- [ ] Confirm Flux reconciles the `grafana-loki-single-binary` HelmRelease against the new HelmRepository URL in integration
- [ ] Confirm Renovate's next run proposes upgrades from `grafana-community.github.io/helm-charts` (not the enterprise registry)