### PR TITLE
Allow HTTP egress in internal-egress network policy profile

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -38,7 +38,7 @@ pod:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
       capabilities:
-        drop: [ ALL ]
+        drop: [ALL]
 configMap:
   theme: dark
 
@@ -301,13 +301,13 @@ configMap:
 secret:
   existingSecret: "authelia-secrets"
   additionalSecrets:
-    lldap-secrets: {}
-    authelia-db-credentials: {}
-    dragonfly-auth: {}
-    grafana-oidc-client-secret: {}
-    open-webui-oidc-client-secret: {}
-    immich-oidc-client-secret: {}
-    jellyfin-oidc-client-secret: {}
-    zipline-oidc-client-secret: {}
-    vaultwarden-oidc-client-secret: {}
-    authelia-smtp-credentials: {}
+    lldap-secrets: { }
+    authelia-db-credentials: { }
+    dragonfly-auth: { }
+    grafana-oidc-client-secret: { }
+    open-webui-oidc-client-secret: { }
+    immich-oidc-client-secret: { }
+    jellyfin-oidc-client-secret: { }
+    zipline-oidc-client-secret: { }
+    vaultwarden-oidc-client-secret: { }
+    authelia-smtp-credentials: { }

--- a/kubernetes/clusters/live/charts/open-webui.yaml
+++ b/kubernetes/clusters/live/charts/open-webui.yaml
@@ -72,7 +72,7 @@ podSecurityContext:
 containerSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:
-    drop: [ ALL ]
+    drop: [ALL]
 
 persistence:
   enabled: true

--- a/kubernetes/platform/charts/istio-csr.yaml
+++ b/kubernetes/platform/charts/istio-csr.yaml
@@ -25,8 +25,8 @@ app:
     # Workload certificate validity (24h)
     certificateDuration: 24h
     # istiod serving certificate (168h with 72h rotation)
-    istiodCertificateDuration: 168h # 7 days
-    istiodCertificateRenewBefore: 72h # 3 days
+    istiodCertificateDuration: 168h  # 7 days
+    istiodCertificateRenewBefore: 72h  # 3 days
     istiodCertificateEnable: true
     # Mount root CA for distribution to namespaces
     rootCAFile: /var/run/secrets/istio-csr/ca.pem

--- a/kubernetes/platform/config/network-policy/profiles/profile-internal-egress.yaml
+++ b/kubernetes/platform/config/network-policy/profiles/profile-internal-egress.yaml
@@ -6,7 +6,7 @@ metadata:
   name: profile-internal-egress
 spec:
   description: >-
-    Internal-egress profile: Internal gateway ingress + internet egress.
+    Internal-egress profile: Internal gateway ingress + internet egress (HTTP + HTTPS).
     For services that call external APIs but aren't directly exposed to the internet.
     DNS egress and Prometheus scrape ingress handled by baseline CCNPs.
   endpointSelector:
@@ -19,10 +19,12 @@ spec:
             io.kubernetes.pod.namespace: istio-gateway
             gateway.networking.k8s.io/gateway-name: internal
   egress:
-    # Allow internet egress (HTTPS only - HTTP disabled for security)
+    # Allow internet egress (HTTP + HTTPS)
     - toEntities:
         - world
       toPorts:
         - ports:
+            - port: "80"
+              protocol: TCP
             - port: "443"
               protocol: TCP


### PR DESCRIPTION
## Summary

- Extends `profile-internal-egress` CCNP to allow port 80 (HTTP) in addition to port 443 (HTTPS) for internet egress
- Unblocks Ollama model pulls from `registry.ollama.ai` which uses HTTP for blob downloads
- Affects all 7 namespaces using this profile: `ai`, `factorio`, `homepage`, `minecraft`, `satisfactory`, `valheim`, `velero`

## Root Cause

Hubble showed `ollama → registry.ollama.ai:80 DROPPED`. The `internal-egress` profile previously restricted internet egress to HTTPS only. Ollama's model registry serves blobs over HTTP (integrity is verified via SHA256 content addressing, not TLS).

## Test plan

- [ ] PR merges and Flux reconciles `network-policy-config` Kustomization
- [ ] Verify `profile-internal-egress` CCNP updated in cluster (`kubectl get ccnp profile-internal-egress -o yaml`)
- [ ] Pull a model via OpenWebUI admin panel → Models → succeeds without 403/drop
- [ ] Hubble shows `ollama → registry.ollama.ai:80 FORWARDED`