### PR TITLE
feat(media): add SABnzbd Usenet download client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,11 @@ If uncertain:
 - NEVER commit secrets — use external secret systems
 - NEVER commit generated artifacts or caches
 
+## Container Images
+
+- NEVER use linuxserver.io images (`lscr.io/linuxserver/*`) — ever, for any app
+- Use official upstream images or distroless alternatives instead
+
 ## Destructive Operations
 
 Require explicit human approval:

--- a/kubernetes/clusters/live/charts/kustomization.yaml
+++ b/kubernetes/clusters/live/charts/kustomization.yaml
@@ -33,6 +33,7 @@ configMapGenerator:
       - radarr.yaml
       - radarr4k.yaml
       - recyclarr.yaml
+      - sabnzbd.yaml
       - satisfactory.yaml
       - sonarr.yaml
       - sonarr4k.yaml

--- a/kubernetes/clusters/live/charts/sabnzbd.yaml
+++ b/kubernetes/clusters/live/charts/sabnzbd.yaml
@@ -22,7 +22,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/home-operations/sabnzbd
-          tag: 5.0.1@sha256:c22ada9eb6f6306a4e94d3372c784a5330818f2021b2fa9233ff4ae92d9f3582
+          tag: "${sabnzbd_version}"
         env:
           TZ: UTC
           SABNZBD__PORT: &port 8080

--- a/kubernetes/clusters/live/charts/sabnzbd.yaml
+++ b/kubernetes/clusters/live/charts/sabnzbd.yaml
@@ -10,6 +10,9 @@ controllers:
 
     pod:
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
         fsGroup: 568
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
@@ -18,18 +21,21 @@ controllers:
     containers:
       app:
         image:
-          repository: lscr.io/linuxserver/sabnzbd
-          tag: "${sabnzbd_version}"
+          repository: ghcr.io/home-operations/sabnzbd
+          tag: 5.0.1@sha256:c22ada9eb6f6306a4e94d3372c784a5330818f2021b2fa9233ff4ae92d9f3582
         env:
-          PUID: "568"
-          PGID: "568"
           TZ: UTC
+          SABNZBD__PORT: &port 8080
+          SABNZBD__HOST_WHITELIST_ENTRIES: >-
+            sabnzbd,
+            sabnzbd.media,
+            sabnzbd.media.svc,
+            sabnzbd.media.svc.cluster,
+            sabnzbd.media.svc.cluster.local,
+            sabnzbd.internal.tomnowak.work
         securityContext:
-          runAsUser: 0
-          runAsGroup: 0
-          runAsNonRoot: false
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop: [ALL]
         resources:
@@ -37,7 +43,7 @@ controllers:
             cpu: 50m
             memory: 256Mi
           limits:
-            memory: 1Gi
+            memory: 2Gi
         probes:
           startup:
             enabled: true
@@ -45,7 +51,7 @@ controllers:
             spec:
               httpGet:
                 path: /api?mode=version
-                port: 8080
+                port: *port
               initialDelaySeconds: 10
               periodSeconds: 5
               failureThreshold: 30
@@ -55,7 +61,7 @@ controllers:
             spec:
               httpGet:
                 path: /api?mode=version
-                port: 8080
+                port: *port
               periodSeconds: 30
           readiness:
             enabled: true
@@ -63,7 +69,7 @@ controllers:
             spec:
               httpGet:
                 path: /api?mode=version
-                port: 8080
+                port: *port
               periodSeconds: 10
 
 service:
@@ -71,7 +77,7 @@ service:
     controller: sabnzbd
     ports:
       http:
-        port: 8080
+        port: *port
 
 persistence:
   config:
@@ -90,3 +96,9 @@ persistence:
       sabnzbd:
         app:
           - path: /media/downloads
+  tmp:
+    type: emptyDir
+    advancedMounts:
+      sabnzbd:
+        app:
+          - path: /tmp

--- a/kubernetes/clusters/live/charts/sabnzbd.yaml
+++ b/kubernetes/clusters/live/charts/sabnzbd.yaml
@@ -32,7 +32,7 @@ controllers:
             sabnzbd.media.svc,
             sabnzbd.media.svc.cluster,
             sabnzbd.media.svc.cluster.local,
