### PR TITLE
fix(monitoring): resolve Prometheus rule evaluation timeouts

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -59,11 +59,12 @@ prometheus:
       - memory-snapshot-on-shutdown
     retention: 14d
     retentionSize: ${prometheus_retention_size}
+    queryTimeout: 5m
     resources:
       requests:
         cpu: 100m
       limits:
-        memory: 2000Mi
+        memory: 8Gi
     storageSpec:
       volumeClaimTemplate:
         spec:

--- a/kubernetes/platform/config/canary-checker/prometheus-rules.yaml
+++ b/kubernetes/platform/config/canary-checker/prometheus-rules.yaml
@@ -45,6 +45,7 @@ spec:
               last 15 minutes. Investigate potential intermittent issues.
 
     - name: canary-checker.sla
+      interval: 5m
       rules:
         - record: canary:availability:1h
           expr: |


### PR DESCRIPTION
## Summary

- **Add `interval: 5m` to `canary-checker.sla` rule group** — 30d availability recording rules were evaluating every 15s (global default), causing missed evaluations since each eval takes 200s+
- **Increase Prometheus memory limit to 8Gi** — was at 88% of 2Gi, insufficient for loading TSDB blocks during long-range queries (30d over 5,672 apiserver histogram series)
- **Increase query timeout to 5m** — 30d aggregations consistently hit the 2m ceiling with "context deadline exceeded"

Resolves `PrometheusRuleFailures` (critical) and `PrometheusMissingRuleEvaluations` (warning) alerts on live cluster.

## Test plan

- [ ] Verify Prometheus pod restarts successfully with new 8Gi limit
- [ ] Confirm `canary-checker.sla` group shows 5m interval in Prometheus rules UI
- [ ] Monitor `prometheus_rule_group_last_duration_seconds` for canary-checker.sla — should stay under 300s
- [ ] Confirm `PrometheusRuleFailures` and `PrometheusMissingRuleEvaluations` alerts clear within ~10m of rollout