### PR TITLE
fix: revert broken hardening changes (valheim, minecraft backup, loki ruler)

### DIFF
--- a/kubernetes/clusters/live/charts/minecraft.yaml
+++ b/kubernetes/clusters/live/charts/minecraft.yaml
@@ -105,13 +105,6 @@ controllers:
           SRC_DIR: /data/world
           DEST_DIR: /backups
           BACKUP_METHOD: tar
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: [ALL]
-          runAsUser: 1000
-          runAsGroup: 1000
-          runAsNonRoot: true
         resources:
           requests:
             cpu: 50m

--- a/kubernetes/clusters/live/charts/valheim.yaml
+++ b/kubernetes/clusters/live/charts/valheim.yaml
@@ -44,13 +44,6 @@ controllers:
           BACKUPS_MAX_COUNT: "10"
           BACKUPS_IF_IDLE: "true"
           BACKUPS_IDLE_GRACE_PERIOD: "3600"
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: [ALL]
-          runAsUser: 1000
-          runAsGroup: 1000
-          runAsNonRoot: true
         resources:
           requests:
             cpu: "4"

--- a/kubernetes/platform/charts/grafana-loki-single-binary.yaml
+++ b/kubernetes/platform/charts/grafana-loki-single-binary.yaml
@@ -41,24 +41,6 @@ loki:
         store: inmemory
   limits_config:
     retention_period: 14d
-ruler:
-  enabled: true
-  directories:
-    fake:
-      rules.yaml: |
-        groups:
-          - name: waf-detection
-            interval: 5m
-            rules:
-              - alert: CorazaWAFDetectionAnomaly
-                expr: |
-                  sum(count_over_time({namespace="istio-gateway", container="istio-proxy"} |= "Coraza" [5m])) > 50
-                for: 10m
-                labels:
-                  severity: warning
-                annotations:
-                  summary: "Coraza WAF PL2 detection rules firing frequently"
-                  description: "More than 50 WAF detection-only matches in 5 minutes. Review Grafana WAF dashboard to identify false positives before promoting PL2 to blocking."
 singleBinary:
   replicas: 1
   priorityClassName: platform


### PR DESCRIPTION
## Summary
Fixes three regressions from the security hardening PRs:

- **Valheim** — revert container securityContext. Image requires root for chown, supervisord, timezone writes. CrashLoopBackOff without root.
- **Minecraft backup** — revert backup container securityContext. Lock file permission denied on `/backups` volume (owned by different UID). App container security context kept (working fine).
- **Loki ruler** — remove `ruler.directories` and `ruler.enabled`. Chart generates ConfigMap name `grafana-loki-single-binary-single-binary-rules-fake` but never creates it, blocking pod creation for 6+ hours. `rulerConfig` kept for when rules are added correctly.

## What's preserved
- Minecraft app container still hardened (runAsNonRoot, drop ALL, no priv escalation)
- Satisfactory + Factorio hardening working fine
- Coraza WAF detection_paranoia_level=2 still active
- Loki rulerConfig (alertmanager_url, storage, ring) still configured — just no rules loaded yet

## Test plan
- [ ] Valheim pod starts and enters Running state
- [ ] Minecraft backup container starts and writes lock file successfully
- [ ] Loki pod starts (no more FailedMount on rules-fake ConfigMap)
- [ ] Alloy resumes (depends on Loki HelmRelease being ready)