### PR TITLE
fix(firefly): correct image to fireflyiii/core on Docker Hub

### DIFF
--- a/kubernetes/clusters/live/charts/firefly.yaml
+++ b/kubernetes/clusters/live/charts/firefly.yaml
@@ -11,7 +11,7 @@ controllers:
     containers:
       app:
         image:
-          repository: ghcr.io/firefly-iii/firefly-iii
+          repository: fireflyiii/core
           tag: ${firefly_version}
         env:
           APP_ENV: production

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -60,8 +60,8 @@ exportarr_version=v2.3.0
 gluetun_version=v3.40.4
 # renovate: datasource=docker depName=it-tools packageName=ghcr.io/corentinth/it-tools versioning=loose
 it_tools_version=2024.10.22-7ca5933
-# renovate: datasource=docker depName=firefly-iii packageName=ghcr.io/firefly-iii/firefly-iii
-firefly_version=6.6.2
+# renovate: datasource=docker depName=firefly-iii packageName=fireflyiii/core versioning=regex:^version-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
+firefly_version=version-6.6.2
 
 # Minecraft versions
 # renovate: datasource=docker depName=minecraft-server packageName=itzg/minecraft-server


### PR DESCRIPTION
## Summary

Re-applies the image fix that was lost in a squash-merge conflict.

- Image: `fireflyiii/core:version-6.6.2` (Docker Hub, not GHCR)
- Renovate annotation updated with regex versioning for `version-X.Y.Z` tag format

## Root cause

PR #891 appeared to merge successfully but the `versions.env` and `charts/firefly.yaml` changes were silently reverted during the `Merge branch 'main' into worktree-fix+homepage-widget-errors` sync commit — the squash merge of #891 ended up as a no-op (0 files changed).

## Test plan

- [ ] `fireflyiii/core:version-6.6.2` pulls successfully
- [ ] Pod reaches Running state