### PR TITLE
fix(media): inject generated API keys into bazarr and sabnzbd

### DIFF
--- a/kubernetes/clusters/live/charts/bazarr.yaml
+++ b/kubernetes/clusters/live/charts/bazarr.yaml
@@ -5,6 +5,9 @@ controllers:
   bazarr:
     type: deployment
 
+    annotations:
+      reloader.stakater.com/auto: "true"
+
     pod:
       securityContext:
         runAsNonRoot: true
@@ -21,6 +24,11 @@ controllers:
           repository: ghcr.io/home-operations/bazarr
           tag: "${bazarr_version}"
         env:
+          BAZARR__AUTH__APIKEY:
+            valueFrom:
+              secretKeyRef:
+                name: bazarr-api-key
+                key: api-key
           POSTGRES_ENABLED: "true"
           POSTGRES_HOST: platform-rw.database.svc.cluster.local
           POSTGRES_PORT: "5432"

--- a/kubernetes/clusters/live/charts/sabnzbd.yaml
+++ b/kubernetes/clusters/live/charts/sabnzbd.yaml
@@ -26,6 +26,11 @@ controllers:
         env:
           TZ: UTC
           SABNZBD__PORT: &port 8080
+          SABNZBD__API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: sabnzbd-api-key
+                key: api-key
           SABNZBD__HOST_WHITELIST_ENTRIES: >-
             sabnzbd,
             sabnzbd.media,


### PR DESCRIPTION
## Summary

- Wire `bazarr-api-key` secret into bazarr via `BAZARR__AUTH__APIKEY` env var
- Wire `sabnzbd-api-key` secret into sabnzbd via `SABNZBD__API_KEY` env var
- Add `reloader.stakater.com/auto: "true"` to bazarr (was missing, unlike all other media apps)

## Root cause

`secret-generator` was creating the API key secrets but neither app was consuming them. Both apps self-generated their own keys on first boot, causing exportarr to get 401/403 errors when using the wrong secret values.

## Test plan

- [ ] Verify bazarr and sabnzbd restart after merge and pick up the generated key
- [ ] Confirm `exportarr-bazarr` and `exportarr-sabnzbd` logs show no more 401/403 errors

## Manual step (live cluster, until this promotes)

Until this change promotes to live, patch the secrets to match the current app keys so exportarr stops erroring immediately. After this change lands on live, the apps read from the secret and values stay in sync permanently.
