### PR TITLE
feat(game-servers): harden container security contexts

### DIFF
--- a/kubernetes/clusters/live/charts/minecraft.yaml
+++ b/kubernetes/clusters/live/charts/minecraft.yaml
@@ -45,6 +45,13 @@ controllers:
           # Container runs as UID 1000 internally via gosu
           UID: "1000"
           GID: "1000"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
         resources:
           requests:
             cpu: 500m
@@ -98,6 +105,13 @@ controllers:
           SRC_DIR: /data/world
           DEST_DIR: /backups
           BACKUP_METHOD: tar
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
         resources:
           requests:
             cpu: 50m

--- a/kubernetes/clusters/live/charts/satisfactory.yaml
+++ b/kubernetes/clusters/live/charts/satisfactory.yaml
@@ -22,6 +22,13 @@ controllers:
           MAXPLAYERS: "4"
           MAXTICKRATE: "30"
           AUTOSAVENUM: "5"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
         resources:
           requests:
             cpu: 500m

--- a/kubernetes/clusters/live/charts/valheim.yaml
+++ b/kubernetes/clusters/live/charts/valheim.yaml
@@ -44,6 +44,13 @@ controllers:
           BACKUPS_MAX_COUNT: "10"
           BACKUPS_IF_IDLE: "true"
           BACKUPS_IDLE_GRACE_PERIOD: "3600"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
## Summary

- Adds `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, and `runAsNonRoot: true` to Minecraft (both app and backup containers), Valheim, and Satisfactory game server containers
- Sets `runAsUser: 1000` / `runAsGroup: 1000` matching each server's existing UID/GID configuration
- Matches the existing Factorio container security context pattern
- Part of pre-public-exposure security hardening for game server port forwarding

## Test plan

- [ ] Verify Minecraft server starts and accepts connections on port 25565 (Java) and 19132 (Bedrock)
- [ ] Verify Minecraft backup sidecar runs successfully
- [ ] Verify Valheim server starts and accepts connections on port 2456
- [ ] Verify Satisfactory server starts and accepts connections on port 7777
- [ ] Confirm no CrashLoopBackOff or permission errors in pod logs