### PR TITLE
fix(authelia): correct Tandoor OIDC redirect URIs

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -348,8 +348,8 @@ configMap:
           require_pkce: true
           pkce_challenge_method: S256
           redirect_uris:
-            - https://recipes.${internal_domain}/accounts/oidc/login/callback/
-            - https://recipes.${external_domain}/accounts/oidc/login/callback/
+            - https://recipes.${internal_domain}/accounts/oidc/authelia/login/callback/
+            - https://recipes.${external_domain}/accounts/oidc/authelia/login/callback/
           scopes:
             - openid
             - profile


### PR DESCRIPTION
## Summary

- Tandoor uses django-allauth which includes the `provider_id` in the callback URL
- Registered URIs were missing the `/authelia/` slug: `/accounts/oidc/login/callback/`
- Correct URIs: `/accounts/oidc/authelia/login/callback/`

## Root cause

```
redirect_uri 'https://recipes.ionfury.tv/accounts/oidc/authelia/login/callback/'
does not match any pre-registered redirect_uris
```

## Test plan
- [ ] Tandoor OIDC login completes successfully