### PR TITLE
feat(tandoor): add OIDC/SSO support via Authelia

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -283,6 +283,26 @@ configMap:
           grant_types:
             - authorization_code
           token_endpoint_auth_method: client_secret_post
+        - client_id: tandoor
+          client_name: Tandoor
+          client_secret:
+            path: /secrets/tandoor-oidc-client-secret/client-secret
+          public: false
+          authorization_policy: two_factor
+          require_pkce: true
+          pkce_challenge_method: S256
+          redirect_uris:
+            - https://recipes.${internal_domain}/accounts/oidc/login/callback/
+            - https://recipes.${external_domain}/accounts/oidc/login/callback/
+          scopes:
+            - openid
+            - profile
+            - email
+          response_types:
+            - code
+          grant_types:
+            - authorization_code
+          token_endpoint_auth_method: client_secret_post
         - client_id: vaultwarden
           client_name: Vaultwarden
           client_secret:
@@ -330,4 +350,5 @@ secret:
     zipline-oidc-client-secret: { }
     vaultwarden-oidc-client-secret: { }
     paperless-oidc-client-secret: { }
+    tandoor-oidc-client-secret: { }
     authelia-smtp-credentials: { }

--- a/kubernetes/clusters/live/charts/tandoor.yaml
+++ b/kubernetes/clusters/live/charts/tandoor.yaml
@@ -72,6 +72,16 @@ controllers:
           GUNICORN_WORKERS: "3"
           GUNICORN_THREADS: "2"
           GUNICORN_MEDIA: "0"
+          # OIDC/SSO via Authelia
+          SOCIAL_PROVIDERS: "allauth.socialaccount.providers.openid_connect"
+          TANDOOR_OIDC_CLIENT_SECRET:
+            valueFrom:
+              secretKeyRef:
+                name: tandoor-oidc-client-secret
+                key: client-secret
+          SOCIALACCOUNT_PROVIDERS:
+            dependsOn: TANDOOR_OIDC_CLIENT_SECRET
+            value: '{"openid_connect": {"OAUTH_PKCE_ENABLED": true, "APPS": [{"provider_id": "authelia", "name": "Authelia", "client_id": "tandoor", "secret": "$(TANDOOR_OIDC_CLIENT_SECRET)", "settings": {"server_url": "https://auth.${external_domain}/.well-known/openid-configuration"}}]}}'
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false

--- a/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - zipline-oidc-client-secret.yaml
   - vaultwarden-oidc-client-secret.yaml
   - paperless-oidc-client-secret.yaml
+  - tandoor-oidc-client-secret.yaml
   - authelia-secrets.yaml
   - authelia-smtp-credentials.yaml
   - authelia-smtp-egress.yaml

--- a/kubernetes/clusters/live/config/authelia-prereqs/tandoor-oidc-client-secret.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/tandoor-oidc-client-secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tandoor-oidc-client-secret
+  namespace: authelia
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: client-secret
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "64"
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "tandoor"
+data: { }

--- a/kubernetes/clusters/live/config/tandoor/kustomization.yaml
+++ b/kubernetes/clusters/live/config/tandoor/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - namespace.yaml
   - tandoor-secret.yaml
   - tandoor-db-credentials.yaml
+  - tandoor-oidc-client-secret-replica.yaml
   - garage-bucket.yaml
   - garage-key.yaml
   - internal-route.yaml

--- a/kubernetes/clusters/live/config/tandoor/tandoor-oidc-client-secret-replica.yaml
+++ b/kubernetes/clusters/live/config/tandoor/tandoor-oidc-client-secret-replica.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tandoor-oidc-client-secret
+  namespace: tandoor
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: authelia/tandoor-oidc-client-secret
+data: { }


### PR DESCRIPTION
## Summary

- Register Tandoor as an Authelia OIDC client with PKCE (`client_secret_post`, two-factor policy)
- Both internal (`recipes.internal.tomnowak.work`) and external (`recipes.ionfury.tv`) callback URIs registered — Tandoor has dual-exposed routes
- Provision `tandoor-oidc-client-secret` via secret-generator in the `authelia` namespace, replicated to `tandoor` namespace
- Configure `SOCIAL_PROVIDERS`, `TANDOOR_OIDC_CLIENT_SECRET`, and `SOCIALACCOUNT_PROVIDERS` env vars in Tandoor Helm values using the `dependsOn` pattern to interpolate the secret at runtime

## Test plan

- [ ] Authelia HelmRelease reconciles cleanly after merge (new client and additionalSecret)
- [ ] `tandoor-oidc-client-secret` Secret is auto-generated in `authelia` namespace by secret-generator
- [ ] Secret replicates into `tandoor` namespace via kubernetes-replicator
- [ ] Tandoor pods restart (reloader detects env change) and start successfully
- [ ] Navigate to `https://recipes.internal.tomnowak.work/accounts/login/` — SSO login option with Authelia is present
- [ ] Completing Authelia authentication redirects back to Tandoor and logs the user in