### PR TITLE
fix(monitoring): fix broken dashboards and remove dead entries

### DIFF
--- a/kubernetes/platform/charts/grafana.yaml
+++ b/kubernetes/platform/charts/grafana.yaml
@@ -245,9 +245,6 @@ dashboards:
       revision: 2
       datasource:
         - { name: DS_PROMETHEUS, value: Prometheus }
-    node-feature-discovery:
-      url: https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/examples/grafana-dashboard.json
-      datasource: Prometheus
     ipmi-exporter:
       # renovate: depName="IPMI Exporter"
       gnetId: 15765
@@ -280,17 +277,12 @@ dashboards:
       # renovate: depName="Loki Logs Dashboard"
       gnetId: 15324
       revision: 1
-      datasource: Prometheus
+      datasource: Loki
   database:
     cloudnative-pg:
       # renovate: depName="CloudNativePG"
       gnetId: 20417
       revision: 4
-      datasource: Prometheus
-    dragonfly:
-      # renovate: depName="Dragonfly"
-      gnetId: 11692
-      revision: 1
       datasource: Prometheus
   sre:
     kubernetes-capacity-planning:
@@ -302,7 +294,8 @@ dashboards:
       # renovate: depName="Monitoring Golden Signals"
       gnetId: 21073
       revision: 1
-      datasource: Prometheus
+      datasource:
+        - { name: DS_GRAFANACLOUD-RUTU862-PROM, value: Prometheus }
 sidecar:
   dashboards:
     enabled: true


### PR DESCRIPTION
## Summary

Grafana API audit found 16 dead/broken dashboards out of 83 total. This PR fixes the subset not already covered by #1016.

- **Remove Node Feature Discovery dashboard** (hardware folder): No NFD metrics exist in the cluster, dashboard was completely dead
- **Fix Loki Logs dashboard datasource** (platform-services folder): Changed from `Prometheus` to `Loki` -- this dashboard contains LogQL queries that must target the Loki datasource
- **Fix Golden Signals dashboard datasource** (SRE folder): The dashboard references `${DS_GRAFANACLOUD-RUTU862-PROM}` variable which doesn't exist; added explicit datasource mapping to replace the broken variable with the `Prometheus` datasource
- **Remove Dragonfly/Redis dashboard** (database folder): gnetId 11692 is a Redis dashboard using `redis_*` metrics, but Dragonfly exports `dragonfly_*` metrics; the Dragonfly operator already provisions its own dashboard via `grafanaDashboard: enabled: true`

Jellyfin dashboard was investigated but left in place -- its `jellyfin_*` metric names match the jellyfin-exporter, so "No data" is likely a transient issue rather than a structural mismatch.

## Test plan

- [x] `task k8s:validate` passes
- [ ] After merge, verify Loki Logs dashboard loads data from Loki datasource
- [ ] After merge, verify Golden Signals dashboard panels populate correctly
- [ ] Confirm removed dashboards no longer appear in Grafana