### PR TITLE
feat(infrastructure): add node44 as live cluster worker node

### DIFF
--- a/infrastructure/inventory.hcl
+++ b/infrastructure/inventory.hcl
@@ -229,8 +229,8 @@ locals {
       }]
     }
     node44 = { // Supermicro 8C@2.1GHz 32Gi
-      cluster = "none"
-      type    = "none"
+      cluster = "live"
+      type    = "worker"
       install = {
         selector = "disk.model == 'Micron_5100_MTFD'"
       }


### PR DESCRIPTION
## Summary

- Assigns node44 (Supermicro 8C@2.1GHz 32Gi) to the live cluster as a worker node
- Adds 960GB of fast SSD capacity (2x 480GB Kingston, tagged fast/ssd/any) to relieve storage pressure
- Motivated by SSD exhaustion on node41/node42 (1920GB each at 0 bytes free) causing Longhorn volume faults
- node44 was already fully defined in inventory but inactive (cluster=none, type=none)

## Test plan

- [ ] Review diff confirms only `cluster` and `type` fields changed for node44
- [ ] `task tg:plan-live` shows node44 added to the live cluster with expected Talos config, network, and Longhorn disk resources
- [ ] `task tg:apply-live` after merge to provision node44 into the live cluster
- [ ] Verify node44 joins the cluster: `kubectl --context live get nodes`
- [ ] Verify Longhorn discovers the two Kingston SSDs on node44