### PR TITLE
feat(infra): add per-node hugepages feature

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -205,6 +205,18 @@
       "allowedVersions": "!/^v3\\.41\\./"
     },
     {
+      // siderolabs/talos terraform provider 0.11.0: on_destroy.reset unknown value
+      // causes Value Conversion Error on plan/validate
+      // Upstream: https://github.com/siderolabs/terraform-provider-talos/issues/334
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchDepNames": [
+        "siderolabs/talos"
+      ],
+      "allowedVersions": "< 0.11.0"
+    },
+    {
       // pluto aqua datasource diverges from GitHub releases - force github-releases
       // to prevent phantom versions that 404 on install
       "matchManagers": ["mise"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -220,8 +220,7 @@
       // pluto aqua datasource diverges from GitHub releases - force github-releases
       // to prevent phantom versions that 404 on install
       "matchManagers": ["mise"],
-      "matchPackageNames": ["aqua:FairwindsOps/pluto"],
-      "packageName": "FairwindsOps/pluto",
+      "matchPackageNames": ["FairwindsOps/pluto"],
       "extractVersion": "^v(?<version>.+)$"
     }
   ]

--- a/.github/version-holds.yaml
+++ b/.github/version-holds.yaml
@@ -9,3 +9,8 @@ holds:
     reason: "v3.41.x healthcheck regression blocks DNS queries to kube-dns after VPN tunnel establishment"
     upstream_issue: https://github.com/qdm12/gluetun/issues/3132
     created: "2026-02-18"
+  - dep: siderolabs/talos
+    constraint: "< 0.11.0"
+    reason: "0.11.0 on_destroy.reset Value Conversion Error causes all plan/validate operations to fail"
+    upstream_issue: https://github.com/siderolabs/terraform-provider-talos/issues/334
+    created: "2026-05-06"

--- a/infrastructure/inventory.hcl
+++ b/infrastructure/inventory.hcl
@@ -259,6 +259,12 @@ locals {
     node45 = { // Supermicro 8C@2.1GHz 32Gi
       cluster = "dev"
       type    = "controlplane"
+      features = {
+        hugepages = {
+          size  = "2M"
+          count = 512
+        }
+      }
       install = {
         selector = "disk.model == 'Micron_5100_MTFD'"
       }

--- a/infrastructure/modules/config/main.tf
+++ b/infrastructure/modules/config/main.tf
@@ -101,6 +101,30 @@ locals {
     ])
   }
 
+  # Per-machine hugepages config (null if not set)
+  machine_hugepages = {
+    for name, machine in local.cluster_machines :
+    name => try(machine.features.hugepages, null)
+  }
+
+  # 2M pages → sysctl (runtime, no reboot)
+  machine_sysctls = {
+    for name, hp in local.machine_hugepages :
+    name => hp != null && hp.size == "2M" ? {
+      "vm.nr_hugepages" = tostring(hp.count)
+    } : {}
+  }
+
+  # 1G pages → kernel cmdline (boot-time, requires reboot)
+  machine_hugepages_kernel_args = {
+    for name, hp in local.machine_hugepages :
+    name => hp != null && hp.size == "1G" ? [
+      "default_hugepagesz=1G",
+      "hugepagesz=1G",
+      "hugepages=${hp.count}",
+    ] : []
+  }
+
   # Transform machines with feature-specific configuration
   machines = {
     for name, machine in local.cluster_machines :
@@ -109,7 +133,7 @@ locals {
         machine.install,
         {
           extensions        = concat(lookup(machine.install, "extensions", []), local.longhorn_enabled ? ["iscsi-tools", "util-linux-tools"] : [])
-          extra_kernel_args = concat(lookup(machine.install, "extra_kernel_args", []), local.performance_kernel_args)
+          extra_kernel_args = concat(lookup(machine.install, "extra_kernel_args", []), local.performance_kernel_args, local.machine_hugepages_kernel_args[name])
           selector          = lookup(machine.install, "selector", "")
           secureboot        = lookup(machine.install, "secureboot", false)
           architecture      = lookup(machine.install, "architecture", "amd64")
@@ -126,6 +150,7 @@ locals {
       files               = local.spegel_enabled ? [local.spegel_containerd_config] : []
       kernel_modules      = local.machine_has_nvidia[name] ? local.nvidia_kernel_modules : []
       annotations         = local.machine_longhorn_annotations[name]
+      sysctls             = local.machine_sysctls[name]
     })
   }
 
@@ -253,6 +278,7 @@ locals {
           machine_files                       = machine.files
           machine_kubelet_extraMounts         = machine.kubelet_extraMounts
           machine_kernel_modules              = machine.kernel_modules
+          machine_sysctls                     = machine.sysctls
         })],
 
         # HostnameConfig document

