### PR TITLE
fix(qbittorrent): bind to tun0 to route tracker announces through VPN

### DIFF
--- a/kubernetes/clusters/live/charts/qbittorrent.yaml
+++ b/kubernetes/clusters/live/charts/qbittorrent.yaml
@@ -76,6 +76,8 @@ controllers:
           QBT_BitTorrent__Session__DefaultSavePath: /media/downloads/complete
           QBT_BitTorrent__Session__TempPath: /media/downloads/incomplete
           QBT_BitTorrent__Session__TempPathEnabled: "true"
+          QBT_BitTorrent__Session__Interface: tun0
+          QBT_BitTorrent__Session__InterfaceName: tun0
         securityContext:
           runAsUser: 568
           runAsGroup: 568


### PR DESCRIPTION
## Summary

- qBittorrent was binding tracker announce sockets to the pod's eth0 IP (`172.18.x.x`)
- Policy routing (ip rule 100) sent traffic from that IP via eth0, bypassing the VPN
- Gluetun's iptables OUTPUT chain has no ACCEPT rule for eth0 → external IPs — SYNs silently dropped
- All tracker announces timed out; `wget` worked because it doesn't pre-bind a source IP (falls through to tun0 route)
- Fix: `QBT_BitTorrent__Session__Interface=tun0` forces qBittorrent to use the VPN interface as source, routing all connections through the VPN tunnel

## Test plan

- [ ] Deploy and verify tracker announces succeed (status 2 = Working in `/api/v2/torrents/trackers`)
- [ ] Run TorrentPeek leak test — check URL should show NordVPN exit IP, not real node IP
- [ ] Confirm no pod crash / qBittorrent still starts cleanly with tun0 binding