### PR TITLE
feat(firefly): deploy Firefly III personal finance manager

### DIFF
--- a/kubernetes/clusters/live/charts/firefly.yaml
+++ b/kubernetes/clusters/live/charts/firefly.yaml
@@ -1,0 +1,88 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+# https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+controllers:
+  firefly:
+    type: deployment
+    replicas: 1
+    annotations:
+      reloader.stakater.com/auto: "true"
+
+    containers:
+      app:
+        image:
+          repository: ghcr.io/firefly-iii/firefly-iii
+          tag: ${firefly_version}
+        env:
+          APP_ENV: production
+          APP_DEBUG: "false"
+          APP_URL:
+            value: "https://firefly.${internal_domain}"
+          SITE_OWNER: ionfury@gmail.com
+          TRUSTED_PROXIES: "**"
+          DEFAULT_LANGUAGE: en_US
+          DEFAULT_LOCALE: en_US
+          TZ: UTC
+          # Database — shared platform CNPG cluster via pooler
+          DB_CONNECTION: pgsql
+          DB_HOST: platform-pooler-rw.database.svc.cluster.local
+          DB_PORT: "5432"
+          DB_DATABASE: firefly
+          DB_USERNAME: firefly
+          DB_PASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: firefly-db-credentials
+                key: password
+          # Encryption key — from AWS SSM via ExternalSecret
+          APP_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: firefly-app-key
+                key: APP_KEY
+        resources:
+          requests:
+            cpu: 50m
+            memory: 256Mi
+          limits:
+            memory: 1Gi
+        probes:
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /health
+                port: 8080
+              initialDelaySeconds: 15
+              periodSeconds: 5
+              failureThreshold: 30
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /health
+                port: 8080
+              periodSeconds: 30
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /health
+                port: 8080
+              periodSeconds: 10
+
+service:
+  app:
+    controller: firefly
+    ports:
+      http:
+        port: 8080
+
+persistence:
+  upload:
+    existingClaim: firefly-upload
+    globalMounts:
+      - path: /var/www/html/storage/upload

--- a/kubernetes/clusters/live/charts/homepage.yaml
+++ b/kubernetes/clusters/live/charts/homepage.yaml
@@ -89,6 +89,11 @@ controllers:
               secretKeyRef:
                 name: homepage-grafana-api-key
                 key: api-key
+          HOMEPAGE_VAR_FIREFLY_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: homepage-firefly-api-key
+                key: api-key
         resources:
           requests:
             cpu: 10m

--- a/kubernetes/clusters/live/charts/homepage.yaml
+++ b/kubernetes/clusters/live/charts/homepage.yaml
@@ -26,7 +26,7 @@ controllers:
           readOnlyRootFilesystem: false
           runAsNonRoot: false
           capabilities:
-            drop: [ "ALL" ]
+            drop: ["ALL"]
         image:
           repository: ghcr.io/gethomepage/homepage
           tag: "${homepage_version}"

--- a/kubernetes/clusters/live/config/database/cluster-roles-patch.yaml
+++ b/kubernetes/clusters/live/config/database/cluster-roles-patch.yaml
@@ -66,3 +66,8 @@ spec:
         login: true
         passwordSecret:
           name: open-webui-role-password
+      - name: firefly
+        ensure: present
+        login: true
+        passwordSecret:
+          name: firefly-role-password

--- a/kubernetes/clusters/live/config/database/databases.yaml
+++ b/kubernetes/clusters/live/config/database/databases.yaml
@@ -178,3 +178,15 @@ spec:
   cluster:
     name: platform
   databaseReclaimPolicy: retain
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: firefly-database
+  namespace: database
+spec:
+  name: firefly
+  owner: firefly
+  cluster:
+    name: platform
+  databaseReclaimPolicy: retain

--- a/kubernetes/clusters/live/config/database/role-secrets.yaml
+++ b/kubernetes/clusters/live/config/database/role-secrets.yaml
@@ -169,3 +169,17 @@ metadata:
 type: kubernetes.io/basic-auth
 stringData:
   username: open-webui
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: firefly-role-password
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "firefly"
+type: kubernetes.io/basic-auth
+stringData:
+  username: firefly

--- a/kubernetes/clusters/live/config/firefly/external-route.yaml
+++ b/kubernetes/clusters/live/config/firefly/external-route.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: firefly-external
+  namespace: firefly
+spec:
+  parentRefs:
+    - name: external
+      namespace: istio-gateway
+  hostnames:
+    - "firefly.${external_domain}"
+  rules:
+    - backendRefs:
+        - name: firefly
+          port: 8080

--- a/kubernetes/clusters/live/config/firefly/firefly-app-key.yaml
+++ b/kubernetes/clusters/live/config/firefly/firefly-app-key.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: firefly-app-key
+  namespace: firefly
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: firefly-app-key
+  data:
+    - secretKey: APP_KEY
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/firefly/app-key

--- a/kubernetes/clusters/live/config/firefly/firefly-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/firefly/firefly-db-credentials.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: firefly-db-credentials
+  namespace: firefly
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: database/firefly-role-password
+type: Opaque
+data: { }

--- a/kubernetes/clusters/live/config/firefly/firefly-upload-pvc.yaml
+++ b/kubernetes/clusters/live/config/firefly/firefly-upload-pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: firefly-upload
+  namespace: firefly
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: fast
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/clusters/live/config/firefly/internal-route.yaml
+++ b/kubernetes/clusters/live/config/firefly/internal-route.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: firefly-internal
+  namespace: firefly
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Firefly III"
+    gethomepage.dev/group: "Apps"
+    gethomepage.dev/icon: "firefly-iii.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=firefly"
+    gethomepage.dev/widget.type: "firefly"
+    gethomepage.dev/widget.url: "http://firefly.firefly.svc:8080"
+    gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_FIREFLY_API_KEY}}"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: istio-gateway
+  hostnames:
+    - "firefly.${internal_domain}"
+  rules:
+    - backendRefs:
+        - name: firefly
+          port: 8080

