### PR TITLE
feat(media): mount separate download PVCs in all media pods

### DIFF
--- a/kubernetes/clusters/live/charts/qbittorrent.yaml
+++ b/kubernetes/clusters/live/charts/qbittorrent.yaml
@@ -208,6 +208,13 @@ persistence:
       qbittorrent:
         app:
           - path: /media/downloads
+  qbittorrent-downloads:
+    type: persistentVolumeClaim
+    existingClaim: qbittorrent-downloads
+    advancedMounts:
+      qbittorrent:
+        app:
+          - path: /downloads/qbittorrent
   gluetun-data:
     type: emptyDir
     advancedMounts:

--- a/kubernetes/clusters/live/charts/radarr.yaml
+++ b/kubernetes/clusters/live/charts/radarr.yaml
@@ -111,6 +111,20 @@ persistence:
       radarr:
         app:
           - path: /media/downloads
+  sabnzbd-downloads:
+    type: persistentVolumeClaim
+    existingClaim: sabnzbd-downloads
+    advancedMounts:
+      radarr:
+        app:
+          - path: /downloads/sabnzbd
+  qbittorrent-downloads:
+    type: persistentVolumeClaim
+    existingClaim: qbittorrent-downloads
+    advancedMounts:
+      radarr:
+        app:
+          - path: /downloads/qbittorrent
   media-library:
     type: persistentVolumeClaim
     existingClaim: media-library

--- a/kubernetes/clusters/live/charts/radarr4k.yaml
+++ b/kubernetes/clusters/live/charts/radarr4k.yaml
@@ -111,6 +111,20 @@ persistence:
       radarr4k:
         app:
           - path: /media/downloads
+  sabnzbd-downloads:
+    type: persistentVolumeClaim
+    existingClaim: sabnzbd-downloads
+    advancedMounts:
+      radarr4k:
+        app:
+          - path: /downloads/sabnzbd
+  qbittorrent-downloads:
+    type: persistentVolumeClaim
+    existingClaim: qbittorrent-downloads
+    advancedMounts:
+      radarr4k:
+        app:
+          - path: /downloads/qbittorrent
   media-library:
     type: persistentVolumeClaim
     existingClaim: media-library

--- a/kubernetes/clusters/live/charts/sabnzbd.yaml
+++ b/kubernetes/clusters/live/charts/sabnzbd.yaml
@@ -101,6 +101,13 @@ persistence:
       sabnzbd:
         app:
           - path: /media/downloads
+  sabnzbd-downloads:
+    type: persistentVolumeClaim
+    existingClaim: sabnzbd-downloads
+    advancedMounts:
+      sabnzbd:
+        app:
+          - path: /downloads/sabnzbd
   tmp:
     type: emptyDir
     advancedMounts:

--- a/kubernetes/clusters/live/charts/sonarr.yaml
+++ b/kubernetes/clusters/live/charts/sonarr.yaml
@@ -111,6 +111,20 @@ persistence:
       sonarr:
         app:
           - path: /media/downloads
+  sabnzbd-downloads:
+    type: persistentVolumeClaim
+    existingClaim: sabnzbd-downloads
+    advancedMounts:
+      sonarr:
+        app:
+          - path: /downloads/sabnzbd
+  qbittorrent-downloads:
+    type: persistentVolumeClaim
+    existingClaim: qbittorrent-downloads
+    advancedMounts:
+      sonarr:
+        app:
+          - path: /downloads/qbittorrent
   media-library:
     type: persistentVolumeClaim
     existingClaim: media-library

--- a/kubernetes/clusters/live/charts/sonarr4k.yaml
+++ b/kubernetes/clusters/live/charts/sonarr4k.yaml
@@ -111,6 +111,20 @@ persistence:
       sonarr4k:
         app:
           - path: /media/downloads
+  sabnzbd-downloads:
+    type: persistentVolumeClaim
+    existingClaim: sabnzbd-downloads
+    advancedMounts:
+      sonarr4k:
+        app:
+          - path: /downloads/sabnzbd
+  qbittorrent-downloads:
+    type: persistentVolumeClaim
+    existingClaim: qbittorrent-downloads
+    advancedMounts:
+      sonarr4k:
+        app:
+          - path: /downloads/qbittorrent
   media-library:
     type: persistentVolumeClaim
     existingClaim: media-library


### PR DESCRIPTION
## Summary

- Mount `sabnzbd-downloads` PVC at `/downloads/sabnzbd` in sabnzbd pod
- Mount `qbittorrent-downloads` PVC at `/downloads/qbittorrent` in qbittorrent pod
- Mount both new PVCs in sonarr/sonarr4k/radarr/radarr4k at identical paths so arr apps can import without remote path mapping
- **Old `media-downloads` mounts left in place** — removal follows after download clients are switched and verified

## Migration sequence

1. Merge this PR — all pods restart with new mounts available at `/downloads/sabnzbd` and `/downloads/qbittorrent`
2. Reconfigure SABnzbd: set Temporary Folder to `/downloads/sabnzbd/incomplete`, Completed Folder to `/downloads/sabnzbd/complete`
3. Reconfigure qBittorrent: set Default Save Path to `/downloads/qbittorrent`
4. Update arr download client paths to point at the new locations
5. Verify end-to-end: download → import → media-library
6. Merge #1064 to remove `media-downloads` PVC (and update charts to drop old mounts)

## Test plan

- [ ] All 6 pods restart cleanly with new volume mounts
- [ ] `/downloads/sabnzbd` accessible in sabnzbd, sonarr, sonarr4k, radarr, radarr4k pods
- [ ] `/downloads/qbittorrent` accessible in qbittorrent, sonarr, sonarr4k, radarr, radarr4k pods
- [ ] Old `/media/downloads` mount still works (no regression)
- [ ] End-to-end download + import verified before proceeding to removal
