### PR TITLE
feat(authelia): add Jellyseerr OIDC client registration

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -301,6 +301,25 @@ configMap:
           access_token_signed_response_alg: none
           userinfo_signed_response_alg: none
           token_endpoint_auth_method: client_secret_post
+        - client_id: jellyseerr
+          client_name: Jellyseerr
+          client_secret:
+            path: /secrets/jellyseerr-oidc-client-secret/client-secret
+          public: false
+          authorization_policy: jellyfin
+          require_pkce: true
+          pkce_challenge_method: S256
+          redirect_uris:
+            - https://requests.${external_domain}/api/v1/auth/oidc-callback
+          scopes:
+            - openid
+            - profile
+            - email
+          response_types:
+            - code
+          grant_types:
+            - authorization_code
+          token_endpoint_auth_method: client_secret_post
         - client_id: paperless
           client_name: Paperless
           client_secret:
@@ -388,4 +407,5 @@ secret:
     vaultwarden-oidc-client-secret: { }
     paperless-oidc-client-secret: { }
     tandoor-oidc-client-secret: { }
+    jellyseerr-oidc-client-secret: { }
     authelia-smtp-credentials: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/jellyseerr-oidc-client-secret.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/jellyseerr-oidc-client-secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jellyseerr-oidc-client-secret
+  namespace: authelia
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: client-secret
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "64"
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "media"
+data: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - vaultwarden-oidc-client-secret.yaml
   - paperless-oidc-client-secret.yaml
   - tandoor-oidc-client-secret.yaml
+  - jellyseerr-oidc-client-secret.yaml
   - authelia-secrets.yaml
   - authelia-smtp-credentials.yaml
   - authelia-smtp-egress.yaml

--- a/kubernetes/clusters/live/config/media-prereqs/jellyseerr-oidc-client-secret.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/jellyseerr-oidc-client-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jellyseerr-oidc-client-secret
+  namespace: media
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: authelia/jellyseerr-oidc-client-secret
+data: { }

--- a/kubernetes/clusters/live/config/media-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - jellyfin-exporter-api-token.yaml
   - recyclarr-config.yaml
   - db-credentials.yaml
+  - jellyseerr-oidc-client-secret.yaml


### PR DESCRIPTION
## Summary

- Adds `jellyseerr-oidc-client-secret` Secret in the `authelia` namespace, generated by secret-generator (64-char hex) and replication-allowed to the `media` namespace
- Adds the `jellyseerr-oidc-client-secret` replica Secret in the `media` namespace via kubernetes-replicator, registered in `media-prereqs/kustomization.yaml`
- Registers Jellyseerr as an Authelia OIDC client using the `jellyfin` authorization policy (allows `group:jellyfin_users` and `group:jellyfin_admins`), PKCE S256, redirect URI `https://requests.${external_domain}/api/v1/auth/oidc-callback`
- Mounts the secret into Authelia via `secret.additionalSecrets`

Jellyseerr does not support OIDC configuration via environment variables — UI configuration is required post-deploy and is out of scope for this PR.

## Test plan

- [ ] Flux reconciles `authelia-prereqs` kustomization cleanly on the live cluster
- [ ] `jellyseerr-oidc-client-secret` Secret appears in `authelia` namespace with a populated `client-secret` key
- [ ] `jellyseerr-oidc-client-secret` Secret is replicated into the `media` namespace
- [ ] Authelia pod restarts cleanly and logs show the `jellyseerr` OIDC client loaded without error
- [ ] Flux reconciles `media-prereqs` kustomization cleanly