### PR TITLE
feat(gateway): harden external ingress before internet exposure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        args: [--strict]

--- a/kubernetes/clusters/live/config/vaultwarden/external-route.yaml
+++ b/kubernetes/clusters/live/config/vaultwarden/external-route.yaml
@@ -23,7 +23,7 @@ spec:
             path:
               type: ReplaceFullPath
               replaceFullPath: /
-            statusCode: 302
+            statusCode: 301
     # Route all other traffic normally
     - matches:
         - path:

--- a/kubernetes/platform/config/gateway/coraza-config.yaml
+++ b/kubernetes/platform/config/gateway/coraza-config.yaml
@@ -46,7 +46,3 @@ data:
 
     # Response body inspection disabled (performance)
     SecResponseBodyAccess Off
-
-    # Block Vaultwarden admin panel from external access (hard 403, not a redirect)
-    SecRule REQUEST_HEADERS:Host "@contains vault.${external_domain}" "id:9000010,phase:1,chain,deny,status:403,log,msg:'Vaultwarden admin blocked'"
-    SecRule REQUEST_URI "@beginsWith /admin" "t:none"

--- a/kubernetes/platform/config/gateway/coraza-config.yaml
+++ b/kubernetes/platform/config/gateway/coraza-config.yaml
@@ -46,3 +46,7 @@ data:
 
     # Response body inspection disabled (performance)
     SecResponseBodyAccess Off
+
+    # Block Vaultwarden admin panel from external access (hard 403, not a redirect)
+    SecRule REQUEST_HEADERS:Host "@contains vault.${external_domain}" "id:9000010,phase:1,chain,deny,status:403,log,msg:'Vaultwarden admin blocked'"
+    SecRule REQUEST_URI "@beginsWith /admin" "t:none"

--- a/kubernetes/platform/config/gateway/coraza-wasm-plugin.yaml
+++ b/kubernetes/platform/config/gateway/coraza-wasm-plugin.yaml
@@ -14,8 +14,8 @@ spec:
   imagePullPolicy: IfNotPresent
   # Run early in filter chain, before authentication
   phase: AUTHN
-  # Allow traffic if WAF errors - availability over security
-  failStrategy: FAIL_OPEN
+  # Deny traffic if WAF errors - security over availability
+  failStrategy: FAIL_CLOSE
   pluginConfig:
     directives_map:
       default:
@@ -35,4 +35,6 @@ spec:
         - SecRequestBodyLimit 10485760
         - SecRequestBodyNoFilesLimit 131072
         - SecResponseBodyAccess Off
+        - SecRule REQUEST_HEADERS:Host "@contains vault.${external_domain}" "id:9000010,phase:1,chain,deny,status:403,log,msg:'Vaultwarden admin blocked'"
+        - SecRule REQUEST_URI "@beginsWith /admin" "t:none"
     default_directives: default

--- a/kubernetes/platform/config/gateway/coraza-wasm-plugin.yaml
+++ b/kubernetes/platform/config/gateway/coraza-wasm-plugin.yaml
@@ -35,6 +35,4 @@ spec:
         - SecRequestBodyLimit 10485760
         - SecRequestBodyNoFilesLimit 131072
         - SecResponseBodyAccess Off
-        - SecRule REQUEST_HEADERS:Host "@contains vault.${external_domain}" "id:9000010,phase:1,chain,deny,status:403,log,msg:'Vaultwarden admin blocked'"
-        - SecRule REQUEST_URI "@beginsWith /admin" "t:none"
     default_directives: default

--- a/kubernetes/platform/config/gateway/external-gateway-ratelimit.yaml
+++ b/kubernetes/platform/config/gateway/external-gateway-ratelimit.yaml
@@ -54,4 +54,4 @@ spec:
         value:
           rate_limits:
             - actions:
-                - remote_address: {}
+                - remote_address: { }

