### PR TITLE
feat(media): add separate 250Gi ephemeral download PVCs for sabnzbd and qbittorrent

### DIFF
--- a/kubernetes/clusters/live/config/media-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - namespace.yaml
   - media-library-pvc.yaml
   - media-downloads-pvc.yaml
+  - sabnzbd-downloads-pvc.yaml
+  - qbittorrent-downloads-pvc.yaml
   - secrets.yaml
   - network-policy.yaml
   - nordvpn-credentials.yaml

--- a/kubernetes/clusters/live/config/media-prereqs/qbittorrent-downloads-pvc.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/qbittorrent-downloads-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qbittorrent-downloads
+  namespace: media
+  labels:
+    velero.io/exclude-from-backup: "true"
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: fast-ephemeral
+  resources:
+    requests:
+      storage: 250Gi

--- a/kubernetes/clusters/live/config/media-prereqs/sabnzbd-downloads-pvc.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/sabnzbd-downloads-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sabnzbd-downloads
+  namespace: media
+  labels:
+    velero.io/exclude-from-backup: "true"
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: fast-ephemeral
+  resources:
+    requests:
+      storage: 250Gi


### PR DESCRIPTION
## Summary

- Add `sabnzbd-downloads` PVC: 250Gi, `fast-ephemeral` (SSD, 1 replica)
- Add `qbittorrent-downloads` PVC: 250Gi, `fast-ephemeral` (SSD, 1 replica)
- Both mounted RWX so sonarr/radarr/sonarr4k/radarr4k can read from them to copy completed downloads into `media-library`
- `media-downloads` PVC left intact — removal follows in a subsequent PR after download clients are switched

## Why two volumes instead of one

A single 1Ti `media-downloads` PVC exceeded available SSD capacity (~500Gi per node). Splitting by client keeps each volume under the per-disk ceiling, avoids cross-client interference, and allows independent cleanup or resizing.

## Download client reconfiguration required

After this merges and Flux provisions the new PVCs, the download clients and arr apps must be updated to use the new volumes. **Use the same path in both the download client pod and the arr pods** — this avoids remote path mapping complexity.

### SABnzbd

Mount `sabnzbd-downloads` PVC at `/downloads/sabnzbd` in the `sabnzbd` deployment.

Set **SABnzbd → Config → Folders → Temporary Download Folder** to `/downloads/sabnzbd/incomplete` and **Completed Download Folder** to `/downloads/sabnzbd/complete`.

### qBittorrent

Mount `qbittorrent-downloads` PVC at `/downloads/qbittorrent` in the `qbittorrent` deployment.

Set qBittorrent **Options → Downloads → Default Save Path** to `/downloads/qbittorrent`.

### sonarr / sonarr4k / radarr / radarr4k

Mount **both** PVCs in each arr deployment using the **same paths** as the download clients:

- `sabnzbd-downloads` → `/downloads/sabnzbd`
- `qbittorrent-downloads` → `/downloads/qbittorrent`

With identical paths in both the download client and arr pods, no remote path mapping configuration is needed — arr apps will resolve the completed download location directly.

### Verification before removing old PVC

1. Trigger a test download in SABnzbd — confirm it writes to `/downloads/sabnzbd`
2. Trigger a test torrent in qBittorrent — confirm it writes to `/downloads/qbittorrent`
3. Confirm sonarr/radarr can import from both paths
4. Once satisfied, apply the removal PR (#1064) for `media-downloads`

## Test plan

- [ ] Flux reconciles and both new PVCs reach `Bound` state
- [ ] Longhorn shows volumes on fast/SSD disks with 1 replica
- [ ] SABnzbd pod restarts cleanly with new volume mount
- [ ] qBittorrent pod restarts cleanly with new volume mount
- [ ] arr apps mount both download PVCs at matching paths
- [ ] End-to-end test: download → import → media-library
