### PR TITLE
fix(homepage): resolve widget errors for healthchecks, immich, and ingress RBAC

### DIFF
--- a/kubernetes/clusters/live/config/homepage/clusterrole.yaml
+++ b/kubernetes/clusters/live/config/homepage/clusterrole.yaml
@@ -8,6 +8,10 @@ rules:
   - apiGroups: [""]
     resources: [namespaces, pods, nodes]
     verbs: [get, list]
+  # Ingress resources for service discovery (homepage queries both Ingress and HTTPRoute)
+  - apiGroups: [networking.k8s.io]
+    resources: [ingresses]
+    verbs: [get, list]
   # Gateway API resources for HTTPRoute auto-discovery
   - apiGroups: [gateway.networking.k8s.io]
     resources: [httproutes, gateways]

--- a/kubernetes/clusters/live/config/homepage/network-policy.yaml
+++ b/kubernetes/clusters/live/config/homepage/network-policy.yaml
@@ -90,3 +90,9 @@ spec:
         - ports:
             - port: "34197"
               protocol: UDP
+    - toFQDNs:
+        - matchName: "healthchecks.io"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/clusters/live/config/immich/external-route.yaml
+++ b/kubernetes/clusters/live/config/immich/external-route.yaml
@@ -13,6 +13,7 @@ metadata:
     gethomepage.dev/widget.type: "immich"
     gethomepage.dev/widget.url: "http://immich-server.immich.svc:2283"
     gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_IMMICH_API_KEY}}"
+    gethomepage.dev/widget.version: "2"
     gethomepage.dev/pod-selector: "app.kubernetes.io/name=server"
 spec:
   parentRefs:


### PR DESCRIPTION
## Summary

- **Healthchecks widget** (`API Error: Missing`): network policy had no external egress — adds `toFQDNs` rule for `healthchecks.io:443`
- **Immich widget** (HTTP 404): Immich v1.100+ moved API paths from `/api/server-info/*` to `/api/server/*` — adds `widget.version: "2"` annotation to HTTPRoute
- **Ingress RBAC** (403 log spam): homepage queries both Ingress and HTTPRoute for service discovery — adds `networking.k8s.io/ingresses` to ClusterRole

## Test plan

- [ ] Healthchecks widget shows check statuses (not `API Error: Missing`)
- [ ] Immich widget shows photo/video counts (not 404 errors in logs)
- [ ] No more ingress 403 errors flooding homepage logs