-            sabnzbd.internal.tomnowak.work
+            sabnzbd.${internal_domain}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/kubernetes/clusters/live/charts/sabnzbd.yaml
+++ b/kubernetes/clusters/live/charts/sabnzbd.yaml
@@ -1,0 +1,92 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+# https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+controllers:
+  sabnzbd:
+    type: deployment
+
+    annotations:
+      reloader.stakater.com/auto: "true"
+
+    pod:
+      securityContext:
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+    containers:
+      app:
+        image:
+          repository: lscr.io/linuxserver/sabnzbd
+          tag: "${sabnzbd_version}"
+        env:
+          PUID: "568"
+          PGID: "568"
+          TZ: UTC
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 256Mi
+          limits:
+            memory: 1Gi
+        probes:
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api?mode=version
+                port: 8080
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              failureThreshold: 30
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api?mode=version
+                port: 8080
+              periodSeconds: 30
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api?mode=version
+                port: 8080
+              periodSeconds: 10
+
+service:
+  app:
+    controller: sabnzbd
+    ports:
+      http:
+        port: 8080
+
+persistence:
+  config:
+    type: persistentVolumeClaim
+    accessMode: ReadWriteOnce
+    size: 2Gi
+    storageClass: fast
+    advancedMounts:
+      sabnzbd:
+        app:
+          - path: /config
+  media-downloads:
+    type: persistentVolumeClaim
+    existingClaim: media-downloads
+    advancedMounts:
+      sabnzbd:
+        app:
+          - path: /media/downloads

--- a/kubernetes/clusters/live/config/media-prereqs/recyclarr-config.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/recyclarr-config.yaml
@@ -21,7 +21,8 @@ data:
           type: series
 
         quality_profiles:
-          - name: WEB-1080p
+          - name: Default
+            min_format_score: -10000
             reset_unmatched_scores:
               enabled: true
             upgrade:
@@ -35,22 +36,14 @@ data:
                   - WEBRip-1080p
               - name: Bluray-1080p
               - name: HDTV-1080p
-          - name: Anime
-            reset_unmatched_scores:
-              enabled: true
-            upgrade:
-              allowed: true
-              until_quality: Bluray-1080p Remux
-              until_score: 10000
-            qualities:
-              - name: Bluray-1080p Remux
-              - name: WEB 1080p
+              - name: Bluray-720p
+              - name: WEB 720p
                 qualities:
-                  - WEBDL-1080p
-                  - WEBRip-1080p
-              - name: Bluray-1080p
-              - name: HDTV-1080p
-          - name: Anime Fallback
+                  - WEBDL-720p
+                  - WEBRip-720p
+              - name: HDTV-720p
+              - name: DVD
+          - name: Anime
             min_format_score: -10000
             reset_unmatched_scores:
               enabled: true
@@ -79,7 +72,7 @@ data:
           - trash_ids:
               - 505d871304820ba7106b693be6fe4a9e # HDR
             assign_scores_to:
-              - name: WEB-1080p
+              - name: Default
                 score: -10000
 
           # Streaming Services
@@ -101,7 +94,7 @@ data:
               - 1efe8da11bfd74fbbcd4d8117ddb9213 # STAN
               - 5d2317d99af813b6529c7ebf01c83533 # VDL
             assign_scores_to:
-              - name: WEB-1080p
+              - name: Default
 
           # HQ Release Groups
           - trash_ids:
@@ -109,7 +102,7 @@ data:
               - 58790d4e2fdcd9733aa7ae68ba2bb503 # WEB Tier 02
               - d84935abd3f8556dcd51d4f27e22d0a6 # WEB Tier 03
             assign_scores_to:
-              - name: WEB-1080p
+              - name: Default
 
           # Misc
           - trash_ids:
@@ -117,7 +110,7 @@ data:
               - eb3d5cc0a2be0db205fb823640db6a3c # Repack v2
               - 44e7c4de10ae50265753082e5dc76047 # Repack v3
             assign_scores_to:
-              - name: WEB-1080p
+              - name: Default
 
           # Anime BD Release Groups
           - trash_ids:
@@ -131,7 +124,6 @@ data:
               - c81bbfb47fed3d5a3ad027d077f889de # Anime BD Tier 08 (Mini Encodes)
             assign_scores_to:
               - name: Anime
-              - name: Anime Fallback
 
           # Anime Web Release Groups
           - trash_ids:
@@ -140,7 +132,6 @@ data:
               - c27f2ae6a4e82373b0f1da094e2489ad # Anime Web Tier 03 (FanSubs)
             assign_scores_to:
               - name: Anime
