### PR TITLE
fix(authelia): remove pkce_challenge_method from open-webui OIDC client

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -245,7 +245,6 @@ configMap:
           public: false
           authorization_policy: ai
           require_pkce: false
-          pkce_challenge_method: S256
           redirect_uris:
             - https://ai.${internal_domain}/oauth/oidc/callback
           scopes:


### PR DESCRIPTION
## Summary

- Open WebUI OIDC login failing with `code_challenge is missing` error
- Root cause: `pkce_challenge_method: S256` was set alongside `require_pkce: false`, but Authelia enforces PKCE when the method is specified regardless of the `require_pkce` flag
- Open WebUI (authlib) does not send a `code_challenge` in its authorization request
- Fix: remove `pkce_challenge_method` — PKCE stays optional as intended by `require_pkce: false`

## Test plan
- [ ] Open WebUI OIDC login completes successfully