### PR TITLE
fix(monitoring): exclude iSCSI virtual disks from NodeDiskIOSaturation

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -109,7 +109,28 @@ defaultRules:
   create: true
   disabled:
     KubeClientCertificateExpiration: true
+    NodeDiskIOSaturation: true
 additionalPrometheusRulesMap:
+  node-disk-rules:
+    groups:
+      - name: node-disk
+        rules:
+          - alert: NodeDiskIOSaturation
+            annotations:
+              description: |
+                Disk IO queue (aqu-sq) is high on {{ $labels.device }} at {{ $labels.instance }}, has been above 10 for the last 30 minutes, is currently at {{ printf "%.2f" $value }}.
+                This symptom might indicate disk saturation.
+              runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodediskiosaturation
+              summary: Disk IO queue is high.
+            expr: |
+              (
+                rate(node_disk_io_time_weighted_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}[5m])
+              * on(instance, device) group_left()
+                node_disk_info{model!="VIRTUAL-DISK"}
+              ) > 10
+            for: 30m
+            labels:
+              severity: warning
   oom-rules:
     groups:
       - name: oom


### PR DESCRIPTION
## Summary

- Disable upstream `NodeDiskIOSaturation` rule via `defaultRules.disabled`
- Add replacement rule that joins on `node_disk_info{model!="VIRTUAL-DISK"}` to restrict alerting to physical disks only

## Problem

The upstream rule matches all `sd*` devices including Longhorn NBD/iSCSI replica devices. node41 has 38 Longhorn replicas, each presented as an iSCSI virtual disk (`sde`–`sds`+). These devices show inflated `aqu-sq` values because iSCSI `io_time_weighted` includes network round-trip latency — not actual disk saturation.

Result: `NodeDiskIOSaturation` fires on virtual devices while physical SSDs (aqu-sq ~2.0) are healthy. This was confirmed after the Prometheus replica reduction dropped node43's physical SSD from aqu-sq 15.35 → 2.68 while `sds` on node41 remained at ~10.5.

## Fix

`node_disk_info` exposes `model="VIRTUAL-DISK"` for all Longhorn iSCSI NBD devices. Multiplying the IO rate by `node_disk_info{model!="VIRTUAL-DISK"}` (value=1 for all physical disks) filters the alert to physical devices only without changing the threshold or semantics.

## Test plan

- [ ] Confirm `NodeDiskIOSaturation` no longer fires for iSCSI virtual disks on node41
- [ ] Confirm alert still fires for physical disk saturation (threshold unchanged at aqu-sq > 10 for 30m)
- [ ] Verify upstream rule is disabled (no duplicate alerts)