### PR TITLE
fix(gitops): remove velero-restore dependsOn to unblock cluster sync

### DIFF
--- a/docs/runbooks/velero-disaster-recovery.md
+++ b/docs/runbooks/velero-disaster-recovery.md
@@ -46,9 +46,30 @@ mv /tmp/merged.yaml ~/.kube/config
 chmod 0600 ~/.kube/config
 ```
 
-### Step 3: Wait for Velero Restore Gate
+### Step 3: Apply Velero Restore Resources
 
-Flux automatically triggers Velero restores for the `garage` and `database` namespaces on cluster bootstrap via the `velero-restore` Kustomization. The gate Job blocks downstream services until all restores complete.
+The `velero-restore` Kustomization is **not deployed by Flux automatically** — it is excluded from GitOps to prevent Restore CRs from thrashing on every reconciliation. Apply it manually to trigger the restore gate and block downstream services until restores complete.
+
+Wait for Velero and its config to be ready first:
+
+```bash
+kubectl --context <cluster> -n flux-system wait kustomization/velero-config \
+  --for=condition=Ready --timeout=5m
+```
+
+Then apply the restore resources for the cluster:
+
+```bash
+# For live cluster
+kubectl --context <cluster> apply -k \
+  kubernetes/clusters/live/config/velero-restore
+
+# For dev cluster
+kubectl --context <cluster> apply -k \
+  kubernetes/clusters/dev/config/velero-restore
+```
+
+Watch the gate job and restore status:
 
 ```bash
 # Watch the gate job
@@ -59,6 +80,13 @@ kubectl --context <cluster> -n velero get restores
 ```
 
 The gate exits 0 when all Restore CRs reach a terminal phase (Completed/Failed/PartiallyFailed).
+
+Once the gate completes, proceed. Flux reconciliation of `garage-config`, `database-config`, and `cluster-resources` was not blocked during this period — those Kustomizations will have already converged on empty/unrestored state. After restores finish, force a reconciliation to pick up the restored data:
+
+```bash
+flux --context <cluster> reconcile kustomization garage-config --with-source
+flux --context <cluster> reconcile kustomization database-config --with-source
+```
 
 ### Step 4: Wait for Full Flux Reconciliation
 

--- a/kubernetes/clusters/live/helm-charts.yaml
+++ b/kubernetes/clusters/live/helm-charts.yaml
@@ -8,7 +8,6 @@ spec:
   dependsOn:
     - name: platform
     - name: cluster-chart-values
-    - name: velero-restore
   interval: 3m
   path: kubernetes/clusters/live/resourcesets
   postBuild:

--- a/kubernetes/platform/config.yaml
+++ b/kubernetes/platform/config.yaml
@@ -33,7 +33,7 @@ spec:
     - name: garage-config
       namespace: garage
       path: kubernetes/platform/config/garage
-      dependsOn: [garage-operator, canary-checker, velero-restore]
+      dependsOn: [garage-operator, canary-checker]
       wait: true
     - name: gateway
       namespace: istio-gateway
@@ -50,7 +50,7 @@ spec:
     - name: database-config
       namespace: database
       path: ${cluster_path}/config/database
-      dependsOn: [cloudnative-pg, garage-config, canary-checker, velero-restore]
+      dependsOn: [cloudnative-pg, garage-config, canary-checker]
     - name: dragonfly-config
       namespace: cache
       path: kubernetes/platform/config/dragonfly


### PR DESCRIPTION
## Summary

- `velero-restore` Kustomization was removed from GitOps (to prevent Restore CR thrashing) but `dependsOn` entries remained, permanently suspending `garage-config`, `database-config`, and `cluster-resources`
- Removes `velero-restore` from `dependsOn` in `kubernetes/platform/config.yaml` (garage-config, database-config) and `kubernetes/clusters/live/helm-charts.yaml` (cluster-resources)
- Updates `docs/runbooks/velero-disaster-recovery.md` Step 3 to document the manual `kubectl apply -k` procedure for DR, including post-restore `flux reconcile` commands needed since the ordering gate no longer blocks Flux

## Test plan

- [ ] Verify `garage-config`, `database-config`, and `cluster-resources` Kustomizations become `READY: True` after merge
- [ ] During next DR exercise, follow updated Step 3 in the runbook to validate the manual restore path