### PR TITLE
feat(network-policy): allow SABnzbd NNTPS egress on port 563

### DIFF
--- a/kubernetes/clusters/live/config/media-prereqs/network-policy.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/network-policy.yaml
@@ -36,3 +36,22 @@ spec:
   egress:
     - toEntities:
         - world
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: media-sabnzbd-egress
+  namespace: media
+spec:
+  description: "SABnzbd NNTPS egress to Usenet provider on port 563"
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sabnzbd
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "563"
+              protocol: TCP


### PR DESCRIPTION
## Summary

- Hubble confirmed `media/sabnzbd` egress to `news.newshosting.com:563` was `EGRESS DENIED` (`policy-verdict:none`) under the standard profile
- Adds `media-sabnzbd-egress` CiliumNetworkPolicy scoped to `app.kubernetes.io/name: sabnzbd`, allowing TCP 563 to `world` only
- Closes #987

## Test plan

- [ ] Verify Flux reconciles the new CNP in the media namespace
- [ ] Test SABnzbd server connection succeeds on port 563
- [ ] Confirm no new unexpected drops in Hubble for the sabnzbd pod