--- a/infrastructure/modules/config/resources/talos/talos_machine.yaml.tftpl
+++ b/infrastructure/modules/config/resources/talos/talos_machine.yaml.tftpl
@@ -90,6 +90,12 @@ machine:
       - name: ${mod.name}
 %{ endfor ~}
 %{ endif ~}
+%{ if length(machine_sysctls) > 0 ~}
+  sysctls:
+%{ for k, v in machine_sysctls ~}
+    ${k}: "${v}"
+%{ endfor ~}
+%{ endif ~}
   features:
     stableHostname: false
     hostDNS:

--- a/infrastructure/modules/config/tests/feature_hugepages.tftest.hcl
+++ b/infrastructure/modules/config/tests/feature_hugepages.tftest.hcl
@@ -1,0 +1,425 @@
+# Hugepages feature tests - validates per-node hugepages allocation via sysctl (2M)
+# and kernel cmdline (1G), selective application, and coexistence with other features
+
+variables {
+  name = "test-cluster"
+
+  bgp = {
+    router_ip  = "192.168.10.1"
+    router_asn = 64512
+  }
+
+  networking = {
+    id                  = 1
+    internal_tld        = "internal.test.local"
+    external_tld        = "external.test.local"
+    node_subnet         = "192.168.10.0/24"
+    pod_subnet          = "172.18.0.0/16"
+    service_subnet      = "172.19.0.0/16"
+    vip                 = "192.168.10.20"
+    ip_pool_start       = "192.168.10.21"
+    internal_ingress_ip = "192.168.10.22"
+    external_ingress_ip = "192.168.10.23"
+    ip_pool_stop        = "192.168.10.29"
+    bgp_asn             = 64513
+    nameservers         = ["192.168.10.1"]
+    timeservers         = ["0.pool.ntp.org"]
+  }
+
+  versions = {
+    talos       = "v1.9.0"
+    kubernetes  = "1.32.0"
+    cilium      = "1.16.0"
+    gateway_api = "v1.2.0"
+    flux        = "v2.4.0"
+    prometheus  = "20.0.0"
+  }
+
+  local_paths = {
+    talos      = "~/.talos"
+    kubernetes = "~/.kube"
+  }
+
+  accounts = {
+    unifi = {
+      address       = "https://192.168.1.1"
+      site          = "default"
+      api_key_store = "/test/unifi"
+    }
+    github = {
+      org             = "testorg"
+      repository      = "testrepo"
+      repository_path = "clusters"
+      token_store     = "/test/github"
+    }
+    external_secrets = {
+      id_store     = "/test/es-id"
+      secret_store = "/test/es-secret"
+    }
+    healthchecksio = {
+      api_key_store = "/test/hc"
+    }
+  }
+
+  cilium_values_template = <<-EOT
+    cluster:
+      name: $${cluster_name}
+    ipv4NativeRoutingCIDR: $${cluster_pod_subnet}
+    hubble:
+      ui:
+        ingress:
+          hosts:
+            - hubble.$${internal_domain}
+  EOT
+
+  machines = {
+    node1 = {
+      cluster = "test-cluster"
+      type    = "controlplane"
+      install = { selector = "disk.model = *" }
+      bonds = [{
+        link_permanentAddr = ["aa:bb:cc:dd:ee:01"]
+        addresses          = ["192.168.10.101"]
+      }]
+    }
+  }
+}
+
+# 2M hugepages → sysctl output
+run "hugepages_2m_emits_sysctl" {
+  command = plan
+
+  variables {
+    features = []
+    machines = {
+      hp-node = {
+        cluster = "test-cluster"
+        type    = "controlplane"
+        features = {
+          hugepages = { size = "2M", count = 512 }
+        }
+        install = { selector = "disk.model = *" }
+        bonds = [{
+          link_permanentAddr = ["aa:bb:cc:dd:ee:01"]
+          addresses          = ["192.168.10.101"]
+        }]
+      }
+    }
+  }
+
+  assert {
+    condition     = output.machines["hp-node"].sysctls["vm.nr_hugepages"] == "512"
+    error_message = "2M hugepages should emit vm.nr_hugepages sysctl with page count as string"
+  }
+
+  assert {
+    condition     = length(output.machines["hp-node"].sysctls) == 1
+    error_message = "2M hugepages should emit exactly one sysctl"
+  }
+}
+
+# 2M hugepages → no hugepage kernel args
+run "hugepages_2m_no_kernel_args" {
+  command = plan
+
+  variables {
+    features = []
+    machines = {
+      hp-node = {
+        cluster = "test-cluster"
+        type    = "controlplane"
+        features = {
+          hugepages = { size = "2M", count = 512 }
+        }
+        install = { selector = "disk.model = *" }
+        bonds = [{
+          link_permanentAddr = ["aa:bb:cc:dd:ee:01"]
+          addresses          = ["192.168.10.101"]
+        }]
+      }
+    }
+  }
+
+  assert {
+    condition = !anytrue([
+      for arg in output.machines["hp-node"].install.extra_kernel_args :
+      startswith(arg, "hugepage")
+    ])
+    error_message = "2M hugepages should not add hugepage kernel args"
+  }
+}
+
+# 2M hugepages → rendered in Talos machine YAML
+run "hugepages_2m_in_talos_yaml" {
+  command = plan
+
+  variables {
+    features = []
+    machines = {
+      hp-node = {
+        cluster = "test-cluster"
+        type    = "controlplane"
+        features = {
+          hugepages = { size = "2M", count = 512 }
+        }
+        install = { selector = "disk.model = *" }
+        bonds = [{
+          link_permanentAddr = ["aa:bb:cc:dd:ee:01"]
+          addresses          = ["192.168.10.101"]
+        }]
+      }
+    }
+  }
+
+  assert {
+    condition = alltrue([
+      for m in output.talos.talos_machines :
+      strcontains(join("\n", m.configs), "sysctls:")
+    ])
+    error_message = "Talos config should contain sysctls: section"
+  }
+
+  assert {
+    condition = alltrue([
+      for m in output.talos.talos_machines :
+      strcontains(join("\n", m.configs), "vm.nr_hugepages")
+    ])
+    error_message = "Talos config should contain vm.nr_hugepages sysctl"
+  }
+
+  assert {
+    condition = alltrue([
+      for m in output.talos.talos_machines :
+      strcontains(join("\n", m.configs), "\"512\"")
+    ])
+    error_message = "Talos config should contain hugepage count 512"
+  }
+}
+
+# 1G hugepages → kernel cmdline args
+run "hugepages_1g_emits_kernel_args" {
+  command = plan
+
+  variables {
+    features = []
+    machines = {
+      hp-node = {
+        cluster = "test-cluster"
+        type    = "controlplane"
+        features = {
+          hugepages = { size = "1G", count = 8 }
+        }
+        install = { selector = "disk.model = *" }
+        bonds = [{
+          link_permanentAddr = ["aa:bb:cc:dd:ee:01"]
+          addresses          = ["192.168.10.101"]
+        }]
+      }
+    }
+  }
+
+  assert {
+    condition     = contains(output.machines["hp-node"].install.extra_kernel_args, "default_hugepagesz=1G")
+    error_message = "1G hugepages should add default_hugepagesz=1G kernel arg"
+  }
+
+  assert {
+    condition     = contains(output.machines["hp-node"].install.extra_kernel_args, "hugepagesz=1G")
+    error_message = "1G hugepages should add hugepagesz=1G kernel arg"
+  }
+
+  assert {
+    condition     = contains(output.machines["hp-node"].install.extra_kernel_args, "hugepages=8")
+    error_message = "1G hugepages should add hugepages=8 kernel arg"
+  }
+
+  assert {
+    condition     = length(output.machines["hp-node"].sysctls) == 0
+    error_message = "1G hugepages should not emit any sysctls"
+  }
+}
+
+# 1G hugepages → install output contains kernel args
+run "hugepages_1g_in_install_output" {
+  command = plan
+
+  variables {
+    features = []
+    machines = {
+      hp-node = {
+        cluster = "test-cluster"
+        type    = "controlplane"
+        features = {
+          hugepages = { size = "1G", count = 8 }
+        }
+        install = { selector = "disk.model = *" }
+        bonds = [{
+          link_permanentAddr = ["aa:bb:cc:dd:ee:01"]
+          addresses          = ["192.168.10.101"]
+        }]
+      }
+    }
+  }
+
+  assert {
+    condition = alltrue([
+      for m in output.talos.talos_machines :
+      contains(m.install.extra_kernel_args, "hugepages=8")
+    ])
+    error_message = "Install output should contain 1G hugepages kernel arg"
+  }
+
+  assert {
+    condition = alltrue([
+      for m in output.talos.talos_machines :
+      !strcontains(join("\n", m.configs), "sysctls:")
+    ])
+    error_message = "Talos config should not contain sysctls section for 1G hugepages"
+  }
+}
+
+# No hugepages feature → no sysctls, no kernel args
+run "no_hugepages_no_config" {
+  command = plan
+
+  variables {
+    features = []
+  }
+
+  assert {
+    condition = alltrue([
+      for name, m in output.machines :
+      length(m.sysctls) == 0
+    ])
+    error_message = "Nodes without hugepages should have no sysctls"
+  }
+
+  assert {
+    condition = alltrue([
+      for name, m in output.machines :
+      !anytrue([for arg in m.install.extra_kernel_args : startswith(arg, "hugepage")])
+    ])
+    error_message = "Nodes without hugepages should have no hugepage kernel args"
+  }
+}
+
+# Mixed cluster — each node gets only its own config
+run "mixed_cluster_selective" {
+  command = plan
+
+  variables {
+    features = []
+    machines = {
+      plain = {
+        cluster = "test-cluster"
+        type    = "controlplane"
+        install = { selector = "disk.model = *" }
+        bonds = [{
+          link_permanentAddr = ["aa:bb:cc:dd:ee:01"]
+          addresses          = ["192.168.10.101"]
+        }]
+      }
+      hp-2m = {
+        cluster = "test-cluster"
+        type    = "worker"
+        features = {
+          hugepages = { size = "2M", count = 256 }
+        }
+        install = { selector = "disk.model = *" }
+        bonds = [{
+          link_permanentAddr = ["aa:bb:cc:dd:ee:02"]
+          addresses          = ["192.168.10.102"]
+        }]
+      }
+      hp-1g = {
+        cluster = "test-cluster"
+        type    = "worker"
+        features = {
+          hugepages = { size = "1G", count = 4 }
+        }
+        install = { selector = "disk.model = *" }
+        bonds = [{
+          link_permanentAddr = ["aa:bb:cc:dd:ee:03"]
+          addresses          = ["192.168.10.103"]
+        }]
+      }
+    }
+  }
+
+  assert {
+    condition     = length(output.machines["plain"].sysctls) == 0
+    error_message = "Plain node should have no sysctls"
+  }
+
+  assert {
+    condition     = output.machines["hp-2m"].sysctls["vm.nr_hugepages"] == "256"
+    error_message = "2M node should have vm.nr_hugepages = 256"
+  }
+
+  assert {
+    condition     = length(output.machines["hp-2m"].sysctls) == 1
+    error_message = "2M node should have exactly one sysctl"
+  }
+
+  assert {
+    condition     = length(output.machines["hp-1g"].sysctls) == 0
+    error_message = "1G node should have no sysctls"
+  }
+
+  assert {
+    condition     = contains(output.machines["hp-1g"].install.extra_kernel_args, "hugepages=4")
+    error_message = "1G node should have hugepages=4 kernel arg"
+  }
+
+  assert {
+    condition = !anytrue([
+      for arg in output.machines["plain"].install.extra_kernel_args :
+      startswith(arg, "hugepage")
+    ])
+    error_message = "Plain node should have no hugepage kernel args"
+  }
+
+  assert {
+    condition = !anytrue([
+      for arg in output.machines["hp-2m"].install.extra_kernel_args :
+      startswith(arg, "hugepage")
+    ])
+    error_message = "2M node should have no hugepage kernel args"
+  }
+}
+
+# Hugepages coexists with NVIDIA
+run "hugepages_coexists_with_nvidia" {
+  command = plan
+
+  variables {
+    features = []
+    machines = {
+      gpu-hp-node = {
+        cluster = "test-cluster"
+        type    = "worker"
+        features = {
+          hugepages = { size = "2M", count = 1024 }
+        }
+        install = {
+          selector   = "disk.model = *"
+          extensions = ["nonfree-kmod-nvidia-production", "nvidia-container-toolkit-production"]
+        }
+        bonds = [{
+          link_permanentAddr = ["aa:bb:cc:dd:ee:01"]
+          addresses          = ["192.168.10.101"]
+        }]
+      }
+    }
+  }
+
+  assert {
+    condition     = length(output.machines["gpu-hp-node"].kernel_modules) == 4
+    error_message = "GPU+hugepages node should still have 4 NVIDIA kernel modules"
+  }
+
+  assert {
+    condition     = output.machines["gpu-hp-node"].sysctls["vm.nr_hugepages"] == "1024"
+    error_message = "GPU+hugepages node should have vm.nr_hugepages sysctl"
+  }
+}

