### PR TITLE
fix(media): add upgrade cutoff and fix quality names in recyclarr HD profiles

### DIFF
--- a/kubernetes/clusters/live/config/media-prereqs/recyclarr-config.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/recyclarr-config.yaml
@@ -24,6 +24,10 @@ data:
           - name: WEB-1080p
             reset_unmatched_scores:
               enabled: true
+            upgrade:
+              allowed: true
+              until_quality: Bluray-1080p
+              until_score: 10000
             qualities:
               - name: WEB 1080p
                 qualities:
@@ -34,6 +38,10 @@ data:
           - name: Anime
             reset_unmatched_scores:
               enabled: true
+            upgrade:
+              allowed: true
+              until_quality: Bluray-1080p Remux
+              until_score: 10000
             qualities:
               - name: Bluray-1080p Remux
               - name: WEB 1080p
@@ -197,8 +205,12 @@ data:
           - name: WEB-1080p
             reset_unmatched_scores:
               enabled: true
+            upgrade:
+              allowed: true
+              until_quality: Remux-1080p
+              until_score: 10000
             qualities:
-              - name: Bluray-1080p Remux
+              - name: Remux-1080p
               - name: WEB 1080p
                 qualities:
                   - WEBDL-1080p
@@ -208,8 +220,12 @@ data:
           - name: Anime
             reset_unmatched_scores:
               enabled: true
+            upgrade:
+              allowed: true
+              until_quality: Remux-1080p
+              until_score: 10000
             qualities:
-              - name: Bluray-1080p Remux
+              - name: Remux-1080p
               - name: WEB 1080p
                 qualities:
                   - WEBDL-1080p


### PR DESCRIPTION
## Summary

- sonarr `WEB-1080p` and `Anime` profiles were missing `upgrade.until_quality` — recyclarr sent an invalid cutoff on profile creation → HTTP 400 "Cutoff must be an allowed quality or group"
- radarr `WEB-1080p` and `Anime` profiles had the same issue, plus an invalid quality name: Radarr uses `Remux-1080p`, not `Bluray-1080p Remux` (which is Sonarr's name for the same tier)
- sonarr4k and radarr4k already had `upgrade` blocks (added in #956) and worked — only the HD instances were missing them

## Root cause

recyclarr requires `upgrade.until_quality` to correctly set the `cutoff` field when POSTing a new quality profile. Without it, the submitted cutoff value doesn't match any item in the quality list and Sonarr/Radarr reject the request.

## Verification

Fix applied directly to live ConfigMap and tested via manual recyclarr job — all four instances (`sonarr`, `sonarr4k`, `radarr`, `radarr4k`) returned ✓ across custom formats, quality profiles, and quality sizes.

## Test plan
- [ ] Recyclarr daily run completes with all ✓
- [ ] Sonarr Settings → Profiles shows WEB-1080p and Anime
- [ ] Radarr Settings → Profiles shows WEB-1080p and Anime