--- a/kubernetes/platform/config/gateway/external-gateway-ratelimit.yaml
+++ b/kubernetes/platform/config/gateway/external-gateway-ratelimit.yaml
@@ -1,0 +1,57 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/networking.istio.io/envoyfilter_v1alpha3.json
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: external-gateway-local-ratelimit
+spec:
+  workloadSelector:
+    labels:
+      gateway.networking.k8s.io/gateway-name: external
+  configPatches:
+    # Inject local rate limit HTTP filter before the router
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+              subFilter:
+                name: "envoy.filters.http.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.local_ratelimit
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            value:
+              stat_prefix: external_gateway_per_ip
+              filter_enabled:
+                default_value:
+                  numerator: 100
+                  denominator: HUNDRED
+              filter_enforced:
+                default_value:
+                  numerator: 100
+                  denominator: HUNDRED
+              # 200 requests/min per source IP
+              descriptors:
+                - entries:
+                    - key: remote_address
+                  token_bucket:
+                    max_tokens: 200
+                    tokens_per_fill: 200
+                    fill_interval: 60s
+              enable_x_ratelimit_headers: DRAFT_VERSION_03
+    # Add remote_address action to all external gateway virtual hosts so descriptors are generated
+    - applyTo: VIRTUAL_HOST
+      match:
+        context: GATEWAY
+      patch:
+        operation: MERGE
+        value:
+          rate_limits:
+            - actions:
+                - remote_address: {}

--- a/kubernetes/platform/config/gateway/kustomization.yaml
+++ b/kubernetes/platform/config/gateway/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
   - coraza-wasm-plugin.yaml
   - coraza-config.yaml
   - coraza-waf-rules.yaml
+  - external-gateway-ratelimit.yaml
   - platform-auth-policy.yaml


### PR DESCRIPTION
## Summary

Pre-hardening changes before forwarding ports 80/443 through UDM to the external Istio gateway (`192.168.10.23`). Based on internal code review and external recon (nmap, testssl, WAF probing).

- **Rate limiting**: new `EnvoyFilter` injects Envoy local rate limiter on external gateway pods — 200 req/min per source IP using per-descriptor token buckets. UDM DNAT preserves real client IPs so per-IP limits are effective
- **WAF fail-safe**: `FAIL_OPEN` → `FAIL_CLOSE` — WAF crash now denies traffic rather than passing it unfiltered
- **Vaultwarden `/admin` block**: Coraza phase-1 chained rule returns 403 before request reaches the backend or HTTPRoute layer, scoped to `vault.${external_domain}` host; existing HTTPRoute redirect hardened 302 → 301 as belt-and-suspenders
- **`.pre-commit-config.yaml`**: adds yamllint pre-commit hook so formatting issues are caught locally before CI

## Recon Findings (pre-PR)

- TLS 1.0/1.1 rejected, TLS 1.2+1.3 only ✅
- All major CVEs (Heartbleed, BEAST, POODLE, CRIME, SWEET32, FREAK, LOGJAM): not vulnerable ✅
- XSS and double-encoded path traversal: blocked by WAF ✅
- SNI mandatory (direct IP connection fails) ✅
- HSTS missing on 8/9 external services — not fixed in this PR (intentional, follow-up)
- `server: istio-envoy` and `x-envoy-upstream-service-time` headers leak on all responses — not fixed in this PR (low severity)

## Test plan

- [ ] Verify Flux reconciles `gateway` Kustomization without errors
- [ ] Confirm `external-gateway-local-ratelimit` EnvoyFilter applied to external gateway pods
- [ ] Verify 429 returned after >200 requests/min from same IP
- [ ] Confirm `curl https://vault.tomnowak.work/admin` returns 403 (not 302)
- [ ] Confirm WAF still blocks XSS: `curl "https://auth.tomnowak.work/?x=<script>alert(1)</script>"` → 403
- [ ] Confirm all external services still load normally