### PR TITLE
fix(media): add quality definitions for sonarr4k and radarr4k recyclarr profiles

### DIFF
--- a/kubernetes/clusters/live/config/media-prereqs/recyclarr-config.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/recyclarr-config.yaml
@@ -131,6 +131,14 @@ data:
           - name: WEB-2160p
             reset_unmatched_scores:
               enabled: true
+            qualities:
+              - name: Bluray-2160p Remux
+              - name: WEB 2160p
+                qualities:
+                  - WEBDL-2160p
+                  - WEBRip-2160p
+              - name: Bluray-2160p
+              - name: HDTV-2160p
 
         custom_formats:
           # HDR formats — positively scored for 4K
@@ -306,6 +314,14 @@ data:
           - name: WEB-2160p
             reset_unmatched_scores:
               enabled: true
+            qualities:
+              - name: Remux-2160p
+              - name: WEB 2160p
+                qualities:
+                  - WEBDL-2160p
+                  - WEBRip-2160p
+              - name: Bluray-2160p
+              - name: HDTV-2160p
 
         custom_formats:
           # Unwanted for 4K


### PR DESCRIPTION
## Summary

- `sonarr4k` and `radarr4k` are fresh instances with no pre-existing quality profiles
- Recyclarr v7+ requires a `qualities` list when creating a profile for the first time; subsequent runs on existing profiles do not need it
- Both instances were failing with: `Profile 'WEB-2160p': qualities is required when creating profiles for the first time`

## Changes

Added `qualities` to the `WEB-2160p` profile for both 4K instances. Quality names sourced directly from each instance's `/api/v3/qualitydefinition` API.

| Instance | Qualities added |
|---|---|
| `sonarr4k` | `Bluray-2160p Remux` > `WEB 2160p` (WEBDL-2160p + WEBRip-2160p) > `Bluray-2160p` > `HDTV-2160p` |
| `radarr4k` | `Remux-2160p` > `WEB 2160p` (WEBDL-2160p + WEBRip-2160p) > `Bluray-2160p` > `HDTV-2160p` |

Note: Sonarr names its 4K remux tier `Bluray-2160p Remux`; Radarr names it `Remux-2160p`.

## Test plan

- [ ] Recyclarr CronJob next run shows `✓` for both `sonarr4k` and `radarr4k`
- [ ] `WEB-2160p` quality profile exists in sonarr4k and radarr4k UIs after sync