### PR TITLE
fix(infra): scope velero S3 lifecycle rules to backups/ and restores/ prefixes

### DIFF
--- a/infrastructure/modules/velero-storage/main.tf
+++ b/infrastructure/modules/velero-storage/main.tf
@@ -48,16 +48,40 @@ resource "aws_s3_bucket_public_access_block" "velero_backup" {
   restrict_public_buckets = true
 }
 
-# Lifecycle rule - expire backups after 35 days (safety net beyond Velero's 28-day TTL)
-# Unlike Longhorn, Velero backups are self-contained tarballs. Deleting old
-# objects does not corrupt newer backups, making age-based expiration safe.
+# Lifecycle rules - expire Velero metadata after 35 days (safety net beyond Velero's 28-day TTL)
+#
+# Rules are scoped to Velero-managed prefixes (backups/, restores/) only.
+# The kopia/ prefix is intentionally excluded: Kopia uses a shared repository model
+# where pack/index files are referenced across multiple backups. An unscoped rule
+# would expire kopia repository metadata, corrupting all repositories in the bucket.
 resource "aws_s3_bucket_lifecycle_configuration" "velero_backup" {
   for_each = var.clusters
   bucket   = aws_s3_bucket.velero_backup[each.key].id
 
   rule {
-    id     = "expire-old-backups"
+    id     = "expire-old-backup-metadata"
     status = "Enabled"
+
+    filter {
+      prefix = "backups/"
+    }
+
+    expiration {
+      days = 35
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+  }
+
+  rule {
+    id     = "expire-old-restore-metadata"
+    status = "Enabled"
+
+    filter {
+      prefix = "restores/"
+    }
 
     expiration {
       days = 35

--- a/infrastructure/modules/velero-storage/tests/plan.tftest.hcl
+++ b/infrastructure/modules/velero-storage/tests/plan.tftest.hcl
@@ -43,6 +43,28 @@ run "creates_iam_users" {
   }
 }
 
+run "lifecycle_rules_scoped_to_velero_prefixes" {
+  command = plan
+  providers = {
+    aws = aws.mock
+  }
+
+  variables {
+    clusters = ["dev"]
+    region   = "us-east-2"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_lifecycle_configuration.velero_backup["dev"].rule[0].filter[0].prefix == "backups/"
+    error_message = "Backup metadata lifecycle rule must be scoped to backups/ prefix only"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_lifecycle_configuration.velero_backup["dev"].rule[1].filter[0].prefix == "restores/"
+    error_message = "Restore metadata lifecycle rule must be scoped to restores/ prefix only"
+  }
+}
+
 run "stores_credentials_in_ssm" {
   command = plan
   providers = {


### PR DESCRIPTION
## Summary

- S3 lifecycle rule on Velero backup buckets had an empty `filter {}`, applying 35-day expiration to **all** objects including `kopia/` repository metadata
- Kopia uses a shared repository model — pack/index files are referenced across multiple backups; expiring them corrupts all repositories silently
- Scopes expiration to `backups/` and `restores/` prefixes only, leaving `kopia/` untouched
- Adds test asserting prefix scoping is enforced

## Root Cause

`VeleroBackupStale` alert fired on live cluster because `kopia/database/` repository metadata was deleted by the unscoped lifecycle rule, causing all `database` namespace DataUploads to fail with `repository not initialized in the provided storage`.

## Test plan

- [ ] `task tg:test-velero-storage` passes (new assertion validates prefix scoping)
- [ ] `task tg:validate-global` passes
- [ ] After `terragrunt apply` on global stack, verify S3 lifecycle rules are updated via AWS console or CLI
- [ ] Delete `database-aws-kopia` BackupRepository CR on live to trigger re-initialization
- [ ] Verify next weekly backup completes fully for `database` namespace