### PR TITLE
fix(media): persist recyclarr state via PVC instead of emptyDir

### DIFF
--- a/kubernetes/clusters/live/charts/recyclarr.yaml
+++ b/kubernetes/clusters/live/charts/recyclarr.yaml
@@ -21,45 +21,6 @@ controllers:
         seccompProfile:
           type: RuntimeDefault
 
-    initContainers:
-      adopt:
-        image:
-          repository: ghcr.io/recyclarr/recyclarr
-          tag: "${recyclarr_version}"
-        args: ["state", "repair", "--adopt"]
-        env:
-          SONARR_API_KEY:
-            valueFrom:
-              secretKeyRef:
-                name: sonarr-api-key
-                key: api-key
-          RADARR_API_KEY:
-            valueFrom:
-              secretKeyRef:
-                name: radarr-api-key
-                key: api-key
-          SONARR4K_API_KEY:
-            valueFrom:
-              secretKeyRef:
-                name: sonarr4k-api-key
-                key: api-key
-          RADARR4K_API_KEY:
-            valueFrom:
-              secretKeyRef:
-                name: radarr4k-api-key
-                key: api-key
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: [ALL]
-        resources:
-          requests:
-            cpu: 10m
-            memory: 64Mi
-          limits:
-            memory: 128Mi
-
     containers:
       app:
         image:
@@ -101,11 +62,12 @@ controllers:
 
 persistence:
   config-dir:
-    type: emptyDir
+    type: persistentVolumeClaim
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    storageClass: fast
     advancedMounts:
       recyclarr:
-        adopt:
-          - path: /config
         app:
           - path: /config
   config:
@@ -113,10 +75,6 @@ persistence:
     name: recyclarr-config
     advancedMounts:
       recyclarr:
-        adopt:
-          - path: /config/recyclarr.yml
-            subPath: recyclarr.yml
-            readOnly: true
         app:
           - path: /config/recyclarr.yml
             subPath: recyclarr.yml

--- a/kubernetes/clusters/live/charts/recyclarr.yaml
+++ b/kubernetes/clusters/live/charts/recyclarr.yaml
@@ -21,6 +21,45 @@ controllers:
         seccompProfile:
           type: RuntimeDefault
 
+    initContainers:
+      adopt:
+        image:
+          repository: ghcr.io/recyclarr/recyclarr
+          tag: "${recyclarr_version}"
+        args: ["state", "repair", "--adopt"]
+        env:
+          SONARR_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: sonarr-api-key
+                key: api-key
+          RADARR_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: radarr-api-key
+                key: api-key
+          SONARR4K_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: sonarr4k-api-key
+                key: api-key
+          RADARR4K_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: radarr4k-api-key
+                key: api-key
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+
     containers:
       app:
         image:
@@ -65,6 +104,8 @@ persistence:
     type: emptyDir
     advancedMounts:
       recyclarr:
+        adopt:
+          - path: /config
         app:
           - path: /config
   config:
@@ -72,6 +113,10 @@ persistence:
     name: recyclarr-config
     advancedMounts:
       recyclarr:
+        adopt:
+          - path: /config/recyclarr.yml
+            subPath: recyclarr.yml
+            readOnly: true
         app:
           - path: /config/recyclarr.yml
             subPath: recyclarr.yml


### PR DESCRIPTION
## Summary

- Recyclarr's state DB (SQLite, tracks CF ownership) was on an `emptyDir` — destroyed after every CronJob pod exit
- Each new run saw existing CFs in Sonarr/Radarr with no ownership record: `N Custom Formats cannot be synced because CFs with matching names already exist`
- This is a fundamental design issue: state must outlive the pod

## Change

Switch `config-dir` from `emptyDir` → `persistentVolumeClaim` (1Gi, `fast` StorageClass), matching the pattern used by bjw-s/home-ops and other media apps in this cluster (`bazarr`, `sonarr`, `radarr`, etc.).

## One-time manual step after merge

Because a prior manual recyclarr run already created CFs in `sonarr4k` and `radarr4k` outside of recyclarr's (now-lost) state DB, the new PVC will start with an empty state and hit the same "matching names" error on first sync.

**Before the first post-merge sync:** go into sonarr4k and radarr4k UIs → Settings → Custom Formats → delete all custom formats. Recyclarr will recreate and own them on the next run. Subsequent runs require no manual action.

## Test plan

- [ ] Recyclarr CronJob next run: all 6 instances show `✓` with no CF sync errors
- [ ] `recyclarr-config-dir` PVC provisioned and bound in `media` namespace
- [ ] Subsequent daily runs continue to succeed without intervention