### PR TITLE
fix(velero): exclude media-downloads and media-library PVCs from backup

### DIFF
--- a/kubernetes/clusters/live/config/media-prereqs/media-downloads-pvc.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/media-downloads-pvc.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: media-downloads
   namespace: media
+  annotations:
+    velero.io/exclude-from-backup: "true"
 spec:
   accessModes:
     - ReadWriteMany

--- a/kubernetes/clusters/live/config/media-prereqs/media-library-pvc.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/media-library-pvc.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: media-library
   namespace: media
+  annotations:
+    velero.io/exclude-from-backup: "true"
 spec:
   accessModes:
     - ReadWriteMany


### PR DESCRIPTION
## Summary

- Adds `velero.io/exclude-from-backup: "true"` annotation to `media/media-downloads` (1 TiB) and `media/media-library` (10 TiB) PVCs
- These PVCs were causing the Velero `default` schedule to `PartiallyFail`: `media-downloads` is ephemeral download cache (re-downloadable, no value in backing up), and `media-library` at 10 TiB exceeds Velero's prepare timeout
- The `media` namespace remains in the `default` schedule scope so other resources in that namespace (secrets, configmaps, etc.) continue to be backed up

## Test plan

- [ ] After merge, trigger or wait for the next Velero `default` schedule run (`kubectl get schedule default -n velero`)
- [ ] Verify backup completes without `PartiallyFailed` status: `kubectl get backups -n velero --sort-by=.metadata.creationTimestamp`
- [ ] Confirm the two PVCs are absent from the backup's included volumes