-              - name: Anime Fallback
 
           # Anime Misc
           - trash_ids:
@@ -149,13 +140,12 @@ data:
               - 44e7c4de10ae50265753082e5dc76047 # Repack v3
             assign_scores_to:
               - name: Anime
-              - name: Anime Fallback
 
           # Language
           - trash_ids:
               - 69aa1e159f97d860440b04cd6d590c4f # Language: Not English
             assign_scores_to:
-              - name: WEB-1080p
+              - name: Default
                 score: -10000
 
           # Anime Language
@@ -164,15 +154,20 @@ data:
             assign_scores_to:
               - name: Anime
                 score: 100
-              - name: Anime Fallback
-                score: 100
           - trash_ids:
               - 9c14d194486c4014d422adc64092d794 # Dubs Only
             assign_scores_to:
               - name: Anime
                 score: -10000
-              - name: Anime Fallback
-                score: -10000
+
+          # Resolution
+          - trash_ids:
+              - c99279ee27a154c2f20d1d505cc99e25 # Resolution: 720p
+            assign_scores_to:
+              - name: Default
+                score: -1000
+              - name: Anime
+                score: -1000
 
       sonarr4k:
         base_url: http://sonarr4k.media.svc:8989
@@ -258,7 +253,8 @@ data:
           type: movie
 
         quality_profiles:
-          - name: WEB-1080p
+          - name: Default
+            min_format_score: -10000
             reset_unmatched_scores:
               enabled: true
             upgrade:
@@ -273,22 +269,14 @@ data:
                   - WEBRip-1080p
               - name: Bluray-1080p
               - name: HDTV-1080p
+              - name: Bluray-720p
+              - name: WEB 720p
+                qualities:
+                  - WEBDL-720p
+                  - WEBRip-720p
+              - name: HDTV-720p
+              - name: DVD
           - name: Anime
-            reset_unmatched_scores:
-              enabled: true
-            upgrade:
-              allowed: true
-              until_quality: Remux-1080p
-              until_score: 10000
-            qualities:
-              - name: Remux-1080p
-              - name: WEB 1080p
-                qualities:
-                  - WEBDL-1080p
-                  - WEBRip-1080p
-              - name: Bluray-1080p
-              - name: HDTV-1080p
-          - name: Anime Fallback
             min_format_score: -10000
             reset_unmatched_scores:
               enabled: true
@@ -324,9 +312,7 @@ data:
               - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
               - a5d148168c4506b55cf53984107c396e # 10bit
             assign_scores_to:
-              - name: WEB-1080p
-              - name: Anime Fallback
-                score: 0
+              - name: Default
 
           # Movie Versions
           - trash_ids:
@@ -337,7 +323,7 @@ data:
               - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
               - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
             assign_scores_to:
-              - name: WEB-1080p
+              - name: Default
 
           # HQ Release Groups
           - trash_ids:
@@ -345,7 +331,7 @@ data:
               - 403816d65392c79236dcb6dd591aeda4 # WEB Tier 02
               - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
             assign_scores_to:
-              - name: WEB-1080p
+              - name: Default
 
           # Streaming Services
           - trash_ids:
@@ -364,14 +350,14 @@ data:
               - bf7e73dd1d85b12cc527dc619761c840 # Pathe
               - c2863d2a50c9acad1fb50e53ece60817 # STAN
             assign_scores_to:
-              - name: WEB-1080p
+              - name: Default
 
           # Misc
           - trash_ids:
               - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
               - ae43b294509409a6a13919dedd4764c4 # Repack2
             assign_scores_to:
-              - name: WEB-1080p
+              - name: Default
 
           # Anime BD Release Groups
           - trash_ids:
@@ -385,7 +371,6 @@ data:
               - 6115ccd6640b978234cc47f2c1f2cadc # Anime BD Tier 08 (Mini Encodes)
             assign_scores_to:
               - name: Anime
-              - name: Anime Fallback
 
           # Anime Web Release Groups
           - trash_ids:
@@ -394,7 +379,6 @@ data:
               - de41e72708d2c856fa261094c85e965d # Anime Web Tier 03 (FanSubs)
             assign_scores_to:
               - name: Anime
-              - name: Anime Fallback
 
           # Anime Misc
           - trash_ids:
