### PR TITLE
fix(authelia): add missing vaultwarden-oidc-client-secret volume mount

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -309,4 +309,5 @@ secret:
     immich-oidc-client-secret: { }
     jellyfin-oidc-client-secret: { }
     zipline-oidc-client-secret: { }
+    vaultwarden-oidc-client-secret: { }
     authelia-smtp-credentials: { }

--- a/kubernetes/clusters/live/charts/homepage.yaml
+++ b/kubernetes/clusters/live/charts/homepage.yaml
@@ -26,7 +26,7 @@ controllers:
           readOnlyRootFilesystem: false
           runAsNonRoot: false
           capabilities:
-            drop: [ "ALL" ]
+            drop: ["ALL"]
         image:
           repository: ghcr.io/gethomepage/homepage
           tag: "${homepage_version}"


### PR DESCRIPTION
## Summary

- Add `vaultwarden-oidc-client-secret` to Authelia `additionalSecrets` — accidentally dropped from #877
- Fix pre-existing yamllint violation in `homepage.yaml` (`drop: [ "ALL" ]` → `drop: ["ALL"]`)

## Root Cause

The `replace_all` edit (`{}` → `{ }`) during #877 clobbered the prior edit that added the `vaultwarden-oidc-client-secret` entry. The OIDC client config referencing the secret path was committed correctly, but the volume mount was not — causing Authelia to crash on startup with `no such file or directory`.

## Impact

Authelia is currently in CrashLoopBackOff (105 restarts). Old pods still serving traffic. Merge fixes Authelia immediately.