--- a/kubernetes/clusters/live/config/firefly/kustomization.yaml
+++ b/kubernetes/clusters/live/config/firefly/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - firefly-db-credentials.yaml
+  - firefly-app-key.yaml
+  - firefly-upload-pvc.yaml
+  - internal-route.yaml
+  - external-route.yaml

--- a/kubernetes/clusters/live/config/firefly/namespace.yaml
+++ b/kubernetes/clusters/live/config/firefly/namespace.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: firefly
+  labels:
+    istio.io/dataplane-mode: ambient
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline
+    network-policy.homelab/profile: standard
+    access.network-policy.homelab/postgres: "true"

--- a/kubernetes/clusters/live/config/homepage/clusterrole.yaml
+++ b/kubernetes/clusters/live/config/homepage/clusterrole.yaml
@@ -8,6 +8,10 @@ rules:
   - apiGroups: [""]
     resources: [namespaces, pods, nodes]
     verbs: [get, list]
+  # Ingress resources for service discovery (homepage queries both Ingress and HTTPRoute)
+  - apiGroups: [networking.k8s.io]
+    resources: [ingresses]
+    verbs: [get, list]
   # Gateway API resources for HTTPRoute auto-discovery
   - apiGroups: [gateway.networking.k8s.io]
     resources: [httproutes, gateways]

--- a/kubernetes/clusters/live/config/homepage/external-secrets.yaml
+++ b/kubernetes/clusters/live/config/homepage/external-secrets.yaml
@@ -106,3 +106,21 @@ spec:
     - secretKey: api-key
       remoteRef:
         key: /homelab/kubernetes/${cluster_name}/homepage/grafana-api-key
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: homepage-firefly-api-key
+  namespace: homepage
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: homepage-firefly-api-key
+  data:
+    - secretKey: api-key
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/homepage/firefly-api-key

--- a/kubernetes/clusters/live/config/homepage/network-policy.yaml
+++ b/kubernetes/clusters/live/config/homepage/network-policy.yaml
@@ -90,3 +90,9 @@ spec:
         - ports:
             - port: "34197"
               protocol: UDP
+    - toFQDNs:
+        - matchName: "healthchecks.io"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/clusters/live/config/immich/external-route.yaml
+++ b/kubernetes/clusters/live/config/immich/external-route.yaml
@@ -13,6 +13,7 @@ metadata:
     gethomepage.dev/widget.type: "immich"
     gethomepage.dev/widget.url: "http://immich-server.immich.svc:2283"
     gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_IMMICH_API_KEY}}"
+    gethomepage.dev/widget.version: "2"
     gethomepage.dev/pod-selector: "app.kubernetes.io/name=server"
 spec:
   parentRefs:

--- a/kubernetes/clusters/live/config/kustomization.yaml
+++ b/kubernetes/clusters/live/config/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - pxe-boot
   - tandoor
   - paperless
+  - firefly
   - homepage
   - longhorn-snapshots
   - velero

--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -190,6 +190,13 @@ spec:
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
       dependsOn: [cloudnative-pg, secret-generator]
+    - name: firefly
+      namespace: firefly
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: [cloudnative-pg, secret-generator]
     - name: homepage
       namespace: homepage
       chart:

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -60,6 +60,8 @@ exportarr_version=v2.3.0
 gluetun_version=v3.40.4
 # renovate: datasource=docker depName=it-tools packageName=ghcr.io/corentinth/it-tools versioning=loose
 it_tools_version=2024.10.22-7ca5933
+# renovate: datasource=docker depName=firefly-iii packageName=ghcr.io/firefly-iii/firefly-iii
+firefly_version=6.6.2
 
 # Minecraft versions
 # renovate: datasource=docker depName=minecraft-server packageName=itzg/minecraft-server


### PR DESCRIPTION
## Summary

- Deploys [Firefly III](https://github.com/firefly-iii/firefly-iii) to the live cluster using `bjw-s/app-template`
- CNPG PostgreSQL database on the shared platform cluster with secret-generator role password
- `APP_KEY` encryption key sourced from AWS SSM via ExternalSecret (survives cluster rebuilds)
- 5Gi PVC (`fast`) for attachment/receipt storage
- `baseline` PSS — official image runs nginx as root
- Homepage widget via `gethomepage.dev` annotations on internal HTTPRoute; API key from SSM
- Renovate-managed version pin at `ghcr.io/firefly-iii/firefly-iii:6.6.2`

Closes #885

## Manual prerequisites before merge

```bash
# Generate and store APP_KEY in SSM
openssl rand -hex 32 | aws ssm put-parameter \
  --name /homelab/kubernetes/live/firefly/app-key \
  --type SecureString --value -
```

After first login, generate a Personal Access Token in Firefly III UI and store at:
```
/homelab/kubernetes/live/homepage/firefly-api-key
```

## Test plan

- [ ] SSM parameter `/homelab/kubernetes/live/firefly/app-key` is set before merge
- [ ] `kubectl --context live get helmrelease firefly -n firefly` → `Ready`
- [ ] `kubectl --context live get pod -n firefly` → Running, all probes passing
- [ ] `kubectl --context live get database firefly-database -n database` → `Ready`
- [ ] `https://firefly.<internal_domain>` loads login page
- [ ] Upload a receipt attachment; verify it persists across pod restart
- [ ] After storing API key in SSM, homepage widget shows Firefly III account balances