### PR TITLE
feat(security): promote cache, garage-system, factorio to restricted PSS; media to baseline

### DIFF
--- a/kubernetes/clusters/live/config/factorio/namespace.yaml
+++ b/kubernetes/clusters/live/config/factorio/namespace.yaml
@@ -5,7 +5,7 @@ metadata:
   name: factorio
   labels:
     istio.io/dataplane-mode: ambient
-    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/warn: restricted
     network-policy.homelab/profile: internal-egress

--- a/kubernetes/clusters/live/config/media-prereqs/namespace.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/namespace.yaml
@@ -5,7 +5,7 @@ metadata:
   name: media
   labels:
     istio.io/dataplane-mode: ambient
-    pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/audit: baseline
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
     network-policy.homelab/profile: standard

--- a/kubernetes/platform/namespaces.yaml
+++ b/kubernetes/platform/namespaces.yaml
@@ -42,20 +42,20 @@ spec:
       dataplane: ambient
       security: restricted
       networkPolicy: false
-    # --- baseline: require some elevated capabilities (e.g. NET_BIND_SERVICE) ---
     - name: cache
       dataplane: ambient
-      security: baseline
+      security: restricted
       networkPolicy: false
+    - name: garage-system
+      dataplane: ambient
+      security: restricted
+      networkPolicy: false
+    # --- baseline: require some elevated capabilities (e.g. NET_BIND_SERVICE) ---
     - name: istio-gateway
       dataplane: ambient
       security: baseline
       networkPolicy: false
     - name: garage
-      dataplane: ambient
-      security: baseline
-      networkPolicy: false
-    - name: garage-system
       dataplane: ambient
       security: baseline
       networkPolicy: false


### PR DESCRIPTION
## Summary
- Promotes cache, garage-system, factorio from baseline to restricted PSS enforcement (live audit confirms all pods already comply)
- Drops media-prereqs from privileged to baseline (only gluetun NET_ADMIN needed, allowed under baseline)

## Changes
- `kubernetes/platform/namespaces.yaml` — cache and garage-system moved to restricted security group
- `kubernetes/clusters/live/config/factorio/namespace.yaml` — enforce: restricted
- `kubernetes/clusters/live/config/media-prereqs/namespace.yaml` — enforce: baseline (was privileged)

## Test plan
- [ ] Verify pods in cache, garage-system, factorio namespaces restart successfully after merge
- [ ] Verify qBittorrent/gluetun VPN pod starts in media-prereqs namespace (NET_ADMIN under baseline)
- [ ] Check for PSS admission rejection events: `kubectl get events --field-selector reason=FailedCreate`