### PR TITLE
feat(authelia): add named LLDAP group-based authorization policies

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -156,6 +156,43 @@ configMap:
             - policy: two_factor
               subject:
                 - "group:vaultwarden"
+        jellyfin:
+          default_policy: deny
+          rules:
+            - policy: two_factor
+              subject:
+                - "group:jellyfin_users"
+                - "group:jellyfin_admins"
+        grafana:
+          default_policy: deny
+          rules:
+            - policy: two_factor
+              subject:
+                - "group:grafana"
+        ai:
+          default_policy: deny
+          rules:
+            - policy: two_factor
+              subject:
+                - "group:ai"
+        img:
+          default_policy: deny
+          rules:
+            - policy: two_factor
+              subject:
+                - "group:img"
+        docs:
+          default_policy: deny
+          rules:
+            - policy: two_factor
+              subject:
+                - "group:docs"
+        recipes:
+          default_policy: deny
+          rules:
+            - policy: two_factor
+              subject:
+                - "group:recipes"
       clients:
         - client_id: "immich"
           client_name: Immich
@@ -185,7 +222,7 @@ configMap:
           client_secret:
             path: /secrets/grafana-oidc-client-secret/client-secret
           public: false
-          authorization_policy: two_factor
+          authorization_policy: grafana
           require_pkce: true
           pkce_challenge_method: S256
           redirect_uris:
@@ -206,7 +243,7 @@ configMap:
           client_secret:
             path: /secrets/open-webui-oidc-client-secret/client-secret
           public: false
-          authorization_policy: two_factor
+          authorization_policy: ai
           require_pkce: false
           pkce_challenge_method: S256
           redirect_uris:
@@ -226,7 +263,7 @@ configMap:
           client_secret:
             path: /secrets/zipline-oidc-client-secret/client-secret
           public: false
-          authorization_policy: two_factor
+          authorization_policy: img
           require_pkce: false
           consent_mode: implicit
           redirect_uris:
@@ -247,7 +284,7 @@ configMap:
           client_secret:
             path: /secrets/jellyfin-oidc-client-secret/client-secret
           public: false
-          authorization_policy: two_factor
+          authorization_policy: jellyfin
           require_pkce: true
           pkce_challenge_method: S256
           require_pushed_authorization_requests: false
@@ -269,7 +306,7 @@ configMap:
           client_secret:
             path: /secrets/paperless-oidc-client-secret/client-secret
           public: false
-          authorization_policy: two_factor
+          authorization_policy: docs
           require_pkce: true
           pkce_challenge_method: S256
           redirect_uris:


### PR DESCRIPTION
## Summary

- Add six named `authorization_policies` to the Authelia OIDC config, each with `default_policy: deny` and a `two_factor` rule restricted to the corresponding LLDAP group(s):
  - `jellyfin` — groups `jellyfin_users`, `jellyfin_admins`
  - `grafana` — group `grafana`
  - `ai` — group `ai`
  - `img` — group `img`
  - `docs` — group `docs`
  - `recipes` — group `recipes`
- Update `authorization_policy` on five existing OIDC clients to reference their named policy instead of the catch-all `two_factor`:
  - `jellyfin` → `jellyfin`
  - `grafana` → `grafana`
  - `open-webui` → `ai`
  - `zipline` → `img`
  - `paperless` → `docs`
- The `recipes` policy is defined now so it is ready when PR #924 (feat/tandoor-oidc) merges; the tandoor client's `authorization_policy` field will be set to `recipes` in that PR.

## Test plan

- [ ] Authelia HelmRelease reconciles cleanly after merge (new named policies, updated client references)
- [ ] Users in the correct LLDAP group can authenticate to each app via Authelia OIDC
- [ ] Users NOT in the relevant LLDAP group receive an authorization denial from Authelia (not a login failure)
- [ ] Existing clients with unchanged policy (`immich` → `photos`, `vaultwarden` → `vaultwarden`) continue to work