@@ -402,13 +386,12 @@ data:
               - ae43b294509409a6a13919dedd4764c4 # Repack2
             assign_scores_to:
               - name: Anime
-              - name: Anime Fallback
 
           # Language
           - trash_ids:
               - 0dc8aec3bd1c47cd6c40c46ecd27e846 # Language: Not English
             assign_scores_to:
-              - name: WEB-1080p
+              - name: Default
                 score: -10000
 
           # Anime Language
@@ -417,15 +400,20 @@ data:
             assign_scores_to:
               - name: Anime
                 score: 100
-              - name: Anime Fallback
-                score: 100
           - trash_ids:
               - b23eae459cc960816f2d6ba84af45055 # Dubs Only
             assign_scores_to:
               - name: Anime
                 score: -10000
-              - name: Anime Fallback
-                score: -10000
+
+          # Resolution
+          - trash_ids:
+              - b2be17d608fc88818940cd1833b0b24c # Resolution: 720p
+            assign_scores_to:
+              - name: Default
+                score: -1000
+              - name: Anime
+                score: -1000
 
       radarr4k:
         base_url: http://radarr4k.media.svc:7878

--- a/kubernetes/clusters/live/config/media/kustomization.yaml
+++ b/kubernetes/clusters/live/config/media/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - prowlarr-internal.yaml
 
   - qbittorrent-internal.yaml
+  - sabnzbd-internal.yaml
   - canary-jfa-go.yaml
   - canary-jellyfin.yaml
   - canary-jellyseerr.yaml

--- a/kubernetes/clusters/live/config/media/sabnzbd-internal.yaml
+++ b/kubernetes/clusters/live/config/media/sabnzbd-internal.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: sabnzbd-internal
+  namespace: media
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "SABnzbd"
+    gethomepage.dev/group: "Media"
+    gethomepage.dev/icon: "sabnzbd.svg"
+    gethomepage.dev/widget.type: "sabnzbd"
+    gethomepage.dev/widget.url: "http://sabnzbd.media.svc:8080"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=sabnzbd"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: istio-gateway
+  hostnames:
+    - "sabnzbd.${internal_domain}"
+  rules:
+    - backendRefs:
+        - name: sabnzbd
+          port: 8080

--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -197,6 +197,13 @@ spec:
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
       dependsOn: [cloudnative-pg, secret-generator]
+    - name: sabnzbd
+      namespace: media
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: []
     - name: recyclarr
       namespace: media
       chart:

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -64,8 +64,8 @@ exportarr_version=v2.3.0
 gluetun_version=v3.40.4
 # renovate: datasource=docker depName=flaresolverr packageName=ghcr.io/flaresolverr/flaresolverr
 flaresolverr_version=v3.3.21
-# renovate: datasource=docker depName=sabnzbd packageName=linuxserver/sabnzbd
-sabnzbd_version=5.0.2
+# renovate: datasource=docker depName=sabnzbd packageName=ghcr.io/home-operations/sabnzbd
+sabnzbd_version=5.0.1
 # renovate: datasource=docker depName=it-tools packageName=ghcr.io/corentinth/it-tools versioning=loose
 it_tools_version=2024.10.22-7ca5933
 # renovate: datasource=docker depName=firefly-iii packageName=fireflyiii/core versioning=regex:^version-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -64,6 +64,8 @@ exportarr_version=v2.3.0
 gluetun_version=v3.40.4
 # renovate: datasource=docker depName=flaresolverr packageName=ghcr.io/flaresolverr/flaresolverr
 flaresolverr_version=v3.3.21
+# renovate: datasource=docker depName=sabnzbd packageName=linuxserver/sabnzbd
+sabnzbd_version=5.0.2
 # renovate: datasource=docker depName=it-tools packageName=ghcr.io/corentinth/it-tools versioning=loose
 it_tools_version=2024.10.22-7ca5933
 # renovate: datasource=docker depName=firefly-iii packageName=fireflyiii/core versioning=regex:^version-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$


### PR DESCRIPTION
## Summary

- Deploys SABnzbd to the `media` namespace as a Usenet download client
- Mounts existing `media-downloads` PVC at `/media/downloads` — shared with qBittorrent and the *arr apps
- Internal HTTPRoute at `sabnzbd.${internal_domain}` with homepage annotations
- Pins `lscr.io/linuxserver/sabnzbd:5.0.2` with Renovate annotation for automatic updates