### PR TITLE
fix(live): open-webui liveness probe and jfa-go canary

### DIFF
--- a/kubernetes/clusters/live/charts/open-webui.yaml
+++ b/kubernetes/clusters/live/charts/open-webui.yaml
@@ -96,7 +96,7 @@ startupProbe:
 
 livenessProbe:
   httpGet:
-    path: /health
+    path: /health/db
     port: http
   periodSeconds: 30
 

--- a/kubernetes/clusters/live/config/media/canary-jfa-go.yaml
+++ b/kubernetes/clusters/live/config/media/canary-jfa-go.yaml
@@ -9,7 +9,7 @@ spec:
   schedule: "@every 1m"
   http:
     - name: external-gateway-health
-      url: https://join.${external_domain}/invite
+      url: https://join.${external_domain}/my/account
       responseCodes: [200]
       maxSSLExpiry: 7
       thresholdMillis: 5000

--- a/kubernetes/clusters/live/config/media/canary-jfa-go.yaml
+++ b/kubernetes/clusters/live/config/media/canary-jfa-go.yaml
@@ -10,6 +10,6 @@ spec:
   http:
     - name: external-gateway-health
       url: https://join.${external_domain}/
-      responseCodes: [200]
+      responseCodes: [200, 302]
       maxSSLExpiry: 7
       thresholdMillis: 5000

--- a/kubernetes/clusters/live/config/media/canary-jfa-go.yaml
+++ b/kubernetes/clusters/live/config/media/canary-jfa-go.yaml
@@ -9,7 +9,7 @@ spec:
   schedule: "@every 1m"
   http:
     - name: external-gateway-health
-      url: https://join.${external_domain}/
-      responseCodes: [200, 302]
+      url: https://join.${external_domain}/invite
+      responseCodes: [200]
       maxSSLExpiry: 7
       thresholdMillis: 5000


### PR DESCRIPTION
## Summary

- **open-webui liveness probe → `/health/db`**: Pod currently enters permanent `PendingRollbackError` state after any transient DB failure but never restarts because liveness probe (`/health`) passes while only readiness (`/health/db`) fails. Changing liveness to also check DB ensures auto-restart on stuck sessions.
- **jfa-go canary accepts 302**: HTTPRoute redirects `/` → `/invite`, so root path legitimately returns 302. Canary was failing 100% for 9 days.

## Context

- open-webui upstream bug: [Discussion #18936](https://github.com/open-webui/open-webui/discussions/18936) — `ScopedSession` lacks `rollback()` on error. `pool_pre_ping=True` is already set but doesn't help stuck transactions.
- Startup probe remains on `/health` (no DB check during startup) to avoid restart loops during initial DB migration.

## Test plan

- [ ] Verify open-webui pod restarts automatically when DB session is broken (liveness fails → kubelet kills pod)
- [ ] Verify startup probe still allows healthy boot (initial migration period uses /health, not /health/db)
- [ ] Confirm jfa-go canary transitions to passing after deploy