### PR TITLE
chore(live): remove velero-restore from active Flux reconciliation

### DIFF
--- a/kubernetes/clusters/live/kustomization.yaml
+++ b/kubernetes/clusters/live/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - config.yaml
   - helm-charts.yaml
   - chart-values.yaml
-  - velero-restore.yaml
 configMapGenerator:
   - name: cluster-vars
     options:


### PR DESCRIPTION
## Summary

- Removes `velero-restore.yaml` reference from `kubernetes/clusters/live/kustomization.yaml`
- All files preserved in place for future cluster restores

## Why

The velero-restore Kustomization was a one-time bootstrap mechanism. Leaving it active caused Velero to re-run the restore every time the Restore CR was recreated by Flux, resurrecting deleted resources (root cause of orphaned `media/jellyfin` PVC from stale May 3 backup).

## Test plan
- [ ] Flux reconciles live cluster without `velero-restore` Kustomization
- [ ] No new spurious restore runs in `kubectl get restore.velero.io -n velero`
- [ ] Orphaned `media/jellyfin` PVC manually deleted before merge