### PR TITLE
fix(waf): skip body inspection for Immich asset uploads

### DIFF
--- a/kubernetes/clusters/live/charts/firefly.yaml
+++ b/kubernetes/clusters/live/charts/firefly.yaml
@@ -11,7 +11,7 @@ controllers:
     containers:
       app:
         image:
-          repository: ghcr.io/firefly-iii/firefly-iii
+          repository: fireflyiii/core
           tag: ${firefly_version}
         env:
           APP_ENV: production

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -60,8 +60,8 @@ exportarr_version=v2.3.0
 gluetun_version=v3.40.4
 # renovate: datasource=docker depName=it-tools packageName=ghcr.io/corentinth/it-tools versioning=loose
 it_tools_version=2024.10.22-7ca5933
-# renovate: datasource=docker depName=firefly-iii packageName=ghcr.io/firefly-iii/firefly-iii
-firefly_version=6.6.2
+# renovate: datasource=docker depName=firefly-iii packageName=fireflyiii/core versioning=regex:^version-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
+firefly_version=version-6.6.2
 
 # Minecraft versions
 # renovate: datasource=docker depName=minecraft-server packageName=itzg/minecraft-server

--- a/kubernetes/platform/config/gateway/coraza-config.yaml
+++ b/kubernetes/platform/config/gateway/coraza-config.yaml
@@ -23,6 +23,11 @@ data:
     # SecRule REQUEST_URI "@beginsWith /api/system-config" "id:9000001,..."
     # Zipline server settings endpoint: OIDC URLs in body cause RFI false positives.
     # SecRule REQUEST_URI "@beginsWith /api/server/settings" "id:9000002,..."
+    # Immich asset upload: Coraza WASM memory limit causes multipart EOF on photo uploads
+    # (rule 200002 blocks with "MULTIPART: unexpected EOF"). Skip body inspection entirely.
+    SecRule REQUEST_URI "@beginsWith /api/assets" "id:9000003,phase:1,pass,nolog,ctl:requestBodyAccess=Off"
+    # Immich iOS app sends text/plain to /api/auth/validateToken — rule 920420 false positive.
+    SecRule REQUEST_URI "@beginsWith /api/auth/validateToken" "id:9000004,phase:1,pass,nolog,ctl:ruleRemoveById=920420"
 
     # Allow full REST method set (CRS default omits PUT/PATCH/DELETE).
     # Must be after @crs-setup-conf so we override its tx.allowed_methods default.

--- a/kubernetes/platform/config/gateway/coraza-wasm-plugin.yaml
+++ b/kubernetes/platform/config/gateway/coraza-wasm-plugin.yaml
@@ -30,6 +30,8 @@ spec:
           "id:900002,phase:1,pass,t:none,nolog,setvar:tx.inbound_anomaly_score_threshold=10"
         - Include @owasp_crs/*.conf
         - SecRuleEngine On
+        - SecRule REQUEST_URI "@beginsWith /api/assets" "id:9000003,phase:1,pass,nolog,ctl:requestBodyAccess=Off"
+        - SecRule REQUEST_URI "@beginsWith /api/auth/validateToken" "id:9000004,phase:1,pass,nolog,ctl:ruleRemoveById=920420"
         - SecRequestBodyLimit 10485760
         - SecRequestBodyNoFilesLimit 131072
         - SecResponseBodyAccess Off


### PR DESCRIPTION
## Summary

- Coraza WASM was hitting memory limit buffering 288KB+ multipart photo uploads on `POST /api/assets`, causing rule 200002 to deny with `MULTIPART: unexpected EOF` → HTTP 400 to iOS client
- Added `ctl:requestBodyAccess=Off` for `/api/assets` — binary image payloads provide no meaningful WAF inspection value (no SQLi/XSS in JPEGs)
- Suppressed rule 920420 false positive on `/api/auth/validateToken` where Immich iOS sends `text/plain` content type

Both `coraza-config.yaml` (docs) and `coraza-wasm-plugin.yaml` (runtime) updated in sync.

## Root cause evidence

```
wasm log coraza-waf: Failed to write request body error="memoryLimit reached while writing"
wasm log coraza-waf: Access denied (phase 2). Failed to parse request body. [id "200002"] [data "MULTIPART: unexpected EOF"] [uri "/api/assets"]
```

## Test plan

- [ ] Trigger Immich iOS sync and confirm uploads complete without 400 errors
- [ ] Verify WAF still blocks attack patterns on other endpoints (SQLi, XSS)
- [ ] Confirm `/api/auth/validateToken` no longer logs 920420 warnings