### PR TITLE
fix(monitoring): fix Loki Logs dashboard namespace variable default

### DIFF
--- a/kubernetes/platform/charts/grafana.yaml
+++ b/kubernetes/platform/charts/grafana.yaml
@@ -273,11 +273,6 @@ dashboards:
       gnetId: 9578
       revision: 4
       datasource: Prometheus
-    loki-logs:
-      # renovate: depName="Loki Logs Dashboard"
-      gnetId: 15324
-      revision: 1
-      datasource: Loki
   database:
     cloudnative-pg:
       # renovate: depName="CloudNativePG"

--- a/kubernetes/platform/config/monitoring/grafana-dashboard-loki-logs.yaml
+++ b/kubernetes/platform/config/monitoring/grafana-dashboard-loki-logs.yaml
@@ -1,0 +1,294 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-loki-logs
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+  annotations:
+    grafana_folder: "Platform Services"
+data:
+  loki-logs.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "$$hashKey": "object:75",
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "Loki logs panel with prometheus variables ",
+      "editable": true,
+      "gnetId": 15324,
+      "graphTooltip": 0,
+      "id": null,
+      "iteration": 1638208747820,
+      "links": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "loki",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 3,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": false,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.1.6",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(count_over_time({namespace=\"$namespace\", pod=~\"$pod\"} |~ \"$search\"[$__interval]))",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:168",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            },
+            {
+              "$$hashKey": "object:169",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": "loki",
+          "gridPos": {
+            "h": 25,
+            "w": 24,
+            "x": 0,
+            "y": 3
+          },
+          "id": 2,
+          "maxDataPoints": "",
+          "options": {
+            "dedupStrategy": "none",
+            "enableLogDetails": true,
+            "prettifyLogMessage": false,
+            "showCommonLabels": false,
+            "showLabels": false,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"$namespace\", pod=~\"$pod\"} |~ \"$search\"",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Logs Panel",
+          "type": "logs"
+        },
+        {
+          "datasource": null,
+          "gridPos": {
+            "h": 3,
+            "w": 24,
+            "x": 0,
+            "y": 28
+          },
+          "id": 4,
+          "options": {
+            "content": "<div style=\"text-align:center\"> For Grafana Loki blog example </div>\n\n\n",
+            "mode": "html"
+          },
+          "pluginVersion": "8.1.6",
+          "timeFrom": null,
+          "timeShift": null,
+          "transparent": true,
+          "type": "text"
+        }
+      ],
+      "schemaVersion": 30,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "allValue": ".+",
+            "current": {
+              "selected": true,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": "prometheus",
+            "definition": "label_values(kube_pod_info, namespace)",
+            "description": null,
+            "error": null,
+            "hide": 0,
+            "includeAll": true,
+            "label": "Namespace",
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": {
+              "query": "label_values(kube_pod_info, namespace)",
+              "refId": "Prometheus-namespace-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": ".*",
+            "current": {},
+            "datasource": "prometheus",
+            "definition": "label_values(container_network_receive_bytes_total{namespace=~\"$namespace\"},pod)",
+            "description": null,
+            "error": null,
+            "hide": 0,
+            "includeAll": true,
+            "label": "Pod",
+            "multi": true,
+            "name": "pod",
+            "options": [],
+            "query": {
+              "query": "label_values(container_network_receive_bytes_total{namespace=~\"$namespace\"},pod)",
+              "refId": "Prometheus-pod-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "level=warn",
+              "value": "level=warn"
+            },
+            "description": null,
+            "error": null,
+            "hide": 0,
+            "label": "Search",
+            "name": "search",
+            "options": [
+              {
+                "selected": true,
+                "text": "level=warn",
+                "value": "level=warn"
+              }
+            ],
+            "query": "level=warn",
+            "skipUrlSync": false,
+            "type": "textbox"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
+      "timezone": "",
+      "title": "Loki Logs Dashboard",
+      "uid": "liz0yRCZz",
+      "version": 5
+    }

--- a/kubernetes/platform/config/monitoring/kustomization.yaml
+++ b/kubernetes/platform/config/monitoring/kustomization.yaml
@@ -43,3 +43,4 @@ resources:
   - velero-dashboard.yaml
   - network-throughput-dashboard.yaml
   - platform-home-dashboard.yaml
+  - grafana-dashboard-loki-logs.yaml


### PR DESCRIPTION
## Summary

- The Loki Logs dashboard (gnetId 15324) failed on load with LogQL error: `queries require at least one regexp or equality matcher that does not have an empty-compatible value`
- Root cause: the `namespace` template variable had no default value; Helm's `dashboards: gnetId:` mechanism cannot patch template variable defaults in community dashboards
- Fix: replace the Helm-downloaded entry with a ConfigMap containing the dashboard JSON patched to set `includeAll: true` and `allValue: ".+"` on the namespace variable, so the default selection is "All" producing `{namespace=~".+"}` — a valid Loki matcher
- Also replaced `${DS_LOKI}` and `${DS_PROMETHEUS}` template input references with concrete datasource UIDs (`loki`, `prometheus`) since those are only resolved by Grafana's import wizard, not the sidecar ConfigMap mechanism

## Test plan

- [ ] `task k8s:validate` passes (validated: 0 errors, 0 invalid resources)
- [ ] After merge and Flux reconciliation, Grafana loads the Loki Logs dashboard without LogQL errors
- [ ] Dashboard defaults to "All" namespaces on load
- [ ] Dashboard appears in the "Platform Services" folder in Grafana