### PR TITLE
fix(open-webui): merge OIDC logins with existing local accounts by email

### DIFF
--- a/kubernetes/clusters/live/charts/open-webui.yaml
+++ b/kubernetes/clusters/live/charts/open-webui.yaml
@@ -52,6 +52,8 @@ extraEnvVars:
     value: "user"
   - name: ENABLE_OPENAI_API
     value: "false"
+  - name: OAUTH_MERGE_ACCOUNTS_BY_EMAIL
+    value: "true"
 
 sso:
   enabled: true


### PR DESCRIPTION
## Summary

- Enables `OAUTH_MERGE_ACCOUNTS_BY_EMAIL=true` so OIDC logins automatically link to existing local accounts with matching email
- Without this, users with pre-existing local accounts cannot sign in via OIDC

## Test plan
- [ ] OIDC login links to existing local account (no duplicate account created)