### PR TITLE
fix(media): run recyclarr state repair --adopt before each sync

### DIFF
--- a/kubernetes/clusters/live/charts/recyclarr.yaml
+++ b/kubernetes/clusters/live/charts/recyclarr.yaml
@@ -21,6 +21,45 @@ controllers:
         seccompProfile:
           type: RuntimeDefault
 
+    initContainers:
+      adopt:
+        image:
+          repository: ghcr.io/recyclarr/recyclarr
+          tag: "${recyclarr_version}"
+        args: ["state", "repair", "--adopt"]
+        env:
+          SONARR_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: sonarr-api-key
+                key: api-key
+          RADARR_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: radarr-api-key
+                key: api-key
+          SONARR4K_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: sonarr4k-api-key
+                key: api-key
+          RADARR4K_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: radarr4k-api-key
+                key: api-key
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+
     containers:
       app:
         image:
@@ -65,6 +104,8 @@ persistence:
     type: emptyDir
     advancedMounts:
       recyclarr:
+        adopt:
+          - path: /config
         app:
           - path: /config
   config:
@@ -72,6 +113,10 @@ persistence:
     name: recyclarr-config
     advancedMounts:
       recyclarr:
+        adopt:
+          - path: /config/recyclarr.yml
+            subPath: recyclarr.yml
+            readOnly: true
         app:
           - path: /config/recyclarr.yml
             subPath: recyclarr.yml


### PR DESCRIPTION
## Summary

- Recyclarr's state DB (SQLite, tracks CF ownership) lives on an `emptyDir` volume and is destroyed after every CronJob pod exit
- On the next run, recyclarr sees CFs in Sonarr/Radarr that it has no record of creating and refuses to update them: `N Custom Formats cannot be synced because CFs with matching names already exist. To adopt existing CFs, run: recyclarr state repair --adopt`
- Since state never persists across runs, `--adopt` must precede every `sync`

## Changes

Added an `initContainer` (`adopt`) that runs `recyclarr state repair --adopt` on the shared `/config` emptyDir before the main `app` container runs `recyclarr sync`. Both containers share the same image, env vars, security context, and volume mounts.

The `readOnlyRootFilesystem: true` constraint rules out a shell one-liner (`sh -c "repair && sync"`); the initContainer pattern is the correct approach.

## Test plan

- [ ] Next recyclarr CronJob run shows `✓` for all instances (sonarr, sonarr-anime, sonarr4k, radarr, radarr-anime, radarr4k) with no "CFs with matching names" errors
- [ ] initContainer `adopt` exits 0 before `app` starts