### PR TITLE
feat(monitoring): alert on SSD endurance depletion

### DIFF
--- a/kubernetes/platform/config/longhorn/prometheus-rules.yaml
+++ b/kubernetes/platform/config/longhorn/prometheus-rules.yaml
@@ -111,6 +111,26 @@ spec:
             summary: "Longhorn replica rebuild stalled on {{ $labels.volume }}"
             description: "Volume {{ $labels.volume }} has been rebuilding for over 30 minutes at {{ $value }}%. This may indicate disk I/O issues or network problems."
 
+        # SSD Endurance - Warning
+        - alert: LonghornDiskEnduranceWarning
+          expr: longhorn_disk_health_attribute_raw{attribute_id=~"202|231"} < 30
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Longhorn disk {{ $labels.disk }} on {{ $labels.node }} endurance < 30%"
+            description: "Disk {{ $labels.disk }} on node {{ $labels.node }} has {{ $value }}% SSD lifetime remaining. Plan disk replacement."
+
+        # SSD Endurance - Critical
+        - alert: LonghornDiskEnduranceCritical
+          expr: longhorn_disk_health_attribute_raw{attribute_id=~"202|231"} < 10
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Longhorn disk {{ $labels.disk }} on {{ $labels.node }} endurance < 10%"
+            description: "Disk {{ $labels.disk }} on node {{ $labels.node }} has {{ $value }}% SSD lifetime remaining. Immediate replacement required to prevent data loss."
+
     # Recording rules that aggregate disk metrics by storage pool (fast/slow)
     # based on disk name patterns from inventory (ssd = fast, hdd = slow).
     - name: longhorn-pool-recording-rules


### PR DESCRIPTION
## Summary

- Add `LonghornDiskEnduranceWarning` — fires when SSD lifetime remaining drops below 30%
- Add `LonghornDiskEnduranceCritical` — fires when SSD lifetime remaining drops below 10%
- Covers attribute 202 (Crucial MX500 `Percent_Lifetime_Remain`) and attribute 231 (Kingston SEDC600 `SSD_Life_Left`)

## Motivation

Investigation of `NodeDiskIOSaturation` alerts revealed node43's Crucial CT1000MX500SSD1 is at **18% endurance remaining**. No alert existed for this condition. `longhorn_disk_health` (SMART pass/fail) would never catch gradual P/E cycle depletion — a drive can report PASSED at 1% endurance remaining.

The new warning alert will immediately fire for node43's Crucial (18% < 30%). node41/42 Kingston SSDs are at 99% and unaffected.

## Test plan

- [ ] Confirm `LonghornDiskEnduranceWarning` fires for node43 `crucial-ssd-1tb-0` after deploy
- [ ] Confirm node41/42 Kingston disks do not fire (99% remaining)
- [ ] Verify alert routes correctly through Alertmanager