### PR TITLE
feat(monitoring): enable Loki ruler, WAF detection PL2 observability

### DIFF
--- a/kubernetes/platform/charts/grafana-loki-single-binary.yaml
+++ b/kubernetes/platform/charts/grafana-loki-single-binary.yaml
@@ -27,34 +27,38 @@ loki:
         index:
           prefix: loki_index_
           period: 24h
-  ruler:
-    enable_api: true
+  rulerConfig:
+    wal:
+      dir: /var/loki/ruler-wal
     storage:
       type: local
       local:
-        directory: /var/loki/rules
+        directory: /etc/loki/rules
     alertmanager_url: http://alertmanager-operated.monitoring.svc.cluster.local:9093
     evaluation_interval: 1m
     ring:
       kvstore:
         store: inmemory
-  rulerConfig:
-    alerting_rules:
-      fake:
-        - name: waf-detection
-          interval: 5m
-          rules:
-            - alert: CorazaWAFDetectionAnomaly
-              expr: |
-                sum(count_over_time({namespace="istio-gateway", container="istio-proxy"} |= "Coraza" [5m])) > 50
-              for: 10m
-              labels:
-                severity: warning
-              annotations:
-                summary: "Coraza WAF PL2 detection rules firing frequently"
-                description: "More than 50 WAF detection-only matches in 5 minutes. Review Grafana WAF dashboard to identify false positives before promoting PL2 to blocking."
   limits_config:
     retention_period: 14d
+ruler:
+  enabled: true
+  directories:
+    fake:
+      rules.yaml: |
+        groups:
+          - name: waf-detection
+            interval: 5m
+            rules:
+              - alert: CorazaWAFDetectionAnomaly
+                expr: |
+                  sum(count_over_time({namespace="istio-gateway", container="istio-proxy"} |= "Coraza" [5m])) > 50
+                for: 10m
+                labels:
+                  severity: warning
+                annotations:
+                  summary: "Coraza WAF PL2 detection rules firing frequently"
+                  description: "More than 50 WAF detection-only matches in 5 minutes. Review Grafana WAF dashboard to identify false positives before promoting PL2 to blocking."
 singleBinary:
   replicas: 1
   priorityClassName: platform

--- a/kubernetes/platform/charts/grafana-loki-single-binary.yaml
+++ b/kubernetes/platform/charts/grafana-loki-single-binary.yaml
@@ -27,6 +27,32 @@ loki:
         index:
           prefix: loki_index_
           period: 24h
+  ruler:
+    enable_api: true
+    storage:
+      type: local
+      local:
+        directory: /var/loki/rules
+    alertmanager_url: http://alertmanager-operated.monitoring.svc.cluster.local:9093
+    evaluation_interval: 1m
+    ring:
+      kvstore:
+        store: inmemory
+  rulerConfig:
+    alerting_rules:
+      fake:
+        - name: waf-detection
+          interval: 5m
+          rules:
+            - alert: CorazaWAFDetectionAnomaly
+              expr: |
+                sum(count_over_time({namespace="istio-gateway", container="istio-proxy"} |= "Coraza" [5m])) > 50
+              for: 10m
+              labels:
+                severity: warning
+              annotations:
+                summary: "Coraza WAF PL2 detection rules firing frequently"
+                description: "More than 50 WAF detection-only matches in 5 minutes. Review Grafana WAF dashboard to identify false positives before promoting PL2 to blocking."
   limits_config:
     retention_period: 14d
 singleBinary:

--- a/kubernetes/platform/config/gateway/coraza-wasm-plugin.yaml
+++ b/kubernetes/platform/config/gateway/coraza-wasm-plugin.yaml
@@ -28,6 +28,8 @@ spec:
           HEAD POST OPTIONS PUT PATCH DELETE'"
         - SecAction
           "id:900002,phase:1,pass,t:none,nolog,setvar:tx.inbound_anomaly_score_threshold=10"
+        - SecAction
+          "id:900003,phase:1,pass,t:none,nolog,setvar:tx.detection_paranoia_level=2"
         - Include @owasp_crs/*.conf
         - SecRuleEngine On
         - SecRule REQUEST_URI "@beginsWith /api/assets" "id:9000003,phase:1,pass,nolog,ctl:requestBodyAccess=Off"


### PR DESCRIPTION
## Summary

- **Enables Loki ruler** (alerting from logs) in SingleBinary mode with local filesystem storage and inmemory kvstore. Routes alerts through existing Alertmanager at `alertmanager-operated.monitoring.svc.cluster.local:9093`, flowing into the Discord notification pipeline.
- **Bumps Coraza WAF detection paranoia to level 2** (`tx.detection_paranoia_level=2`) while keeping blocking at PL1. PL2 rules fire and log but do not contribute to blocking score -- production safety unchanged.
- **Adds Loki alert rule** (`CorazaWAFDetectionAnomaly`) that fires when more than 50 WAF detection matches occur in a 5-minute window (sustained for 10 minutes). This surfaces PL2 rule activity for review before promoting to blocking enforcement.

**Purpose:** Observe PL2 rule behavior in production traffic before promoting to blocking. Part of pre-public-exposure security hardening.

## Test plan

- [ ] Verify Loki ruler starts successfully in SingleBinary mode (`kubectl logs` for ruler initialization)
- [ ] Confirm Alertmanager connectivity from Loki ruler (check ruler logs for alert dispatch)
- [ ] Verify Coraza WAF still blocks PL1 violations (SQLi/XSS test against external gateway)
- [ ] Confirm PL2 detection rules are logging (check istio-proxy logs on external gateway pods for Coraza detection entries)
- [ ] Validate Loki alert rule appears in ruler (`/loki/api/v1/rules` endpoint)
- [ ] Tune LogQL query if needed based on actual Coraza log format in cluster