### PR TITLE
fix(garage): migrate GarageBucket resources to v1beta1 API

### DIFF
--- a/kubernetes/clusters/dev/config/garage/dr-test-bucket.yaml
+++ b/kubernetes/clusters/dev/config/garage/dr-test-bucket.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageBucket
 metadata:
   name: dr-test
@@ -10,6 +10,7 @@ spec:
   quotas:
     maxSize: "1Gi"
   keyPermissions:
-    - keyRef: dr-test-s3
+    - keyRef:
+        name: dr-test-s3
       read: true
       write: true

--- a/kubernetes/clusters/live/config/tandoor/garage-bucket.yaml
+++ b/kubernetes/clusters/live/config/tandoor/garage-bucket.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageBucket
 metadata:
   name: tandoor

--- a/kubernetes/clusters/live/config/zipline/garage-bucket.yaml
+++ b/kubernetes/clusters/live/config/zipline/garage-bucket.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageBucket
 metadata:
   name: zipline

--- a/kubernetes/platform/config/garage/cnpg-immich-bucket.yaml
+++ b/kubernetes/platform/config/garage/cnpg-immich-bucket.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageBucket
 metadata:
   name: cnpg-immich-backups
@@ -9,6 +9,7 @@ spec:
   quotas:
     maxSize: "50Gi"
   keyPermissions:
-    - keyRef: cnpg-immich-s3
+    - keyRef:
+        name: cnpg-immich-s3
       read: true
       write: true

--- a/kubernetes/platform/config/garage/cnpg-platform-bucket.yaml
+++ b/kubernetes/platform/config/garage/cnpg-platform-bucket.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageBucket
 metadata:
   name: cnpg-platform-backups
@@ -9,6 +9,7 @@ spec:
   quotas:
     maxSize: "50Gi"
   keyPermissions:
-    - keyRef: cnpg-platform-s3
+    - keyRef:
+        name: cnpg-platform-s3
       read: true
       write: true

--- a/kubernetes/platform/config/garage/dragonfly-bucket.yaml
+++ b/kubernetes/platform/config/garage/dragonfly-bucket.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageBucket
 metadata:
   name: dragonfly-snapshots
@@ -9,6 +9,7 @@ spec:
   quotas:
     maxSize: "10Gi"
   keyPermissions:
-    - keyRef: dragonfly-s3
+    - keyRef:
+        name: dragonfly-s3
       read: true
       write: true


### PR DESCRIPTION
## Summary

- Bumps `apiVersion` from `garage.rajsingh.info/v1alpha1` to `garage.rajsingh.info/v1beta1` on all six GarageBucket manifests
- Converts `spec.keyPermissions[].keyRef` from a plain string to the structured `{name: <string>}` object required by garage-operator v0.5.8
- Files with no `keyPermissions` (tandoor, zipline) receive only the apiVersion bump

This unblocks the garage-operator from crashlooping due to deserialization failures against the old schema.

## Test plan

- [ ] `task k8s:validate` passes (verified locally — no deprecated APIs, no schema errors)
- [ ] After merge, Flux reconciles GarageBucket resources without operator errors
- [ ] Verify garage-operator pod no longer crashloops on live cluster