### PR TITLE
fix(k8s): move homepage annotations to external HTTPRoutes

### DIFF
--- a/kubernetes/clusters/live/config/authelia/external-route.yaml
+++ b/kubernetes/clusters/live/config/authelia/external-route.yaml
@@ -5,6 +5,12 @@ kind: HTTPRoute
 metadata:
   name: authelia-external
   namespace: authelia
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Authelia"
+    gethomepage.dev/group: "Apps"
+    gethomepage.dev/icon: "authelia.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=authelia"
 spec:
   parentRefs:
     - name: external

--- a/kubernetes/clusters/live/config/authelia/internal-route.yaml
+++ b/kubernetes/clusters/live/config/authelia/internal-route.yaml
@@ -5,12 +5,6 @@ kind: HTTPRoute
 metadata:
   name: authelia-internal
   namespace: authelia
-  annotations:
-    gethomepage.dev/enabled: "true"
-    gethomepage.dev/name: "Authelia"
-    gethomepage.dev/group: "Apps"
-    gethomepage.dev/icon: "authelia.svg"
-    gethomepage.dev/pod-selector: "app.kubernetes.io/name=authelia"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/firefly/external-route.yaml
+++ b/kubernetes/clusters/live/config/firefly/external-route.yaml
@@ -5,6 +5,15 @@ kind: HTTPRoute
 metadata:
   name: firefly-external
   namespace: firefly
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Firefly III"
+    gethomepage.dev/group: "Apps"
+    gethomepage.dev/icon: "firefly-iii.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=firefly"
+    gethomepage.dev/widget.type: "firefly"
+    gethomepage.dev/widget.url: "http://firefly.firefly.svc:8080"
+    gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_FIREFLY_API_KEY}}"
 spec:
   parentRefs:
     - name: external

--- a/kubernetes/clusters/live/config/firefly/internal-route.yaml
+++ b/kubernetes/clusters/live/config/firefly/internal-route.yaml
@@ -5,15 +5,6 @@ kind: HTTPRoute
 metadata:
   name: firefly-internal
   namespace: firefly
-  annotations:
-    gethomepage.dev/enabled: "true"
-    gethomepage.dev/name: "Firefly III"
-    gethomepage.dev/group: "Apps"
-    gethomepage.dev/icon: "firefly-iii.svg"
-    gethomepage.dev/pod-selector: "app.kubernetes.io/name=firefly"
-    gethomepage.dev/widget.type: "firefly"
-    gethomepage.dev/widget.url: "http://firefly.firefly.svc:8080"
-    gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_FIREFLY_API_KEY}}"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/tandoor/external-route.yaml
+++ b/kubernetes/clusters/live/config/tandoor/external-route.yaml
@@ -5,6 +5,12 @@ kind: HTTPRoute
 metadata:
   name: tandoor-external
   namespace: tandoor
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Tandoor"
+    gethomepage.dev/group: "Apps"
+    gethomepage.dev/icon: "tandoor.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=tandoor"
 spec:
   parentRefs:
     - name: external

--- a/kubernetes/clusters/live/config/tandoor/internal-route.yaml
+++ b/kubernetes/clusters/live/config/tandoor/internal-route.yaml
@@ -5,12 +5,6 @@ kind: HTTPRoute
 metadata:
   name: tandoor-internal
   namespace: tandoor
-  annotations:
-    gethomepage.dev/enabled: "true"
-    gethomepage.dev/name: "Tandoor"
-    gethomepage.dev/group: "Apps"
-    gethomepage.dev/icon: "tandoor.svg"
-    gethomepage.dev/pod-selector: "app.kubernetes.io/name=tandoor"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/clusters/live/config/vaultwarden/external-route.yaml
+++ b/kubernetes/clusters/live/config/vaultwarden/external-route.yaml
@@ -5,6 +5,12 @@ kind: HTTPRoute
 metadata:
   name: vaultwarden-external
   namespace: vaultwarden
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Vaultwarden"
+    gethomepage.dev/group: "Apps"
+    gethomepage.dev/icon: "vaultwarden.svg"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=vaultwarden"
 spec:
   parentRefs:
     - name: external

--- a/kubernetes/clusters/live/config/vaultwarden/internal-route.yaml
+++ b/kubernetes/clusters/live/config/vaultwarden/internal-route.yaml
@@ -5,12 +5,6 @@ kind: HTTPRoute
 metadata:
   name: vaultwarden-internal
   namespace: vaultwarden
-  annotations:
-    gethomepage.dev/enabled: "true"
-    gethomepage.dev/name: "Vaultwarden"
-    gethomepage.dev/group: "Apps"
-    gethomepage.dev/icon: "vaultwarden.svg"
-    gethomepage.dev/pod-selector: "app.kubernetes.io/name=vaultwarden"
 spec:
   parentRefs:
     - name: internal


### PR DESCRIPTION
## Summary

- Homepage derives the click-through URL from the hostname of the HTTPRoute that carries its annotations
- Four apps (Firefly, Tandoor, Vaultwarden, Authelia) had annotations on their internal routes, causing dashboard links to point at the internal domain instead of the public external domain
- Moves all `gethomepage.dev/*` annotations from `internal-route.yaml` to `external-route.yaml` for each app; `widget.url` continues pointing at internal cluster DNS

## Test plan

- [ ] Verify Homepage dashboard shows correct external URLs for Firefly, Tandoor, Vaultwarden, and Authelia after Flux reconciles
- [ ] Confirm widget data (Firefly balance widget) still loads — `widget.url` still targets `http://firefly.firefly.svc:8080`
- [ ] Confirm internal routes continue to function (no annotations removed from routing logic, only metadata changed)