### PR TITLE
fix(authelia): use client_secret_basic for django-allauth OIDC clients

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -319,7 +319,7 @@ configMap:
             - code
           grant_types:
             - authorization_code
-          token_endpoint_auth_method: client_secret_post
+          token_endpoint_auth_method: client_secret_basic
         - client_id: tandoor
           client_name: Tandoor
           client_secret:
@@ -339,7 +339,7 @@ configMap:
             - code
           grant_types:
             - authorization_code
-          token_endpoint_auth_method: client_secret_post
+          token_endpoint_auth_method: client_secret_basic
         - client_id: vaultwarden
           client_name: Vaultwarden
           client_secret:


### PR DESCRIPTION
## Summary

- Paperless and Tandoor both use django-allauth which defaults to `client_secret_basic` for token endpoint authentication
- Authelia clients were configured with `client_secret_post`, causing token exchange to fail with `invalid_client`
- Switches both clients to `client_secret_basic` to match django-allauth behavior

## Root cause

```
Error retrieving access token: client_secret_basic method used but client_secret_post registered
```

## Test plan
- [ ] Paperless OIDC login completes successfully
- [ ] Tandoor OIDC login completes successfully