### PR TITLE
docs(claude): require push -u after worktree branch creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Require explicit human approval:
 - No force push or history rewriting
 - Always use PR workflow
 - Use isolated worktrees for changes
+- After creating a worktree branch, immediately run `git push -u origin <branch>` to establish remote tracking — this enables `fetch --prune` to detect merged branches and keeps local state clean
 
 ## Kubernetes Safety
 


### PR DESCRIPTION
## Summary

- Adds Git Safety rule to CLAUDE.md requiring `git push -u origin <branch>` immediately after creating a worktree branch
- Without remote tracking, `fetch --prune` cannot detect merged branches, causing stale local branches/worktrees to accumulate indefinitely

## Test plan

- [ ] Verify future worktree branches are pushed to remote on creation
- [ ] Verify `git branch -v` shows `[gone]` for merged branches after `git fetch --prune`
- [ ] Verify `clean_gone` skill successfully cleans up stale branches