### PR TITLE
fix(istiod): restart on cert-manager-issued TLS secret rotation

### DIFF
--- a/kubernetes/platform/charts/istiod.yaml
+++ b/kubernetes/platform/charts/istiod.yaml
@@ -36,6 +36,8 @@ meshConfig:
 # Disable built-in CA - certificates are issued by istio-csr via cert-manager
 pilot:
   autoscaleMin: 2
+  podAnnotations:
+    secret.reloader.stakater.com/reload: "istiod-tls"
   env:
     ENABLE_CA_SERVER: "false"
 


### PR DESCRIPTION
## Summary

- Adds Stakater Reloader annotation to istiod so it auto-restarts when the `istiod-tls` secret rotates

## Root cause

`cert-manager-istio-csr` rotates the `istiod-tls` secret in `istio-system` every 24h. istiod mounts this as a projected volume, but Kubernetes delivers secret updates via atomic symlink swap of the `..data` directory. istiod's inotify watcher is registered on the file path (not the directory), so it never fires on a symlink swap — istiod keeps serving the expired certificate until manually restarted.

This caused a full cluster outage: ztunnel could not connect to istiod XDS, all pod sandbox creation on affected nodes was blocked, and a cascade of Flux kustomization failures followed.

## Fix

Add `secret.reloader.stakater.com/reload: "istiod-tls"` to `pilot.podAnnotations` in `kubernetes/platform/charts/istiod.yaml`. Stakater Reloader (already deployed in the cluster) watches secrets and triggers a rolling restart of annotated Deployments when the secret changes — ensuring istiod always loads the current certificate.

## Test plan

- [ ] Confirm pipeline promotes to integration and live after merge
- [ ] Optionally force early validation: `cmctl renew istiod-tls -n istio-system` and observe Reloader triggering istiod rolling restart