### PR TITLE
fix(media): fix FlareSolverr CrashLoopBackOff

### DIFF
--- a/kubernetes/clusters/live/charts/flaresolverr.yaml
+++ b/kubernetes/clusters/live/charts/flaresolverr.yaml
@@ -5,11 +5,6 @@ controllers:
   flaresolverr:
     type: deployment
 
-    pod:
-      securityContext:
-        seccompProfile:
-          type: RuntimeDefault
-
     containers:
       app:
         image:
@@ -21,13 +16,8 @@ controllers:
           CAPTCHA_SOLVER: none
           TZ: UTC
         securityContext:
-          runAsUser: 0
-          runAsGroup: 0
-          runAsNonRoot: false
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
-          capabilities:
-            drop: [ALL]
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
## Summary

- Removes `capabilities: drop: [ALL]` and `seccompProfile: RuntimeDefault` from FlareSolverr container
- `drop: [ALL]` strips `DAC_OVERRIDE` from the root process, causing `EACCES` on `/app/chromedriver`
- `RuntimeDefault` seccomp blocks syscalls Chrome requires (`clone3`, `ptrace`, etc.)

## Test plan

- [ ] FlareSolverr pod reaches `Running` state
- [ ] Prowlarr can reach EZTV without Cloudflare block