### PR TITLE
fix(monitoring): reduce prometheus to single instance

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -41,7 +41,7 @@ prometheus:
     enabled: false
   prometheusSpec:
     priorityClassName: platform
-    replicas: 2
+    replicas: 1
     podMetadata:
       labels:
         networking/allow-ingress-internal: "true"


### PR DESCRIPTION
## Summary

- Reduce `prometheusSpec.replicas` from 2 to 1

## Motivation

Two Prometheus instances each with 3-replica Longhorn PVCs creates 6x TSDB read amplification across storage nodes. This was identified as a primary driver of `NodeDiskIOSaturation` alerts on node41/42/43.

Single instance retains full observability — Longhorn's 3-replica storage ensures the pod remains portable across node drains and unplanned failures. The second Prometheus instance provided no additional reliability that isn't already covered by Longhorn replication.

**Related:** node43's Crucial SSD (18% endurance remaining, 35 Longhorn replicas) is scheduled for physical replacement. Reducing Prometheus IO pressure first reduces risk during that maintenance window.

## Test plan

- [ ] Confirm `prometheus-kube-prometheus-stack-0` terminates, `prometheus-kube-prometheus-stack-1` removed
- [ ] Confirm remaining Prometheus instance is healthy and scraping all targets
- [ ] Verify `NodeDiskIOSaturation` alerts clear or reduce after TSDB IO stabilizes
- [ ] Confirm Grafana dashboards remain functional