### PR TITLE
fix(authelia): use client_secret_post for Tandoor OIDC token endpoint

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -357,7 +357,7 @@ configMap:
             - code
           grant_types:
             - authorization_code
-          token_endpoint_auth_method: client_secret_basic
+          token_endpoint_auth_method: client_secret_post
         - client_id: vaultwarden
           client_name: Vaultwarden
           client_secret:


### PR DESCRIPTION
## Summary

- Tandoor OIDC token exchange failing: Authelia configured for `client_secret_basic` but Tandoor sends `client_secret_post`
- Root cause: Tandoor has `OAUTH_PKCE_ENABLED: true` in its `SOCIALACCOUNT_PROVIDERS` config, which causes django-allauth to use `client_secret_post` at the token endpoint (unlike Paperless which has PKCE disabled and uses `client_secret_basic`)
- Reverts Tandoor back to `client_secret_post` (only Paperless should be `client_secret_basic`)

## Test plan
- [ ] Tandoor OIDC login completes successfully