### PR TITLE
fix(monitoring): correct jellyfin-exporter ServiceMonitor serviceName

### DIFF
--- a/kubernetes/clusters/live/charts/jellyfin-exporter.yaml
+++ b/kubernetes/clusters/live/charts/jellyfin-exporter.yaml
@@ -75,7 +75,7 @@ service:
 
 serviceMonitor:
   app:
-    serviceName: jellyfin-exporter-app
+    serviceName: jellyfin-exporter
     endpoints:
       - port: metrics
         interval: 60s


### PR DESCRIPTION
## Summary

- `serviceMonitor.app.serviceName` was set to `jellyfin-exporter-app`, but app-template strips the `app` key suffix when generating service names
- The actual Kubernetes Service is named `jellyfin-exporter`, so the ServiceMonitor selector matched nothing
- No Prometheus scrape target was created, meaning jellyfin metrics were never collected

## Test plan

- [ ] Verify `ServiceMonitor` now selects the correct service after Flux reconciles
- [ ] Confirm Prometheus shows a scrape target for `jellyfin-exporter` in the `live` cluster