### PR TITLE
feat(media): move media-downloads PVC to slow (HDD) storage

### DIFF
--- a/kubernetes/clusters/live/config/media-prereqs/media-downloads-pvc.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/media-downloads-pvc.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: fast
+  storageClassName: slow
   resources:
     requests:
       storage: 1Ti


### PR DESCRIPTION
## Summary

- Move `media-downloads` PVC from `fast` (SSD) to `slow` (HDD) storage class
- 1 TiB RWX scratch volume for downloads doesn't need SSD performance
- Frees ~1 TB per replica from overcommitted SSDs on node41/node42

## Operational Steps Required

After merge, manual intervention is needed since Kubernetes cannot change StorageClass on an existing PVC:

1. Scale down all 6 deployments using the volume:
   ```
   k --context live -n media scale deployment sabnzbd qbittorrent sonarr sonarr4k radarr radarr4k --replicas=0
   ```
2. Delete the faulted PVC and its backing PV:
   ```
   k --context live -n media delete pvc media-downloads
   k --context live delete pv pvc-774a6777-2726-4a05-8a72-be4079669f1d
   ```
3. Flux recreates the PVC on `slow` storage class
4. Scale deployments back up (or let Flux reconcile them)
5. Clean up stale queue items in SABnzbd and qBittorrent UIs

## Impact

- Brief downtime for media download pipeline (sonarr, radarr, sabnzbd, qbittorrent)
- In-progress downloads lost (re-grabbable from indexers)
- No impact on media library, databases, or app configs (separate PVCs)

## Test plan

- [ ] Verify new PVC created with `slow` storage class
- [ ] Verify Longhorn volume replicas placed on HDD disks
- [ ] Verify SABnzbd pod starts and can write to /media/downloads
- [ ] Verify sonarr/radarr can access /media/downloads
