### PR TITLE
fix(k8s): resolve runAsNonRoot securityContext conflicts in live charts

### DIFF
--- a/kubernetes/clusters/live/charts/booter.yaml
+++ b/kubernetes/clusters/live/charts/booter.yaml
@@ -26,7 +26,6 @@ controllers:
             drop: ["ALL"]
             add:
               - NET_BIND_SERVICE
-          runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
 

--- a/kubernetes/clusters/live/charts/firefly.yaml
+++ b/kubernetes/clusters/live/charts/firefly.yaml
@@ -15,6 +15,7 @@ controllers:
           capabilities:
             drop: ["ALL"]
           runAsNonRoot: true
+          runAsUser: 33
           seccompProfile:
             type: RuntimeDefault
         image:

--- a/kubernetes/clusters/live/charts/it-tools.yaml
+++ b/kubernetes/clusters/live/charts/it-tools.yaml
@@ -12,7 +12,6 @@ controllers:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
-          runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
         image:


### PR DESCRIPTION
## Summary

Three deployments in the live cluster are stuck in `CreateContainerConfigError` due to `runAsNonRoot: true` being set on images that run as root or use a named (non-numeric) user.

- **booter** (`ghcr.io/siderolabs/booter`): image has no USER directive and runs as root — remove `runAsNonRoot: true`
- **it-tools** (`ghcr.io/corentinth/it-tools`): image runs as root — remove `runAsNonRoot: true`
- **firefly** (`fireflyiii/core`): image uses named user `www-data` — add `runAsUser: 33` (Debian numeric UID) so Kubernetes can verify the non-root constraint alongside the existing `runAsNonRoot: true`

## Test plan

- [ ] Validate passes: `task k8s:validate` (no errors — confirmed locally before commit)
- [ ] After merge, confirm all three pods transition out of `CreateContainerConfigError` and reach `Running` state on the live cluster