### PR TITLE
fix(media): add fsGroup to recyclarr pod security context for PVC access

### DIFF
--- a/kubernetes/clusters/live/charts/recyclarr.yaml
+++ b/kubernetes/clusters/live/charts/recyclarr.yaml
@@ -18,6 +18,7 @@ controllers:
         runAsNonRoot: true
         runAsUser: 568
         runAsGroup: 568
+        fsGroup: 568
         seccompProfile:
           type: RuntimeDefault
 


### PR DESCRIPTION
## Summary

After switching recyclarr's `config-dir` from `emptyDir` to a PVC (#952), the pod fails immediately with:

```
Access to the path '/config/state' is denied. [ Permission denied ]
```

The PVC is provisioned with root ownership. The container runs as UID/GID 568 but without `fsGroup` set, Kubernetes does not chown the volume on mount.

## Change

Add `fsGroup: 568` to the pod security context. Kubernetes will recursively chown the PVC to GID 568 when the pod starts, giving the container write access.

## Test plan

- [ ] Recyclarr job starts without permission errors
- [ ] All 6 instances sync successfully