### PR TITLE
feat(longhorn): enable orphan cleanup, snapshot limits, and storage reserve

### DIFF
--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -24,7 +24,7 @@ defaultSettings:
   storageMinimalAvailablePercentage: 10
   orphanAutoDeletion: true
   autoCleanupSystemGeneratedSnapshot: true
-  snapshotMaxCount: 5
+  snapshotMaxCount: 3
 csi:
   attacherReplicaCount: ${default_replica_count}
   provisionerReplicaCount: ${default_replica_count}

--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -18,10 +18,13 @@ persistence:
 defaultSettings:
   defaultReplicaCount: ${default_replica_count}
   createDefaultDiskLabeledNodes: true
-  storageReservedPercentageForDefaultDisk: 0
+  storageReservedPercentageForDefaultDisk: 10
   nodeDownPodDeletionPolicy: delete-both-statefulset-and-deployment-pod
   storageOverProvisioningPercentage: 500
   storageMinimalAvailablePercentage: 10
+  orphanAutoDeletion: true
+  autoCleanupSystemGeneratedSnapshot: true
+  snapshotMaxCount: 5
 csi:
   attacherReplicaCount: ${default_replica_count}
   provisionerReplicaCount: ${default_replica_count}


### PR DESCRIPTION
## Summary

- **Enable orphan auto-deletion** — 275 orphaned replica directories on node41/node42 SSDs never cleaned up, consuming significant space
- **Enable system-generated snapshot auto-cleanup** — ~3 TB of uncleaned system snapshots from failed replica rebuilds accumulated on full SSDs
- **Cap snapshots at 5 per volume** — was unlimited (default 250), media volumes alone had 7 snapshots totaling 3 TB
- **Reserve 10% disk space** — was 0%, allowed Longhorn to schedule SSDs to exactly 100% capacity with no buffer

## Context

Both Kingston 1920GB SSDs (node41, node42) hit 0 bytes free, causing:
- `media-downloads` volume to fault (both replicas stopped)
- SABnzbd CrashLoopBackOff (can't mount faulted volume)
- 22 of 48 Longhorn volumes degraded cluster-wide
- Replica rebuild loop (fail → snapshot → no space → fail)

## Expected Impact

Once reconciled, Longhorn will:
1. Begin async orphan directory cleanup on all nodes
2. Purge system-generated snapshots exceeding the max count
3. Free substantial SSD space, allowing stopped replicas to restart
4. `media-downloads` volume should recover and reattach automatically

## Test plan

- [ ] Verify Longhorn settings applied: `kubectl get settings.longhorn.io -n longhorn-system orphan-auto-deletion -o jsonpath='{.value}'`
- [ ] Monitor SSD space recovery on node41/node42 via Longhorn UI
- [ ] Confirm `media-downloads` volume transitions from faulted → attached
- [ ] Confirm SABnzbd pod starts successfully
- [ ] Verify no unexpected snapshot deletions on database/config volumes