### PR TITLE
fix(media): add upgrade cutoff to sonarr4k and radarr4k quality profiles

### DIFF
--- a/kubernetes/clusters/live/config/media-prereqs/recyclarr-config.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/recyclarr-config.yaml
@@ -131,6 +131,10 @@ data:
           - name: WEB-2160p
             reset_unmatched_scores:
               enabled: true
+            upgrade:
+              allowed: true
+              until_quality: Bluray-2160p Remux
+              until_score: 10000
             qualities:
               - name: Bluray-2160p Remux
               - name: WEB 2160p
@@ -314,6 +318,10 @@ data:
           - name: WEB-2160p
             reset_unmatched_scores:
               enabled: true
+            upgrade:
+              allowed: true
+              until_quality: Remux-2160p
+              until_score: 10000
             qualities:
               - name: Remux-2160p
               - name: WEB 2160p


### PR DESCRIPTION
## Summary

Recyclarr fails with `HTTP 400: Cutoff must be an allowed quality or group` when creating the `WEB-2160p` profile on fresh sonarr4k/radarr4k instances.

Without `upgrade.until_quality`, recyclarr attempts to use a default cutoff that is not in the defined `qualities` list. The Sonarr/Radarr API rejects any cutoff not explicitly listed as an allowed quality.

## Change

Add `upgrade` block to both `sonarr4k` and `radarr4k` WEB-2160p profiles:
- `sonarr4k`: `until_quality: Bluray-2160p Remux`
- `radarr4k`: `until_quality: Remux-2160p`

## Test plan

- [ ] Recyclarr sync shows `✓` for Quality Profiles on sonarr4k and radarr4k
- [ ] No HTTP 400 errors in logs