### PR TITLE
fix(media): fix recyclarr instance names and service URLs

### DIFF
--- a/kubernetes/clusters/live/config/media-prereqs/recyclarr-config.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/recyclarr-config.yaml
@@ -12,8 +12,8 @@ metadata:
 data:
   recyclarr.yml: |
     sonarr:
-      main:
-        base_url: http://sonarr-app.media.svc:8989
+      sonarr:
+        base_url: http://sonarr.media.svc:8989
         api_key: !env_var SONARR_API_KEY
 
         quality_definition:
@@ -78,8 +78,8 @@ data:
             assign_scores_to:
               - name: WEB-1080p
 
-      main-anime:
-        base_url: http://sonarr-app.media.svc:8989
+      sonarr-anime:
+        base_url: http://sonarr.media.svc:8989
         api_key: !env_var SONARR_API_KEY
 
         quality_definition:
@@ -121,7 +121,7 @@ data:
               - name: Anime
 
       sonarr4k:
-        base_url: http://sonarr4k-app.media.svc:8989
+        base_url: http://sonarr4k.media.svc:8989
         api_key: !env_var SONARR4K_API_KEY
 
         quality_definition:
@@ -183,8 +183,8 @@ data:
               - name: WEB-2160p
 
     radarr:
-      main:
-        base_url: http://radarr-app.media.svc:7878
+      radarr:
+        base_url: http://radarr.media.svc:7878
         api_key: !env_var RADARR_API_KEY
 
         quality_definition:
@@ -254,8 +254,8 @@ data:
             assign_scores_to:
               - name: WEB-1080p
 
-      main-anime:
-        base_url: http://radarr-app.media.svc:7878
+      radarr-anime:
+        base_url: http://radarr.media.svc:7878
         api_key: !env_var RADARR_API_KEY
 
         quality_definition:
@@ -296,7 +296,7 @@ data:
               - name: Anime
 
       radarr4k:
-        base_url: http://radarr4k-app.media.svc:7878
+        base_url: http://radarr4k.media.svc:7878
         api_key: !env_var RADARR4K_API_KEY
 
         quality_definition:


### PR DESCRIPTION
## Summary

- Recyclarr CronJob was failing with `BackoffLimitExceeded` (7 retries) due to two bugs introduced alongside the sonarr4k/radarr4k/anime instance additions
- Fixed duplicate instance names: recyclarr v7+ requires globally unique names across all service types; `main` and `main-anime` were each used in both `sonarr:` and `radarr:` sections
- Fixed all six `base_url` values: `-app` suffix (e.g. `sonarr-app`) does not match actual Kubernetes service names (`sonarr`, `radarr`, `sonarr4k`, `radarr4k`)

## Changes

| Instance | Before | After |
|---|---|---|
| `sonarr.main` | `main` / `sonarr-app.media.svc` | `sonarr` / `sonarr.media.svc` |
| `sonarr.main-anime` | `main-anime` / `sonarr-app.media.svc` | `sonarr-anime` / `sonarr.media.svc` |
| `sonarr.sonarr4k` | `sonarr4k-app.media.svc` | `sonarr4k.media.svc` |
| `radarr.main` | `main` / `radarr-app.media.svc` | `radarr` / `radarr.media.svc` |
| `radarr.main-anime` | `main-anime` / `radarr-app.media.svc` | `radarr-anime` / `radarr.media.svc` |
| `radarr.radarr4k` | `radarr4k-app.media.svc` | `radarr4k.media.svc` |

## Test plan

- [ ] Recyclarr CronJob completes without error after merge and promotion to live
- [ ] All 6 instances (sonarr, sonarr-anime, sonarr4k, radarr, radarr-anime, radarr4k) report successful sync in recyclarr logs