### PR TITLE
feat(gateway): add HTTP security headers to external gateway

### DIFF
--- a/kubernetes/platform/config/gateway/external-gateway-security-headers.yaml
+++ b/kubernetes/platform/config/gateway/external-gateway-security-headers.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/networking.istio.io/envoyfilter_v1alpha3.json
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: external-gateway-security-headers
+spec:
+  workloadSelector:
+    labels:
+      gateway.networking.k8s.io/gateway-name: external
+  configPatches:
+    - applyTo: VIRTUAL_HOST
+      match:
+        context: GATEWAY
+      patch:
+        operation: MERGE
+        value:
+          response_headers_to_add:
+            - header:
+                key: Strict-Transport-Security
+                value: "max-age=31536000; includeSubDomains; preload"
+              append: false
+            - header:
+                key: X-Content-Type-Options
+                value: "nosniff"
+              append: false
+            - header:
+                key: X-Frame-Options
+                value: "DENY"
+              append: false
+            - header:
+                key: Referrer-Policy
+                value: "strict-origin-when-cross-origin"
+              append: false
+            - header:
+                key: Permissions-Policy
+                value: "camera=(), microphone=(), geolocation=()"
+              append: false

--- a/kubernetes/platform/config/gateway/kustomization.yaml
+++ b/kubernetes/platform/config/gateway/kustomization.yaml
@@ -11,4 +11,5 @@ resources:
   - coraza-config.yaml
   - coraza-waf-rules.yaml
   - external-gateway-ratelimit.yaml
+  - external-gateway-security-headers.yaml
   - platform-auth-policy.yaml


### PR DESCRIPTION
## Summary
- Adds browser security headers (HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy) to all external gateway responses via Istio EnvoyFilter
- Headers applied at the gateway level using VIRTUAL_HOST MERGE so all external routes are covered regardless of individual app behavior
- Part of pre-public-exposure security hardening

## Test plan
- [ ] Verify EnvoyFilter is accepted by Istio on integration cluster
- [ ] Confirm security headers present on external gateway responses: `curl -sI https://<app>.<external_domain>/ | grep -iE 'strict-transport|x-content|x-frame|referrer|permissions'`
- [ ] Verify internal gateway responses are unaffected (workloadSelector targets external only)
- [ ] Validate no disruption to existing external routes (WAF, rate limiting, auth)