### PR TITLE
fix(media): download cleanup, language filtering, anime fallback profile, tdarr write access

### DIFF
--- a/kubernetes/clusters/live/charts/qbittorrent.yaml
+++ b/kubernetes/clusters/live/charts/qbittorrent.yaml
@@ -77,6 +77,10 @@ controllers:
           QBT_BitTorrent__Session__TempPathEnabled: "false"
           QBT_BitTorrent__Session__Interface: tun0
           QBT_BitTorrent__Session__InterfaceName: tun0
+          QBT_BitTorrent__Session__GlobalMaxRatio: "1.0"
+          QBT_BitTorrent__Session__GlobalMaxSeedingMinutes: "60"
+          QBT_BitTorrent__Session__ShareLimitAction: "3"
+          QBT_BitTorrent__Session__ShareLimitsMode: "0"
         securityContext:
           runAsUser: 568
           runAsGroup: 568

--- a/kubernetes/clusters/live/charts/tdarr.yaml
+++ b/kubernetes/clusters/live/charts/tdarr.yaml
@@ -110,7 +110,7 @@ persistence:
       tdarr:
         app:
           - path: /media/library
-            readOnly: true
+            readOnly: false
   transcode-cache:
     type: emptyDir
     advancedMounts:

--- a/kubernetes/clusters/live/config/media-prereqs/recyclarr-config.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/recyclarr-config.yaml
@@ -50,6 +50,29 @@ data:
                   - WEBRip-1080p
               - name: Bluray-1080p
               - name: HDTV-1080p
+          - name: Anime Fallback
+            min_format_score: -10000
+            reset_unmatched_scores:
+              enabled: true
+            upgrade:
+              allowed: true
+              until_quality: Bluray-1080p Remux
+              until_score: 10000
+            qualities:
+              - name: Bluray-1080p Remux
+              - name: WEB 1080p
+                qualities:
+                  - WEBDL-1080p
+                  - WEBRip-1080p
+              - name: Bluray-1080p
+              - name: HDTV-1080p
+              - name: Bluray-720p
+              - name: WEB 720p
+                qualities:
+                  - WEBDL-720p
+                  - WEBRip-720p
+              - name: HDTV-720p
+              - name: DVD
 
         custom_formats:
           # Unwanted HDR for 1080p web releases
@@ -108,6 +131,7 @@ data:
               - c81bbfb47fed3d5a3ad027d077f889de # Anime BD Tier 08 (Mini Encodes)
             assign_scores_to:
               - name: Anime
+              - name: Anime Fallback
 
           # Anime Web Release Groups
           - trash_ids:
@@ -116,6 +140,7 @@ data:
               - c27f2ae6a4e82373b0f1da094e2489ad # Anime Web Tier 03 (FanSubs)
             assign_scores_to:
               - name: Anime
+              - name: Anime Fallback
 
           # Anime Misc
           - trash_ids:
@@ -124,6 +149,30 @@ data:
               - 44e7c4de10ae50265753082e5dc76047 # Repack v3
             assign_scores_to:
               - name: Anime
+              - name: Anime Fallback
+
+          # Language
+          - trash_ids:
+              - 69aa1e159f97d860440b04cd6d590c4f # Language: Not English
+            assign_scores_to:
+              - name: WEB-1080p
+                score: -10000
+
+          # Anime Language
+          - trash_ids:
+              - 418f50b10f1907201b6cfdf881f467b7 # Anime Dual Audio
+            assign_scores_to:
+              - name: Anime
+                score: 100
+              - name: Anime Fallback
+                score: 100
+          - trash_ids:
+              - 9c14d194486c4014d422adc64092d794 # Dubs Only
+            assign_scores_to:
+              - name: Anime
+                score: -10000
+              - name: Anime Fallback
+                score: -10000
 
       sonarr4k:
         base_url: http://sonarr4k.media.svc:8989
@@ -193,6 +242,13 @@ data:
             assign_scores_to:
               - name: WEB-2160p
 
+          # Language
+          - trash_ids:
+              - 69aa1e159f97d860440b04cd6d590c4f # Language: Not English
+            assign_scores_to:
+              - name: WEB-2160p
+                score: -10000
+
     radarr:
       radarr:
         base_url: http://radarr.media.svc:7878
@@ -232,6 +288,29 @@ data:
                   - WEBRip-1080p
               - name: Bluray-1080p
               - name: HDTV-1080p
+          - name: Anime Fallback
+            min_format_score: -10000
+            reset_unmatched_scores:
+              enabled: true
+            upgrade:
+              allowed: true
+              until_quality: Remux-1080p
+              until_score: 10000
+            qualities:
+              - name: Remux-1080p
+              - name: WEB 1080p
+                qualities:
+                  - WEBDL-1080p
+                  - WEBRip-1080p
+              - name: Bluray-1080p
+              - name: HDTV-1080p
+              - name: Bluray-720p
+              - name: WEB 720p
+                qualities:
+                  - WEBDL-720p
+                  - WEBRip-720p
+              - name: HDTV-720p
+              - name: DVD
 
         custom_formats:
           # Unwanted
