### PR TITLE
revert(security): roll back PSS restricted promotion and security contexts

### DIFF
--- a/kubernetes/clusters/live/charts/booter.yaml
+++ b/kubernetes/clusters/live/charts/booter.yaml
@@ -21,13 +21,9 @@ controllers:
           limits:
             memory: 256Mi
         securityContext:
-          allowPrivilegeEscalation: false
           capabilities:
-            drop: ["ALL"]
             add:
               - NET_BIND_SERVICE
-          seccompProfile:
-            type: RuntimeDefault
 
 defaultPodOptions:
   affinity:

--- a/kubernetes/clusters/live/charts/firefly.yaml
+++ b/kubernetes/clusters/live/charts/firefly.yaml
@@ -10,14 +10,6 @@ controllers:
 
     containers:
       app:
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
-          runAsNonRoot: true
-          runAsUser: 33
-          seccompProfile:
-            type: RuntimeDefault
         image:
           repository: fireflyiii/core
           tag: ${firefly_version}

--- a/kubernetes/clusters/live/charts/it-tools.yaml
+++ b/kubernetes/clusters/live/charts/it-tools.yaml
@@ -8,12 +8,6 @@ controllers:
 
     containers:
       app:
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
         image:
           repository: ghcr.io/corentinth/it-tools
           tag: "${it_tools_version}"

--- a/kubernetes/clusters/live/config/booter/namespace.yaml
+++ b/kubernetes/clusters/live/config/booter/namespace.yaml
@@ -5,7 +5,7 @@ metadata:
   name: booter
   labels:
     istio.io/dataplane-mode: ambient
-    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/warn: restricted
     network-policy.homelab/profile: isolated

--- a/kubernetes/clusters/live/config/firefly/namespace.yaml
+++ b/kubernetes/clusters/live/config/firefly/namespace.yaml
@@ -5,8 +5,8 @@ metadata:
   name: firefly
   labels:
     istio.io/dataplane-mode: ambient
-    pod-security.kubernetes.io/enforce: restricted
-    pod-security.kubernetes.io/audit: restricted
-    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline
     network-policy.homelab/profile: standard
     access.network-policy.homelab/postgres: "true"

--- a/kubernetes/clusters/live/config/it-tools/namespace.yaml
+++ b/kubernetes/clusters/live/config/it-tools/namespace.yaml
@@ -5,7 +5,7 @@ metadata:
   name: it-tools
   labels:
     istio.io/dataplane-mode: ambient
-    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/warn: restricted
     network-policy.homelab/profile: internal


### PR DESCRIPTION
## Summary

Rolls back two merged PRs that left firefly, it-tools, and booter broken in the live cluster:

- Reverts **#1019** `fix(k8s): resolve runAsNonRoot securityContext conflicts` (failed fix attempt)
- Reverts **#996** `feat(security): harden firefly, it-tools, booter and promote to restricted PSS` (original breakage)

### What's undone

| File | Change |
|------|--------|
| `charts/booter.yaml` | Remove `allowPrivilegeEscalation`, `drop: ALL`, `seccompProfile` |
| `charts/firefly.yaml` | Remove entire `securityContext` block (incl. `runAsUser: 33` from fix) |
| `charts/it-tools.yaml` | Remove entire `securityContext` block |
| `config/booter/namespace.yaml` | `enforce: restricted` → `enforce: baseline` |
| `config/firefly/namespace.yaml` | All labels `restricted` → `baseline` |
| `config/it-tools/namespace.yaml` | `enforce: restricted` → `enforce: baseline` |

## Test plan

- [ ] After merge, confirm booter, firefly, it-tools pods return to `Running` on live cluster
- [ ] Confirm no PSS admission rejections in live cluster events