### PR TITLE
fix(monitoring): fix canary SLA table column merge

### DIFF
--- a/kubernetes/platform/config/monitoring/canary-sla-dashboard.yaml
+++ b/kubernetes/platform/config/monitoring/canary-sla-dashboard.yaml
@@ -139,10 +139,10 @@ data:
           "gridPos": {"h": 12, "w": 24, "x": 0, "y": 6},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
           "targets": [
-            {"expr": "canary:availability:30d", "format": "table", "instant": true, "legendFormat": "", "refId": "A"},
-            {"expr": "canary:availability:7d",  "format": "table", "instant": true, "legendFormat": "", "refId": "B"},
-            {"expr": "canary:availability:24h", "format": "table", "instant": true, "legendFormat": "", "refId": "C"},
-            {"expr": "canary:availability:1h",  "format": "table", "instant": true, "legendFormat": "", "refId": "D"},
+            {"expr": "canary:availability:30d + 0", "format": "table", "instant": true, "legendFormat": "", "refId": "A"},
+            {"expr": "canary:availability:7d + 0",  "format": "table", "instant": true, "legendFormat": "", "refId": "B"},
+            {"expr": "canary:availability:24h + 0", "format": "table", "instant": true, "legendFormat": "", "refId": "C"},
+            {"expr": "canary:availability:1h + 0",  "format": "table", "instant": true, "legendFormat": "", "refId": "D"},
             {"expr": "max by (name, canary_name, canary_namespace, type) (canary_check)", "format": "table", "instant": true, "legendFormat": "", "refId": "E"}
           ],
           "transformations": [
@@ -151,8 +151,7 @@ data:
               "id": "organize",
               "options": {
                 "excludeByName": {
-                  "Time": true, "__name__": true, "job": true,
-                  "endpoint": true, "service": true, "key": true, "namespace": true
+                  "Time": true
                 },
                 "renameByName": {
                   "Value #A": "30d %", "Value #B": "7d %",


### PR DESCRIPTION
## Summary
- Recording rule queries in the Canary SLA dashboard carry `__name__` labels with different values (`canary:availability:30d`, `7d`, `24h`, `1h`)
- Grafana's `merge` transformation treats `__name__` as a join key, so rows from different queries never match — each check gets 4 separate rows with only one SLA column populated
- Added `+ 0` to each recording rule query (standard PromQL idiom to strip `__name__` via arithmetic) so the merge joins correctly on `name`, `canary_name`, `canary_namespace`, `type`
- Removed stale `excludeByName` entries for labels (`job`, `endpoint`, `service`, `key`, `namespace`) that aggregated queries never produce

## Test plan
- [ ] Verify Canary SLA dashboard table shows one row per check with all 4 SLA columns (30d, 7d, 24h, 1h) populated
- [ ] Verify gauge bars render correctly in each column
- [ ] Verify Status column still shows OK/FAILING mappings