--- a/infrastructure/modules/config/tests/validation.tftest.hcl
+++ b/infrastructure/modules/config/tests/validation.tftest.hcl
@@ -517,6 +517,103 @@ run "valid_multiple_bonds" {
   }
 }
 
+# Hugepages validation - valid sizes
+run "valid_hugepages_2m" {
+  command = plan
+
+  variables {
+    machines = {
+      node1 = {
+        cluster = "validation-test"
+        type    = "controlplane"
+        features = {
+          hugepages = { size = "2M", count = 512 }
+        }
+        install = { selector = "disk.model = *" }
+        bonds = [{
+          link_permanentAddr = ["aa:bb:cc:dd:ee:01"]
+          addresses          = ["192.168.10.101"]
+        }]
+      }
+    }
+  }
+
+  assert {
+    condition     = output.machines["node1"].sysctls["vm.nr_hugepages"] == "512"
+    error_message = "2M hugepages should be accepted"
+  }
+}
+
+run "valid_hugepages_1g" {
+  command = plan
+
+  variables {
+    machines = {
+      node1 = {
+        cluster = "validation-test"
+        type    = "controlplane"
+        features = {
+          hugepages = { size = "1G", count = 4 }
+        }
+        install = { selector = "disk.model = *" }
+        bonds = [{
+          link_permanentAddr = ["aa:bb:cc:dd:ee:01"]
+          addresses          = ["192.168.10.101"]
+        }]
+      }
+    }
+  }
+
+  assert {
+    condition     = contains(output.machines["node1"].install.extra_kernel_args, "hugepages=4")
+    error_message = "1G hugepages should be accepted"
+  }
+}
+
+run "invalid_hugepages_size" {
+  command         = plan
+  expect_failures = [var.machines]
+
+  variables {
+    machines = {
+      node1 = {
+        cluster = "validation-test"
+        type    = "controlplane"
+        features = {
+          hugepages = { size = "4K", count = 100 }
+        }
+        install = { selector = "disk.model = *" }
+        bonds = [{
+          link_permanentAddr = ["aa:bb:cc:dd:ee:01"]
+          addresses          = ["192.168.10.101"]
+        }]
+      }
+    }
+  }
+}
+
+run "invalid_hugepages_count_zero" {
+  command         = plan
+  expect_failures = [var.machines]
+
+  variables {
+    machines = {
+      node1 = {
+        cluster = "validation-test"
+        type    = "controlplane"
+        features = {
+          hugepages = { size = "2M", count = 0 }
+        }
+        install = { selector = "disk.model = *" }
+        bonds = [{
+          link_permanentAddr = ["aa:bb:cc:dd:ee:01"]
+          addresses          = ["192.168.10.101"]
+        }]
+      }
+    }
+  }
+}
+
 # Volumes validation
 run "valid_volumes" {
   command = plan

--- a/infrastructure/modules/config/variables.tf
+++ b/infrastructure/modules/config/variables.tf
@@ -112,6 +112,12 @@ variable "machines" {
     cluster = string
     type    = string
     labels  = optional(map(string), {})
+    features = optional(object({
+      hugepages = optional(object({
+        size  = string
+        count = number
+      }))
+    }), {})
     install = object({
       selector     = string
       extensions   = optional(list(string), [])
@@ -138,6 +144,22 @@ variable "machines" {
   validation {
     condition     = alltrue([for name, m in var.machines : length(m.bonds) > 0])
     error_message = "Each machine must have at least one bond configuration."
+  }
+
+  validation {
+    condition = alltrue([
+      for name, m in var.machines :
+      m.features.hugepages == null || contains(["2M", "1G"], m.features.hugepages.size)
+    ])
+    error_message = "hugepages.size must be one of: '2M', '1G'."
+  }
+
+  validation {
+    condition = alltrue([
+      for name, m in var.machines :
+      m.features.hugepages == null || m.features.hugepages.count > 0
+    ])
+    error_message = "hugepages.count must be greater than 0."
   }
 }
 

--- a/infrastructure/modules/talos/tests/plan.tftest.hcl
+++ b/infrastructure/modules/talos/tests/plan.tftest.hcl
@@ -522,3 +522,58 @@ run "version_propagation" {
     error_message = "Machine secrets should use specified Talos version"
   }
 }
+
+# Talos module accepts machine configs containing machine.sysctls (hugepages 2M)
+run "sysctls_in_machine_config" {
+  command = plan
+
+  variables {
+    talos_machines = [
+      {
+        install = {
+          selector = "disk.model = *"
+        }
+        configs = [
+          <<-EOT
+          cluster:
+            clusterName: talos.local
+            controlPlane:
+              endpoint: https://talos.local:6443
+          machine:
+            type: controlplane
+            sysctls:
+              vm.nr_hugepages: "512"
+          EOT
+          ,
+          <<-EOT
+          apiVersion: v1alpha1
+          kind: HostnameConfig
+          hostname: host1
+          EOT
+          ,
+          <<-EOT
+          apiVersion: v1alpha1
+          kind: BondConfig
+          name: bond0
+          links:
+            - link0_0
+          bondMode: active-backup
+          mtu: 1500
+          addresses:
+            - address: 10.10.10.10/24
+          EOT
+        ]
+      }
+    ]
+  }
+
+  assert {
+    condition     = strcontains(data.talos_machine_configuration.this["host1"].config_patches[0], "vm.nr_hugepages")
+    error_message = "Talos module should accept and preserve sysctls in machine config"
+  }
+
+  assert {
+    condition     = talos_machine_configuration_apply.machines["host1"].endpoint == "10.10.10.10"
+    error_message = "Endpoint should still be extracted correctly with sysctls present"
+  }
+}

--- a/infrastructure/modules/talos/versions.tf
+++ b/infrastructure/modules/talos/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     talos = {
       source  = "siderolabs/talos"
-      version = "0.11.0"
+      version = "0.10.1"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
## Summary

- Adds generic `features` map to inventory.hcl machine schema, used to declare hugepages allocation per node
- Config module decodes `features.hugepages` and emits `machine.sysctls` (2M, runtime) or `install.extraKernelArgs` (1G, boot-time); talos module interface unchanged
- Enables 512x 2M hugepages on dev cluster `node45` as the test case
- Downgrades `siderolabs/talos` terraform provider `0.11.0` → `0.10.1` and blocks Renovate upgrade due to [`on_destroy.reset` Value Conversion Error](https://github.com/siderolabs/terraform-provider-talos/issues/334) that breaks all plan/validate operations

## Test plan

- [x] `task tg:test-config` — 140/140 pass (includes new `feature_hugepages.tftest.hcl` with 8 cases, 4 new validation cases)
- [x] `task tg:test-talos` — 30/30 pass (includes new `sysctls_in_machine_config` smoke test)
- [x] `task tg:fmt` — no formatting changes
- [ ] `task tg:apply-dev` — requires explicit approval; post-apply verify with `talosctl -n 192.168.10.252 read /proc/meminfo | grep -i hugepage`