### PR TITLE
fix(monitoring): organize Grafana dashboards into folders and remove dead entries

### DIFF
--- a/kubernetes/platform/charts/cloudnative-pg.yaml
+++ b/kubernetes/platform/charts/cloudnative-pg.yaml
@@ -8,6 +8,8 @@ monitoring:
   podMonitorEnabled: true
   grafanaDashboard:
     create: true
+    annotations:
+      grafana_folder: "Database"
 resources:
   requests:
     cpu: 10m

--- a/kubernetes/platform/charts/dragonfly-operator.yaml
+++ b/kubernetes/platform/charts/dragonfly-operator.yaml
@@ -26,3 +26,4 @@ serviceMonitor:
 
 grafanaDashboard:
   enabled: true
+  folder: Database

--- a/kubernetes/platform/charts/grafana.yaml
+++ b/kubernetes/platform/charts/grafana.yaml
@@ -127,14 +127,6 @@ dashboardProviders:
         editable: true
         options:
           path: /var/lib/grafana/dashboards/database
-      - name: power
-        orgId: 1
-        folder: Power
-        type: file
-        disableDeletion: false
-        editable: true
-        options:
-          path: /var/lib/grafana/dashboards/power
       - name: sre
         orgId: 1
         folder: SRE
@@ -193,12 +185,6 @@ dashboards:
       url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/control-plane.json
       datasource: Prometheus
   network:
-    cloudflared:
-      # renovate: depName="Cloudflare Tunnels (cloudflared)"
-      gnetId: 17457
-      revision: 6
-      datasource:
-        - { name: DS_PROMETHEUS, value: Prometheus }
     istio-mesh:
       url: https://raw.githubusercontent.com/istio/istio/master/manifests/addons/dashboards/istio-mesh-dashboard.gen.json
       datasource: Prometheus
@@ -273,26 +259,13 @@ dashboards:
       revision: 2
       datasource: Prometheus
   applications:
-    miniflux:
-      url: https://raw.githubusercontent.com/miniflux/v2/main/contrib/grafana/dashboard.json
-      datasource: Prometheus
     exportarr:
       url: https://raw.githubusercontent.com/onedr0p/exportarr/master/examples/grafana/dashboard2.json
-      datasource: Prometheus
-    unpackerr:
-      # renovate: depName="Unpackerr"
-      gnetId: 18817
-      revision: 1
       datasource: Prometheus
   platform-services:
     cert-manager:
       # renovate: depName="Cert-manager-Kubernetes"
       gnetId: 20842
-      revision: 3
-      datasource: Prometheus
-    external-dns:
-      # renovate: depName="External-dns"
-      gnetId: 15038
       revision: 3
       datasource: Prometheus
     external-secrets:
@@ -317,12 +290,6 @@ dashboards:
     dragonfly:
       # renovate: depName="Dragonfly"
       gnetId: 11692
-      revision: 1
-      datasource: Prometheus
-  power:
-    apc-ups-snmp:
-      # renovate: depName="APC UPS (SNMP)"
-      gnetId: 12340
       revision: 1
       datasource: Prometheus
   sre:

--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -106,6 +106,10 @@ kube-state-metrics:
 grafana:
   enabled: false
   forceDeployDashboards: true
+  sidecar:
+    dashboards:
+      annotations:
+        grafana_folder: "Kubernetes"
 defaultRules:
   create: true
   disabled:


### PR DESCRIPTION
## Summary

- Add `grafana_folder: "Kubernetes"` sidecar annotation to kube-prometheus-stack, moving 30 built-in dashboard ConfigMaps from Grafana root into the "Kubernetes" folder
- Add `grafana_folder: "Database"` annotation to cloudnative-pg operator dashboard ConfigMap
- Set `folder: Database` on dragonfly-operator dashboard ConfigMap (chart uses its own `folder` value for the `grafana_folder` annotation)
- Remove dead dashboard entries from Grafana helm values: miniflux, unpackerr, external-dns, cloudflared, APC UPS (SNMP)
- Remove unused `power` dashboard provider (power-accounting-dashboard ConfigMap uses sidecar `grafana_folder` annotation directly)

### Operator charts without folder annotation support (not changed)

- **canary-checker**: only exposes a boolean `grafanaDashboards: true` with no annotation/folder options
- **garage-operator**: only exposes `grafanaDashboard.labels` and `grafanaDashboard.namespace`, no annotation support

## Test plan

- [ ] Verify `task k8s:validate` passes (confirmed locally)
- [ ] After merge, confirm kube-prometheus-stack dashboards appear under "Kubernetes" folder in Grafana
- [ ] Confirm cloudnative-pg dashboard appears under "Database" folder
- [ ] Confirm dragonfly-operator dashboard appears under "Database" folder
- [ ] Confirm removed dashboards (miniflux, unpackerr, external-dns, cloudflared, APC UPS) no longer appear
- [ ] Confirm power-accounting-dashboard still appears under "Power" folder via its ConfigMap annotation