### PR TITLE
fix(velero): scope backup to PVCs and use label-based exclusion for media volumes

### DIFF
--- a/kubernetes/clusters/live/config/media-prereqs/media-downloads-pvc.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/media-downloads-pvc.yaml
@@ -4,7 +4,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: media-downloads
   namespace: media
-  annotations:
+  labels:
     velero.io/exclude-from-backup: "true"
 spec:
   accessModes:

--- a/kubernetes/clusters/live/config/media-prereqs/media-library-pvc.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/media-library-pvc.yaml
@@ -4,7 +4,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: media-library
   namespace: media
-  annotations:
+  labels:
     velero.io/exclude-from-backup: "true"
 spec:
   accessModes:

--- a/kubernetes/clusters/live/config/velero/schedule-default.yaml
+++ b/kubernetes/clusters/live/config/velero/schedule-default.yaml
@@ -13,6 +13,9 @@ spec:
       - csi
     snapshotMoveData: true
     ttl: 672h0m0s
+    includedResources:
+      - persistentvolumeclaims
+    includeClusterResources: false
     includedNamespaces:
       - immich
       - satisfactory


### PR DESCRIPTION
## Summary

- Adds `includedResources: [persistentvolumeclaims]` and `includeClusterResources: false` to the default Velero Schedule so backups cover only PVC resources — Deployments, Secrets, ConfigMaps, etc. are already in git and do not need to be in Velero backups.
- Switches `media-downloads` and `media-library` PVCs from `velero.io/exclude-from-backup` annotation to a **label**, which is the mechanism Velero's `itemInclusionChecks()` evaluates prior to invoking the CSI BackupItemAction. The annotation (added in PR #1020) was silently ignored; the label fires before VolumeSnapshot and DataUpload are created for those PVCs.

Supersedes PR #1020.

## Test plan

- [ ] Velero Schedule `default` reconciles cleanly in the live cluster after merge
- [ ] Next scheduled backup (Sunday 02:00) only creates VolumeSnapshots/DataUploads for PVCs in the `includedNamespaces` list, excluding `media-downloads` and `media-library`
- [ ] No VolumeSnapshot or DataUpload resources appear for `media-downloads` or `media-library` in the `media` namespace