### PR TITLE
feat(media): restrict JFA-Go external access to invite paths

### DIFF
--- a/kubernetes/clusters/live/config/media/jfa-go-external.yaml
+++ b/kubernetes/clusters/live/config/media/jfa-go-external.yaml
@@ -18,6 +18,86 @@ spec:
   hostnames:
     - "join.${external_domain}"
   rules:
-    - backendRefs:
+    # Invite redemption pages
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /invite
+      backendRefs:
         - name: jfa-go
           port: 8056
+    # User self-service account pages
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /my
+      backendRefs:
+        - name: jfa-go
+          port: 8056
+    # Account creation API (POST from invite form)
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /user
+      backendRefs:
+        - name: jfa-go
+          port: 8056
+    # CAPTCHA generation and validation for invite forms
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /captcha
+      backendRefs:
+        - name: jfa-go
+          port: 8056
+    # Auth token login and refresh
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /token
+      backendRefs:
+        - name: jfa-go
+          port: 8056
+    # Language files for invite and user pages
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /lang
+      backendRefs:
+        - name: jfa-go
+          port: 8056
+    # Static assets (JS/CSS) required by invite and user pages
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /js
+      backendRefs:
+        - name: jfa-go
+          port: 8056
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /css
+      backendRefs:
+        - name: jfa-go
+          port: 8056
+    # Password reset page
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /reset
+      backendRefs:
+        - name: jfa-go
+          port: 8056
+    # Redirect everything else (admin panel, admin APIs) to invite page
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /invite
+            statusCode: 302

--- a/kubernetes/clusters/live/config/media/jfa-go-internal.yaml
+++ b/kubernetes/clusters/live/config/media/jfa-go-internal.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: jfa-go-internal
+  namespace: media
+spec:
+  parentRefs:
+    - name: internal
+      namespace: istio-gateway
+  hostnames:
+    - "jfa-go.${internal_domain}"
+  rules:
+    - backendRefs:
+        - name: jfa-go
+          port: 8056

--- a/kubernetes/clusters/live/config/media/kustomization.yaml
+++ b/kubernetes/clusters/live/config/media/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - bazarr-internal.yaml
   - jfa-go-external.yaml
+  - jfa-go-internal.yaml
   - jellyfin-external.yaml
   - jellyseerr-external.yaml
   - tdarr-internal.yaml


### PR DESCRIPTION
## Summary

- Restrict JFA-Go's external route (`join.${external_domain}`) to only expose paths needed for invite redemption, blocking the admin panel and admin APIs from external access
- Add an internal route (`jfa-go.${internal_domain}`) for full admin access from the home network
- Part of pre-public-exposure security hardening

## Path Structure (from JFA-Go source)

JFA-Go serves its admin dashboard at `/` (root path, `PAGES.Admin` defaults to empty string). The invite form lives at `/invite/:invCode`. This clean separation makes an allowlist approach viable.

**Allowed externally** (user-facing):
| Path | Purpose |
|------|---------|
| `/invite` | Invite redemption pages |
| `/my` | User self-service account management |
| `/user` | Account creation API (POST from invite form) |
| `/captcha` | CAPTCHA generation/validation for invites |
| `/token` | Auth token login/refresh |
| `/lang` | Language/localization files |
| `/js`, `/css` | Static assets needed by invite pages |
| `/reset` | Password reset page |

**Blocked externally** (redirected to `/invite` with 302):
| Path | Purpose |
|------|---------|
| `/` | Admin dashboard |
| `/users/*` | User management API |
| `/invites/*` | Invite management API |
| `/profiles/*` | Profile management API |
| `/config/*` | Configuration API |
| `/tasks/*`, `/backups/*`, `/activity/*` | System admin APIs |

## Test plan

- [ ] Verify invite links still work externally at `join.${external_domain}/invite/<code>`
- [ ] Verify accessing `join.${external_domain}/` redirects to `/invite` (302)
- [ ] Verify admin API paths (e.g., `/users`, `/config`) redirect to `/invite`
- [ ] Verify static assets (JS/CSS) load correctly on invite pages
- [ ] Verify full admin panel is accessible at `jfa-go.${internal_domain}` internally