### PR TITLE
fix(renovate): unblock pending updates by switching to registry-based soak windows

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,7 @@
   "prHourlyLimit": 5,
   "prConcurrentLimit": 20,
   "prCreation": "immediate",
+  "internalChecksFilter": "none",
   "terraform": {
     "managerFilePatterns": [
       "/(^|/)infrastructure/.+\\.tf$/"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -111,10 +111,8 @@
     // ============================================================
     {
       "matchDepNames": [
-        "talos"
-      ],
-      "excludeDepNames": [
-        "siderolabs/talos"
+        "talos",
+        "!siderolabs/talos"
       ],
       "groupName": "talos",
       "automerge": true


### PR DESCRIPTION
## Problem

24 dependency updates stuck in \"Pending Status Checks\" on the [Dependency Dashboard](https://github.com/ionfury/homelab/issues/16) for weeks (some 30+ days old). Packages like `tandoor 2.6.9` (33 days old) and `radarr 6.2.0.10390` (30 days old) far exceed their configured soak windows but no PRs were created.

**Root cause:** `config:recommended` sets `internalChecksFilter: "strict"`, which requires a branch to exist before the stability timer starts. When `prHourlyLimit` or a failed renovate run prevented initial branch creation, no branch was created → no internal check was initiated → timer never started → items deadlocked indefinitely.

## Fix

Set `internalChecksFilter: "none"` to evaluate `minimumReleaseAge` directly against the registry publish timestamp instead of requiring a branch-based internal check.

- Soak windows (`1 day` patch, `3 days` minor) still enforced — via registry timestamp
- PR CI checks still gate automerge (`automergeType: "pr"`)
- Eliminates the deadlock condition permanently

## Expected outcome

Next renovate run will create PRs for all updates that have passed their soak window based on registry publish date.