### PR TITLE
feat(security): harden firefly, it-tools, booter and promote to restricted PSS

### DIFF
--- a/kubernetes/clusters/live/charts/booter.yaml
+++ b/kubernetes/clusters/live/charts/booter.yaml
@@ -19,9 +19,14 @@ controllers:
           limits:
             memory: 256Mi
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
+            drop: ["ALL"]
             add:
               - NET_BIND_SERVICE
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
 
 defaultPodOptions:
   affinity:

--- a/kubernetes/clusters/live/charts/firefly.yaml
+++ b/kubernetes/clusters/live/charts/firefly.yaml
@@ -10,6 +10,13 @@ controllers:
 
     containers:
       app:
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         image:
           repository: fireflyiii/core
           tag: ${firefly_version}

--- a/kubernetes/clusters/live/charts/it-tools.yaml
+++ b/kubernetes/clusters/live/charts/it-tools.yaml
@@ -8,6 +8,13 @@ controllers:
 
     containers:
       app:
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         image:
           repository: ghcr.io/corentinth/it-tools
           tag: "${it_tools_version}"

--- a/kubernetes/clusters/live/config/booter/namespace.yaml
+++ b/kubernetes/clusters/live/config/booter/namespace.yaml
@@ -5,7 +5,7 @@ metadata:
   name: booter
   labels:
     istio.io/dataplane-mode: ambient
-    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/warn: restricted
     network-policy.homelab/profile: isolated

--- a/kubernetes/clusters/live/config/firefly/namespace.yaml
+++ b/kubernetes/clusters/live/config/firefly/namespace.yaml
@@ -5,8 +5,8 @@ metadata:
   name: firefly
   labels:
     istio.io/dataplane-mode: ambient
-    pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/audit: baseline
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
     network-policy.homelab/profile: standard
     access.network-policy.homelab/postgres: "true"

--- a/kubernetes/clusters/live/config/it-tools/namespace.yaml
+++ b/kubernetes/clusters/live/config/it-tools/namespace.yaml
@@ -5,7 +5,7 @@ metadata:
   name: it-tools
   labels:
     istio.io/dataplane-mode: ambient
-    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/warn: restricted
     network-policy.homelab/profile: internal


### PR DESCRIPTION
## Summary
- Adds container security contexts to firefly, it-tools, booter (runAsNonRoot, drop ALL caps, no privilege escalation, seccomp RuntimeDefault)
- Promotes all 3 namespaces from baseline to restricted PSS enforcement
- Homepage excluded — upstream image runs as root, stays baseline

## Changes
- `kubernetes/clusters/live/charts/firefly.yaml` — add container securityContext
- `kubernetes/clusters/live/charts/it-tools.yaml` — add container securityContext
- `kubernetes/clusters/live/charts/booter.yaml` — add securityContext fields (already had NET_BIND_SERVICE cap, preserved)
- Namespace YAML files — enforce: restricted

## Test plan
- [ ] Verify firefly, it-tools, booter pods restart successfully
- [ ] Check for PSS admission rejection events
- [ ] Verify booter TFTP still works (needs NET_BIND_SERVICE, allowed under restricted)