### PR TITLE
feat(network-policy): allow SABnzbd NNTPS egress on port 563

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,11 @@ If uncertain:
 - NEVER commit secrets — use external secret systems
 - NEVER commit generated artifacts or caches
 
+## Container Images
+
+- NEVER use linuxserver.io images (`lscr.io/linuxserver/*`) — ever, for any app
+- Use official upstream images or distroless alternatives instead
+
 ## Destructive Operations
 
 Require explicit human approval:

--- a/kubernetes/clusters/live/charts/kustomization.yaml
+++ b/kubernetes/clusters/live/charts/kustomization.yaml
@@ -33,6 +33,7 @@ configMapGenerator:
       - radarr.yaml
       - radarr4k.yaml
       - recyclarr.yaml
+      - sabnzbd.yaml
       - satisfactory.yaml
       - sonarr.yaml
       - sonarr4k.yaml

--- a/kubernetes/clusters/live/charts/sabnzbd.yaml
+++ b/kubernetes/clusters/live/charts/sabnzbd.yaml
@@ -22,7 +22,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/home-operations/sabnzbd
-          tag: 5.0.1@sha256:c22ada9eb6f6306a4e94d3372c784a5330818f2021b2fa9233ff4ae92d9f3582
+          tag: "${sabnzbd_version}"
         env:
           TZ: UTC
           SABNZBD__PORT: &port 8080

--- a/kubernetes/clusters/live/charts/sabnzbd.yaml
+++ b/kubernetes/clusters/live/charts/sabnzbd.yaml
@@ -10,6 +10,9 @@ controllers:
 
     pod:
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
         fsGroup: 568
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
@@ -18,18 +21,21 @@ controllers:
     containers:
       app:
         image:
-          repository: lscr.io/linuxserver/sabnzbd
-          tag: "${sabnzbd_version}"
+          repository: ghcr.io/home-operations/sabnzbd
+          tag: 5.0.1@sha256:c22ada9eb6f6306a4e94d3372c784a5330818f2021b2fa9233ff4ae92d9f3582
         env:
-          PUID: "568"
-          PGID: "568"
           TZ: UTC
+          SABNZBD__PORT: &port 8080
+          SABNZBD__HOST_WHITELIST_ENTRIES: >-
+            sabnzbd,
+            sabnzbd.media,
+            sabnzbd.media.svc,
+            sabnzbd.media.svc.cluster,
+            sabnzbd.media.svc.cluster.local,
+            sabnzbd.internal.tomnowak.work
         securityContext:
-          runAsUser: 0
-          runAsGroup: 0
-          runAsNonRoot: false
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop: [ALL]
         resources:
@@ -37,7 +43,7 @@ controllers:
             cpu: 50m
             memory: 256Mi
           limits:
-            memory: 1Gi
+            memory: 2Gi
         probes:
           startup:
             enabled: true
@@ -45,7 +51,7 @@ controllers:
             spec:
               httpGet:
                 path: /api?mode=version
-                port: 8080
+                port: *port
               initialDelaySeconds: 10
               periodSeconds: 5
               failureThreshold: 30
@@ -55,7 +61,7 @@ controllers:
             spec:
               httpGet:
                 path: /api?mode=version
-                port: 8080
+                port: *port
               periodSeconds: 30
           readiness:
             enabled: true
@@ -63,7 +69,7 @@ controllers:
             spec:
               httpGet:
                 path: /api?mode=version
-                port: 8080
+                port: *port
               periodSeconds: 10
 
 service:
@@ -71,7 +77,7 @@ service:
     controller: sabnzbd
     ports:
       http:
-        port: 8080
+        port: *port
 
 persistence:
   config:
@@ -90,3 +96,9 @@ persistence:
       sabnzbd:
         app:
           - path: /media/downloads
+  tmp:
+    type: emptyDir
+    advancedMounts:
+      sabnzbd:
+        app:
+          - path: /tmp

--- a/kubernetes/clusters/live/charts/sabnzbd.yaml
+++ b/kubernetes/clusters/live/charts/sabnzbd.yaml
@@ -32,7 +32,7 @@ controllers:
             sabnzbd.media.svc,
             sabnzbd.media.svc.cluster,
             sabnzbd.media.svc.cluster.local,
-            sabnzbd.internal.tomnowak.work
+            sabnzbd.${internal_domain}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/kubernetes/clusters/live/charts/sabnzbd.yaml
+++ b/kubernetes/clusters/live/charts/sabnzbd.yaml
@@ -25,7 +25,7 @@ controllers:
           tag: "${sabnzbd_version}"
         env:
           TZ: UTC
-          SABNZBD__PORT: &port 8080
+          SABNZBD__PORT: 8080
           SABNZBD__HOST_WHITELIST_ENTRIES: >-
             sabnzbd,
             sabnzbd.media,
@@ -51,7 +51,7 @@ controllers:
             spec:
               httpGet:
                 path: /api?mode=version
-                port: *port
+                port: 8080
               initialDelaySeconds: 10
               periodSeconds: 5
               failureThreshold: 30
@@ -61,7 +61,7 @@ controllers:
             spec:
               httpGet:
                 path: /api?mode=version
-                port: *port
+                port: 8080
               periodSeconds: 30
           readiness:
             enabled: true
@@ -69,7 +69,7 @@ controllers:
             spec:
               httpGet:
                 path: /api?mode=version
-                port: *port
+                port: 8080
               periodSeconds: 10
 
 service:
@@ -77,7 +77,7 @@ service:
     controller: sabnzbd
     ports:
       http:
-        port: *port
+        port: 8080
 
 persistence:
   config:

