### PR TITLE
feat(paperless): add OIDC/SSO support via Authelia

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -264,6 +264,25 @@ configMap:
           access_token_signed_response_alg: none
           userinfo_signed_response_alg: none
           token_endpoint_auth_method: client_secret_post
+        - client_id: paperless
+          client_name: Paperless
+          client_secret:
+            path: /secrets/paperless-oidc-client-secret/client-secret
+          public: false
+          authorization_policy: two_factor
+          require_pkce: true
+          pkce_challenge_method: S256
+          redirect_uris:
+            - https://paperless.${internal_domain}/accounts/oidc/authelia/login/callback/
+          scopes:
+            - openid
+            - profile
+            - email
+          response_types:
+            - code
+          grant_types:
+            - authorization_code
+          token_endpoint_auth_method: client_secret_post
         - client_id: vaultwarden
           client_name: Vaultwarden
           client_secret:
@@ -310,4 +329,5 @@ secret:
     jellyfin-oidc-client-secret: { }
     zipline-oidc-client-secret: { }
     vaultwarden-oidc-client-secret: { }
+    paperless-oidc-client-secret: { }
     authelia-smtp-credentials: { }

--- a/kubernetes/clusters/live/charts/paperless.yaml
+++ b/kubernetes/clusters/live/charts/paperless.yaml
@@ -81,6 +81,16 @@ controllers:
           PAPERLESS_REDIS:
             dependsOn: DRAGONFLY_PASSWORD
             value: "redis://:$(DRAGONFLY_PASSWORD)@dragonfly.cache.svc.cluster.local:6379"
+          # OIDC/SSO via Authelia
+          PAPERLESS_APPS: "allauth.socialaccount.providers.openid_connect"
+          PAPERLESS_OIDC_CLIENT_SECRET:
+            valueFrom:
+              secretKeyRef:
+                name: paperless-oidc-client-secret
+                key: client-secret
+          PAPERLESS_SOCIALACCOUNT_PROVIDERS:
+            dependsOn: PAPERLESS_OIDC_CLIENT_SECRET
+            value: '{"openid_connect": {"OAUTH_PKCE_ENABLED": true, "APPS": [{"provider_id": "authelia", "name": "Authelia", "client_id": "paperless", "secret": "$(PAPERLESS_OIDC_CLIENT_SECRET)", "settings": {"server_url": "https://auth.${external_domain}/.well-known/openid-configuration"}}]}}'
           # Storage paths
           PAPERLESS_DATA_DIR: "/data"
           PAPERLESS_MEDIA_ROOT: "/media"

--- a/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - grafana-oidc-client-secret.yaml
   - zipline-oidc-client-secret.yaml
   - vaultwarden-oidc-client-secret.yaml
+  - paperless-oidc-client-secret.yaml
   - authelia-secrets.yaml
   - authelia-smtp-credentials.yaml
   - authelia-smtp-egress.yaml

--- a/kubernetes/clusters/live/config/authelia-prereqs/paperless-oidc-client-secret.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/paperless-oidc-client-secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: paperless-oidc-client-secret
+  namespace: authelia
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: client-secret
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "64"
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "paperless"
+data: { }

--- a/kubernetes/clusters/live/config/paperless/kustomization.yaml
+++ b/kubernetes/clusters/live/config/paperless/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - media-pvc.yaml
   - paperless-db-credentials.yaml
   - dragonfly-password-replica.yaml
+  - paperless-oidc-client-secret-replica.yaml
   - paperless-secret.yaml
   - internal-route.yaml
   - canary.yaml

--- a/kubernetes/clusters/live/config/paperless/paperless-oidc-client-secret-replica.yaml
+++ b/kubernetes/clusters/live/config/paperless/paperless-oidc-client-secret-replica.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: paperless-oidc-client-secret
+  namespace: paperless
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: authelia/paperless-oidc-client-secret
+data: { }


### PR DESCRIPTION
## Summary

- Generates a `paperless-oidc-client-secret` via secret-generator in the `authelia` namespace and replicates it to the `paperless` namespace
- Registers Paperless as an Authelia OIDC client with PKCE (S256), `two_factor` policy, and `client_secret_post` auth method
- Configures Paperless-ngx with `django-allauth` `openid_connect` provider; the client secret is injected into the JSON blob using the existing `dependsOn` env-chaining pattern

## Test plan

- [ ] Flux reconciles `authelia-prereqs` kustomization cleanly; `paperless-oidc-client-secret` Secret appears in `authelia` namespace with a generated `client-secret` key
- [ ] `paperless-oidc-client-secret` Secret is replicated into `paperless` namespace
- [ ] Authelia pod restarts and serves OIDC discovery at `/.well-known/openid-configuration` without errors; `paperless` appears in the registered clients
- [ ] Paperless-ngx pod restarts; visiting the login page shows an "Authelia" SSO option
- [ ] Clicking the SSO option redirects to Authelia, completes two-factor auth, and lands back in Paperless as the authenticated user