### PR TITLE
fix(media): update stale TRaSH guide trash_ids for sonarr4k and radarr4k

### DIFF
--- a/kubernetes/clusters/live/config/media-prereqs/recyclarr-config.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/recyclarr-config.yaml
@@ -147,13 +147,7 @@ data:
         custom_formats:
           # HDR formats — positively scored for 4K
           - trash_ids:
-              - 7878c33f1fca4bc0b3a42c4b2674c5db # DV HDR10
-              - 9b27ab6c6f2f29a3282c0e28a3e26e55 # DV HDR10Plus
-              - 3e2c4e748b64a1a1118e0ea3f4cf6875 # HDR
-              - 3497f2e847b8ea2da074e8afb9c35905 # HDR10
-              - a3d82bf24ed956a1ce68a716e4bc9e41 # HDR10Plus
-              - 2b239ed870daba8126a53bd3f457571e # HLG
-              - 17e889ce13117940092308f48b48b45b # PQ
+              - 505d871304820ba7106b693be6fe4a9e # HDR
             assign_scores_to:
               - name: WEB-2160p
 
@@ -163,18 +157,18 @@ data:
               - f67c9ca88f463a48346062e8ad07713f # ATVP
               - 77a7b25585c18af08f60b1547bb9b4fb # CC
               - 36b72f59f4ea20aad9316f475f2d9fbb # DCU
-              - 89358767a60cc28783ab36d3d1848587 # DSNP
-              - 7a235133c87f7da4c8ccccbe915e60aa # HBO
+              - 89358767a60cc28783cdc3d0be9388a4 # DSNP
+              - 7a235133c87f7da4c8cccceca7e3c7a6 # HBO
               - a880d6abc21e7c16884f3ae393f84179 # HMAX
-              - f6cce30f1733d5c8194222a7507f2571 # HULU
-              - 0ac24a2a68a9700bcb7ece4e5ff7c4d3 # iT
+              - f6cce30f1733d5c8194222a7507909bb # HULU
+              - 0ac24a2a68a9700bcb7eeca8e5cd644c # iT
               - 81d1fbf600e2540cee87f3a23f9d3c1c # MAX
-              - d34870697c9db575f17700c6a4f0fb76 # NF
+              - d34870697c9db575f17700212167be23 # NF
               - 1656adc6d7bb2c8cca6acfb6592db421 # PCOK
-              - c67a75ae4a1715f2bb4d492c17f80112 # PMTP
-              - ae58039e1319178e6be73571571d74b1 # SHO
-              - 1bbe48db9b44c9b56bbad028f73e8c1e # STAN
-              - 56ee4e48e28e3e3b3f8a15feaa44a5b4 # VDL
+              - c67a75ae4a1715f2bb4d492755ba4195 # PMTP
+              - ae58039e1319178e6be73caab5c42166 # SHO
+              - 1efe8da11bfd74fbbcd4d8117ddb9213 # STAN
+              - 5d2317d99af813b6529c7ebf01c83533 # VDL
             assign_scores_to:
               - name: WEB-2160p
 
@@ -182,15 +176,15 @@ data:
           - trash_ids:
               - e6258996055b9fbab7e9cb2f75819294 # WEB Tier 01
               - 58790d4e2fdcd9733aa7ae68ba2bb503 # WEB Tier 02
-              - d84935abd3f8556dcd51d4f27e22f1a6 # WEB Tier 03
+              - d84935abd3f8556dcd51d4f27e22d0a6 # WEB Tier 03
             assign_scores_to:
               - name: WEB-2160p
 
           # Misc
           - trash_ids:
-              - ec8fa7296b64e8cd390a1600f4c2510c # Repack/Proper
+              - ec8fa7296b64e8cd390a1600981f3923 # Repack/Proper
               - eb3d5cc0a2be0db205fb823640db6a3c # Repack v2
-              - 44e7c4de10ae50265753082c5dc2eefb # Repack v3
+              - 44e7c4de10ae50265753082e5dc76047 # Repack v3
             assign_scores_to:
               - name: WEB-2160p
 
@@ -337,7 +331,7 @@ data:
               - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
               - ed38b889b31be83fda192888e2286d83 # BR-DISK
               - 90a6f9a284dff5103f6346090e6280c8 # LQ
-              - e204b80c87be9497c8f48d3919e5cd38 # LQ (Release Title)
+              - e204b80c87be9497a8a6eaff48f72905 # LQ (Release Title)
               - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
             assign_scores_to:
               - name: WEB-2160p
@@ -356,22 +350,22 @@ data:
               - 40e9380490e748672c2522eaaeb692f7 # ATVP
               - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
               - 84272245b2988854bfb76a16e60baea5 # DSNP
-              - 509e5f41146e278f9eab1f8db4c9f1cf # HBO
-              - 5763d1b0ce84aff3b21038c4c9f2f90b # HMAX
+              - 509e5f41146e278f9eab1ddaceb34515 # HBO
+              - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
               - 526d445d4c16214309f0fd2b3be18a89 # Hulu
               - 2a6039655313bf5dab1e43523b62c374 # MA
               - 6a061313d22e51e0f25b7cd4dc065233 # MAX
-              - 170b1d363bd8516fbf3a3eb05d4c8571 # NF
+              - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
               - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
               - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
-              - bf7e73dd1d85b12cc4e6a709c71652ed # Pathe
-              - c2863d2a50c9acad1fb50e53ece60571 # STAN
+              - bf7e73dd1d85b12cc527dc619761c840 # Pathe
+              - c2863d2a50c9acad1fb50e53ece60817 # STAN
             assign_scores_to:
               - name: WEB-2160p
 
           # Misc
           - trash_ids:
-              - e7718d7a3ce595f289bfee26adc178f1 # Repack/Proper
+              - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
               - ae43b294509409a6a13919dedd4764c4 # Repack2
             assign_scores_to:
               - name: WEB-2160p


### PR DESCRIPTION
## Summary

Several custom format trash_ids in the `sonarr4k` and `radarr4k` recyclarr instances were invalid, causing warnings on every sync run. IDs are content-hashes of CF definitions — they change when TRaSH guides editors update a CF's name, regex, or conditions.

## Changes

### sonarr4k

| CF | Action |
|---|---|
| DV HDR10, DV HDR10Plus, HDR10, HDR10Plus, HLG, PQ | **Removed** — no longer exist in Sonarr TRaSH guide |
| HDR, DSNP, HBO, HULU, iT, NF, PMTP, SHO, STAN, VDL | Updated to current IDs |
| WEB Tier 03, Repack/Proper, Repack v3 | Updated to current IDs |

### radarr4k

| CF | Action |
|---|---|
| LQ (Release Title), HBO, HMAX, NF, Pathe, STAN, Repack/Proper | Updated to current IDs |

IDs sourced from: https://github.com/TRaSH-Guides/Guides/tree/master/docs/json

## Test plan

- [ ] Recyclarr sync shows no `Invalid trash_id` warnings for sonarr4k or radarr4k
- [ ] All instances still show `✓` across all columns