### PR TITLE
feat(monitoring): alert when external gateway rate limits requests

### DIFF
--- a/kubernetes/platform/config/monitoring/istio-alerts.yaml
+++ b/kubernetes/platform/config/monitoring/istio-alerts.yaml
@@ -232,3 +232,17 @@ spec:
               requests/s. Workloads have stale or expired service account tokens.
               Restart gateway pods and any long-running workloads in the mesh
               to clear in-memory token caches.
+
+    - name: istio-gateway
+      rules:
+        - alert: ExternalGatewayRateLimiting
+          expr: increase(envoy_http_external_gateway_per_ip_local_rate_limit_rate_limited[5m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "External gateway is rate limiting requests"
+            description: >-
+              The external gateway local rate limiter has throttled {{ $value | humanize }}
+              requests in the last 5 minutes. A source IP has exceeded 1000 req/min.
+              Check Loki for source IP: {namespace="istio-gateway"} | json | status="429"


### PR DESCRIPTION
## Summary

- Adds `ExternalGatewayRateLimiting` alert to `istio-alerts` PrometheusRule
- Fires at `warning` severity after 5 minutes of sustained rate limiting on the external gateway
- Triggered by `envoy_http_external_gateway_per_ip_local_rate_limit_rate_limited` counter (1000 req/min per source IP limit set in #938)
- Alert description includes a Loki LogQL snippet to identify the throttled source IP

## Notes

The metric only appears in Prometheus after the first rate-limited request occurs (Envoy does not emit zero-value counters). The alert will remain in pending state until triggered in practice.

## Test plan

- [ ] `yamllint --strict kubernetes/` passes
- [ ] `task k8s:validate` passes
- [ ] Alert appears in Prometheus rules after merge and Flux reconciliation