### PR TITLE
feat(media): delegate auth to oauth2-proxy for all *arr instances

### DIFF
--- a/kubernetes/clusters/live/charts/radarr.yaml
+++ b/kubernetes/clusters/live/charts/radarr.yaml
@@ -34,6 +34,7 @@ controllers:
                 key: password
           RADARR__POSTGRES__MAINDB: radarr-main
           RADARR__POSTGRES__LOGDB: radarr-log
+          RADARR__AUTH__METHOD: External
           RADARR__AUTH__APIKEY:
             valueFrom:
               secretKeyRef:

--- a/kubernetes/clusters/live/charts/radarr4k.yaml
+++ b/kubernetes/clusters/live/charts/radarr4k.yaml
@@ -34,6 +34,7 @@ controllers:
                 key: password
           RADARR__POSTGRES__MAINDB: radarr4k-main
           RADARR__POSTGRES__LOGDB: radarr4k-log
+          RADARR__AUTH__METHOD: External
           RADARR__AUTH__APIKEY:
             valueFrom:
               secretKeyRef:

--- a/kubernetes/clusters/live/charts/sonarr.yaml
+++ b/kubernetes/clusters/live/charts/sonarr.yaml
@@ -34,6 +34,7 @@ controllers:
                 key: password
           SONARR__POSTGRES__MAINDB: sonarr-main
           SONARR__POSTGRES__LOGDB: sonarr-log
+          SONARR__AUTH__METHOD: External
           SONARR__AUTH__APIKEY:
             valueFrom:
               secretKeyRef:

--- a/kubernetes/clusters/live/charts/sonarr4k.yaml
+++ b/kubernetes/clusters/live/charts/sonarr4k.yaml
@@ -34,6 +34,7 @@ controllers:
                 key: password
           SONARR__POSTGRES__MAINDB: sonarr4k-main
           SONARR__POSTGRES__LOGDB: sonarr4k-log
+          SONARR__AUTH__METHOD: External
           SONARR__AUTH__APIKEY:
             valueFrom:
               secretKeyRef:

--- a/kubernetes/clusters/live/config/media/media-auth-policy.yaml
+++ b/kubernetes/clusters/live/config/media/media-auth-policy.yaml
@@ -22,5 +22,7 @@ spec:
               - "bazarr.${internal_domain}"
               - "prowlarr.${internal_domain}"
               - "radarr.${internal_domain}"
+              - "radarr4k.${internal_domain}"
               - "sonarr.${internal_domain}"
+              - "sonarr4k.${internal_domain}"
               - "qbittorrent.${internal_domain}"


### PR DESCRIPTION
## Summary

- Add `AUTH__METHOD: External` env var to sonarr, radarr, sonarr4k, radarr4k — tells each app to skip its own login and trust the upstream proxy
- Add `radarr4k` and `sonarr4k` hosts to the Istio `AuthorizationPolicy` so oauth2-proxy guards the new 4K instances (they were missing, leaving them unprotected)
- Backfill `AUTH__METHOD: External` on the existing sonarr/radarr instances for declarative correctness (previously the setting only existed in Postgres — a fresh DB restore would have re-enabled auth)

## Test plan

- [ ] Verify `radarr4k` and `sonarr4k` redirect to oauth2-proxy login when unauthenticated
- [ ] Verify all four *arr UIs load without showing their own login form after oauth2 auth
- [ ] Verify existing `radarr` and `sonarr` still function normally after pod restart