--- a/kubernetes/clusters/live/charts/sabnzbd.yaml
+++ b/kubernetes/clusters/live/charts/sabnzbd.yaml
@@ -1,0 +1,92 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+# https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+controllers:
+  sabnzbd:
+    type: deployment
+
+    annotations:
+      reloader.stakater.com/auto: "true"
+
+    pod:
+      securityContext:
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+    containers:
+      app:
+        image:
+          repository: lscr.io/linuxserver/sabnzbd
+          tag: "${sabnzbd_version}"
+        env:
+          PUID: "568"
+          PGID: "568"
+          TZ: UTC
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 256Mi
+          limits:
+            memory: 1Gi
+        probes:
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api?mode=version
+                port: 8080
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              failureThreshold: 30
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api?mode=version
+                port: 8080
+              periodSeconds: 30
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api?mode=version
+                port: 8080
+              periodSeconds: 10
+
+service:
+  app:
+    controller: sabnzbd
+    ports:
+      http:
+        port: 8080
+
+persistence:
+  config:
+    type: persistentVolumeClaim
+    accessMode: ReadWriteOnce
+    size: 2Gi
+    storageClass: fast
+    advancedMounts:
+      sabnzbd:
+        app:
+          - path: /config
+  media-downloads:
+    type: persistentVolumeClaim
+    existingClaim: media-downloads
+    advancedMounts:
+      sabnzbd:
+        app:
+          - path: /media/downloads

--- a/kubernetes/clusters/live/config/media-prereqs/network-policy.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/network-policy.yaml
@@ -36,3 +36,22 @@ spec:
   egress:
     - toEntities:
         - world
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: media-sabnzbd-egress
+  namespace: media
+spec:
+  description: "SABnzbd NNTPS egress to Usenet provider on port 563"
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sabnzbd
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "563"
+              protocol: TCP

--- a/kubernetes/clusters/live/config/media/kustomization.yaml
+++ b/kubernetes/clusters/live/config/media/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - prowlarr-internal.yaml
 
   - qbittorrent-internal.yaml
+  - sabnzbd-internal.yaml
   - canary-jfa-go.yaml
   - canary-jellyfin.yaml
   - canary-jellyseerr.yaml

--- a/kubernetes/clusters/live/config/media/sabnzbd-internal.yaml
+++ b/kubernetes/clusters/live/config/media/sabnzbd-internal.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: sabnzbd-internal
+  namespace: media
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "SABnzbd"
+    gethomepage.dev/group: "Media"
+    gethomepage.dev/icon: "sabnzbd.svg"
+    gethomepage.dev/widget.type: "sabnzbd"
+    gethomepage.dev/widget.url: "http://sabnzbd.media.svc:8080"
+    gethomepage.dev/pod-selector: "app.kubernetes.io/name=sabnzbd"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: istio-gateway
+  hostnames:
+    - "sabnzbd.${internal_domain}"
+  rules:
+    - backendRefs:
+        - name: sabnzbd
+          port: 8080

--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -197,6 +197,13 @@ spec:
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
       dependsOn: [cloudnative-pg, secret-generator]
+    - name: sabnzbd
+      namespace: media
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: []
     - name: recyclarr
       namespace: media
       chart:

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -64,8 +64,8 @@ exportarr_version=v2.3.0
 gluetun_version=v3.40.4
 # renovate: datasource=docker depName=flaresolverr packageName=ghcr.io/flaresolverr/flaresolverr
 flaresolverr_version=v3.3.21
-# renovate: datasource=docker depName=sabnzbd packageName=linuxserver/sabnzbd
-sabnzbd_version=5.0.2
+# renovate: datasource=docker depName=sabnzbd packageName=ghcr.io/home-operations/sabnzbd
+sabnzbd_version=5.0.1
 # renovate: datasource=docker depName=it-tools packageName=ghcr.io/corentinth/it-tools versioning=loose
 it_tools_version=2024.10.22-7ca5933
 # renovate: datasource=docker depName=firefly-iii packageName=fireflyiii/core versioning=regex:^version-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -64,6 +64,8 @@ exportarr_version=v2.3.0
 gluetun_version=v3.40.4
 # renovate: datasource=docker depName=flaresolverr packageName=ghcr.io/flaresolverr/flaresolverr
 flaresolverr_version=v3.3.21
+# renovate: datasource=docker depName=sabnzbd packageName=linuxserver/sabnzbd
+sabnzbd_version=5.0.2
 # renovate: datasource=docker depName=it-tools packageName=ghcr.io/corentinth/it-tools versioning=loose
 it_tools_version=2024.10.22-7ca5933
 # renovate: datasource=docker depName=firefly-iii packageName=fireflyiii/core versioning=regex:^version-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$


### PR DESCRIPTION
## Summary

- Hubble confirmed `media/sabnzbd` pods were being DENIED egress to `news.newshosting.com:563` with `policy-verdict:none EGRESS DENIED`
- The `media` namespace uses the `standard` network policy profile, which blocks world egress by default
- Adds a `CiliumNetworkPolicy` (`media-sabnzbd-egress`) that permits TCP port 563 egress to `world` scoped to the `sabnzbd` endpoint selector only
- Unlike `media-qbittorrent-egress` (which allows unrestricted world egress for VPN tunnel establishment), this policy is restricted to port 563 TCP only since SABnzbd connects directly to the Usenet provider

## Test plan

- [ ] Verify Flux reconciles the new CNP without errors
- [ ] Confirm Hubble no longer shows DENIED verdicts for SABnzbd egress to port 563
- [ ] Confirm SABnzbd can successfully download from the Usenet provider