@@ -246,6 +325,8 @@ data:
               - a5d148168c4506b55cf53984107c396e # 10bit
             assign_scores_to:
               - name: WEB-1080p
+              - name: Anime Fallback
+                score: 0
 
           # Movie Versions
           - trash_ids:
@@ -304,6 +385,7 @@ data:
               - 6115ccd6640b978234cc47f2c1f2cadc # Anime BD Tier 08 (Mini Encodes)
             assign_scores_to:
               - name: Anime
+              - name: Anime Fallback
 
           # Anime Web Release Groups
           - trash_ids:
@@ -312,6 +394,7 @@ data:
               - de41e72708d2c856fa261094c85e965d # Anime Web Tier 03 (FanSubs)
             assign_scores_to:
               - name: Anime
+              - name: Anime Fallback
 
           # Anime Misc
           - trash_ids:
@@ -319,6 +402,30 @@ data:
               - ae43b294509409a6a13919dedd4764c4 # Repack2
             assign_scores_to:
               - name: Anime
+              - name: Anime Fallback
+
+          # Language
+          - trash_ids:
+              - 0dc8aec3bd1c47cd6c40c46ecd27e846 # Language: Not English
+            assign_scores_to:
+              - name: WEB-1080p
+                score: -10000
+
+          # Anime Language
+          - trash_ids:
+              - 418f50b10f1907201b6cfdf881f467b7 # Anime Dual Audio
+            assign_scores_to:
+              - name: Anime
+                score: 100
+              - name: Anime Fallback
+                score: 100
+          - trash_ids:
+              - b23eae459cc960816f2d6ba84af45055 # Dubs Only
+            assign_scores_to:
+              - name: Anime
+                score: -10000
+              - name: Anime Fallback
+                score: -10000
 
       radarr4k:
         base_url: http://radarr4k.media.svc:7878
@@ -388,3 +495,10 @@ data:
               - ae43b294509409a6a13919dedd4764c4 # Repack2
             assign_scores_to:
               - name: WEB-2160p
+
+          # Language
+          - trash_ids:
+              - 0dc8aec3bd1c47cd6c40c46ecd27e846 # Language: Not English
+            assign_scores_to:
+              - name: WEB-2160p
+                score: -10000


### PR DESCRIPTION
## Summary

- **qBittorrent**: seed to 1:1 ratio or 60 minutes, then delete torrent + files — prevents unbounded `media-downloads` PVC growth
- **Recyclarr**: block non-English grabs (-10000) on all WEB profiles; add Anime Dual Audio (+100) / Dubs Only (-10000) CFs; add `Anime Fallback` quality profile (DVD/720p tiers, `min_format_score: -10000`) to sonarr + radarr for niche/older content
- **tdarr**: change `media-library` mount from `readOnly: true` to `readOnly: false` so the server can scan metadata and workers can remux

## Manual post-merge steps (UI — do not block merge)

### Radarr (both instances)
- [ ] Settings → Profiles → each quality profile → set Language to **Any**
- [ ] Assign niche titles (Gunbuster, Diebuster, Bluey) to **Anime Fallback** profile

### Sonarr
- [ ] Settings → Profiles → Delay Profiles → change **Prefer Usenet** to **Prefer Torrent**
- [ ] Assign niche series to **Anime Fallback** profile

### Bazarr
- [ ] Settings → Languages → create English-only Language Profile (cutoff: English)
- [ ] Mass-assign profile to all movies and series
- [ ] Settings → Sonarr → Options → Minimum Score → **90%**
- [ ] Settings → Radarr → Options → Minimum Score → **80%**
- [ ] Blacklist existing wrong-language subtitles to trigger re-search

### Tdarr (after pod restarts)
- [ ] Create libraries: Movies, TV, Anime Movies, Anime (paths under `/media/library/`)
- [ ] Create **Standard Content** flow: strip non-English audio + subtitle tracks (remux only)
- [ ] Create **Anime Content** flow: keep Japanese + English audio, strip others; strip non-English subtitles (remux only)
- [ ] Assign flows: Movies + TV → Standard; Anime + Anime Movies → Anime
- [ ] Test each flow on single file before enabling library-wide scan

## Verification

- qBittorrent pod restarts → WebUI → Options → BitTorrent → verify ratio 1.0, 60 min, RemoveWithContent
- Recyclarr CronJob logs after next run: `kubectl logs -n media job/recyclarr-<latest> --context live`
- Sonarr/Radarr UI: WEB-1080p → Custom Formats → "Language: Not English" shows -10000; Anime profile has NO "Language: Not English" entry
- "Anime Fallback" profile exists with DVD/720p qualities and `min_format_score: -10000`
- Tdarr pod restarts cleanly; libraries browsable in UI