### PR TITLE
feat(monitoring): add metrics for vaultwarden, qbittorrent, and minecraft

### DIFF
--- a/kubernetes/clusters/live/charts/minecraft.yaml
+++ b/kubernetes/clusters/live/charts/minecraft.yaml
@@ -119,6 +119,37 @@ controllers:
           readiness:
             enabled: false
 
+      monitor:
+        image:
+          repository: itzg/mc-monitor
+          tag: "${mc_monitor_version}"
+        args:
+          - export-for-prometheus
+        env:
+          EXPORT_SERVERS: "localhost"
+          DEBUG: "false"
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 128Mi
+        probes:
+          startup:
+            enabled: false
+          liveness:
+            enabled: false
+          readiness:
+            enabled: false
+
 service:
   game:
     controller: minecraft
@@ -135,6 +166,20 @@ service:
       rcon:
         port: 25575
         protocol: TCP
+
+  metrics:
+    controller: minecraft
+    ports:
+      metrics:
+        port: 8080
+
+serviceMonitor:
+  metrics:
+    serviceName: minecraft-metrics
+    endpoints:
+      - port: metrics
+        interval: 60s
+        scrapeTimeout: 30s
 
 persistence:
   data:

--- a/kubernetes/clusters/live/charts/qbittorrent.yaml
+++ b/kubernetes/clusters/live/charts/qbittorrent.yaml
@@ -40,7 +40,7 @@ controllers:
           DNS_KEEP_NAMESERVER: "on"
           DOT: "off"
           FIREWALL_OUTBOUND_SUBNETS: "172.18.0.0/16,172.19.0.0/16,192.168.10.0/24"
-          FIREWALL_INPUT_PORTS: "8080,9999"
+          FIREWALL_INPUT_PORTS: "8080,8090,9999"
           HEALTH_SERVER_ADDRESS: "0.0.0.0:9999"
         securityContext:
           runAsUser: 0
@@ -123,6 +123,55 @@ controllers:
                 port: 8080
               periodSeconds: 10
 
+      metrics:
+        image:
+          repository: ghcr.io/martabal/qbittorrent-exporter
+          tag: "${qbittorrent_exporter_version}"
+        env:
+          QBITTORRENT_BASE_URL: "http://localhost:8080"
+          EXPORTER_PORT: "8090"
+        securityContext:
+          runAsUser: 568
+          runAsGroup: 568
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 128Mi
+        probes:
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /metrics
+                port: 8090
+              initialDelaySeconds: 30
+              periodSeconds: 5
+              failureThreshold: 30
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /metrics
+                port: 8090
+              periodSeconds: 30
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /metrics
+                port: 8090
+              periodSeconds: 10
+
 service:
   app:
     controller: qbittorrent
@@ -131,6 +180,16 @@ service:
         port: 8080
       health:
         port: 9999
+      metrics:
+        port: 8090
+
+serviceMonitor:
+  app:
+    serviceName: qbittorrent-app
+    endpoints:
+      - port: metrics
+        interval: 60s
+        scrapeTimeout: 30s
 
 persistence:
   config:

--- a/kubernetes/clusters/live/charts/vaultwarden.yaml
+++ b/kubernetes/clusters/live/charts/vaultwarden.yaml
@@ -59,6 +59,12 @@ controllers:
                 name: vaultwarden-oidc-client-secret
                 key: client-secret
           SSO_SCOPES: "openid profile email offline_access"
+          ENABLE_METRICS: "true"
+          METRICS_TOKEN:
+            valueFrom:
+              secretKeyRef:
+                name: vaultwarden-metrics-token
+                key: token
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
@@ -104,6 +110,18 @@ service:
     ports:
       http:
         port: 80
+
+serviceMonitor:
+  app:
+    serviceName: vaultwarden-app
+    endpoints:
+      - port: http
+        interval: 60s
+        scrapeTimeout: 30s
+        path: /metrics
+        bearerTokenSecret:
+          name: vaultwarden-metrics-token
+          key: token
 
 persistence:
   data:

--- a/kubernetes/clusters/live/config/vaultwarden/kustomization.yaml
+++ b/kubernetes/clusters/live/config/vaultwarden/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - namespace.yaml
   - vaultwarden-admin-token.yaml
   - vaultwarden-db-credentials.yaml
+  - vaultwarden-metrics-token.yaml
   - internal-route.yaml
   - canary.yaml
   - vaultwarden-oidc-client-secret.yaml

--- a/kubernetes/clusters/live/config/vaultwarden/vaultwarden-metrics-token.yaml
+++ b/kubernetes/clusters/live/config/vaultwarden/vaultwarden-metrics-token.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vaultwarden-metrics-token
+  namespace: vaultwarden
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: token
+    secret-generator.v1.mittwald.de/length: "48"
+    secret-generator.v1.mittwald.de/encoding: hex
+data: { }

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -71,6 +71,12 @@ it_tools_version=2024.10.22-7ca5933
 # renovate: datasource=docker depName=firefly-iii packageName=fireflyiii/core versioning=regex:^version-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
 firefly_version=version-6.6.2
 
+# Exporter versions
+# renovate: datasource=docker depName=qbittorrent-exporter packageName=ghcr.io/martabal/qbittorrent-exporter
+qbittorrent_exporter_version=v2.0.1
+# renovate: datasource=docker depName=mc-monitor packageName=itzg/mc-monitor
+mc_monitor_version=0.16.4
+
 # Minecraft versions
 # renovate: datasource=docker depName=minecraft-server packageName=itzg/minecraft-server
 minecraft_server_version=2026.5.2


### PR DESCRIPTION
## Summary
- **Vaultwarden**: Enable native Prometheus metrics (`ENABLE_METRICS=true`) with bearer token auth via secret-generator. ServiceMonitor scrapes `/metrics` on existing HTTP port.
- **Qbittorrent**: Add `martabal/qbittorrent-exporter` sidecar container sharing Gluetun VPN pod network. Exporter on port 8090, added to Gluetun `FIREWALL_INPUT_PORTS`. ServiceMonitor for Prometheus scraping.
- **Minecraft**: Add `itzg/mc-monitor` sidecar alongside existing backup container. Separate ClusterIP metrics service (port 8080) to avoid polluting the LoadBalancer game service. ServiceMonitor attached.

## Changes
- `charts/vaultwarden.yaml` — env vars + ServiceMonitor with bearerTokenSecret
- `charts/qbittorrent.yaml` — metrics sidecar container, firewall port, service port, ServiceMonitor
- `charts/minecraft.yaml` — monitor sidecar, metrics service, ServiceMonitor
- `config/vaultwarden/vaultwarden-metrics-token.yaml` — secret-generator Secret for metrics auth
- `versions.env` — qbittorrent_exporter_version, mc_monitor_version

## Test plan
- [ ] `task k8s:validate` passes (verified locally)
- [ ] After merge: verify `vaultwarden` target appears in Prometheus targets with `up=1`
- [ ] After merge: verify `qbittorrent` exporter target appears (may take time for VPN init)
- [ ] After merge: verify `minecraft` monitor target appears (only when server is running)
- [ ] Confirm no port conflicts on qbittorrent pod (8080 app, 8090 metrics, 9999 health)