### PR TITLE
fix(ci): extract CRD schemas from Helm charts and validate CRs strictly

### DIFF
--- a/.taskfiles/kubernetes/scripts/extract-crd-schemas.sh
+++ b/.taskfiles/kubernetes/scripts/extract-crd-schemas.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Description: Extracts CRD schemas from all Helm charts and converts to kubeconform JSON schemas.
+# Inputs:
+#   - CHARTS_DIR: Path to chart values files
+#   - HELM_CHARTS_FILE: Path to helm-charts.yaml
+#   - VERSION_VARS: Path to versions.env file
+#   - EXPANDED_DIR: Output directory (schemas written to ${EXPANDED_DIR}/crd-schemas/{group}/)
+#   - All Flux substitution vars (cluster_name, internal_domain, etc.)
+#
+# Output structure:
+#   ${EXPANDED_DIR}/crd-schemas/{fullgroup}/{kind}_{version}.json
+# This matches the kubeconform schema-location pattern:
+#   ${EXPANDED_DIR}/crd-schemas/{{ .Group }}/{{ .ResourceKind }}_{{ .ResourceAPIVersion }}.json
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OPENAPI2JSONSCHEMA="${SCRIPT_DIR}/openapi2jsonschema.py"
+CRD_SCHEMAS_DIR="${EXPANDED_DIR}/crd-schemas"
+
+set -a
+# shellcheck source=/dev/null
+source "$VERSION_VARS"
+set +a
+
+mkdir -p "$CRD_SCHEMAS_DIR"
+
+charts_yaml=$(perl -pe 's/\$\{([a-zA-Z_][a-zA-Z0-9_]*)(?::-([^}]*))?\}/
+  my $var = $1; my $default = $2; my $val = $ENV{$var};
+  defined($val) && $val ne "" ? $val : (defined($default) ? $default : "");
+/gex' "$HELM_CHARTS_FILE")
+charts_json=$(echo "$charts_yaml" | yq '.spec.inputs' -o=json)
+
+repo_mapping_file=$(mktemp)
+trap "rm -f $repo_mapping_file" EXIT
+
+echo "$charts_json" | jq -r '.[] | select(.chart.url | startswith("oci://") | not) | .chart.url' | sort -u | while read -r chart_url; do
+  repo_name=$(echo "$chart_url" | sed 's|https://||; s|http://||; s|[./:-]|_|g')
+  helm repo add "$repo_name" "$chart_url" 2>/dev/null || true
+  echo "${chart_url}|${repo_name}" >> "$repo_mapping_file"
+done
+helm repo update 2>/dev/null || true
+
+chart_count=$(echo "$charts_json" | jq -r '. | length')
+echo ""
+echo "Extracting CRD schemas from $chart_count charts..."
+
+for chart_name in $(echo "$charts_json" | jq -r '.[].name'); do
+  chart_info=$(echo "$charts_json" | jq -r ".[] | select(.name == \"$chart_name\")")
+  chart_helm_name=$(echo "$chart_info" | jq -r '.chart.name')
+  chart_version=$(echo "$chart_info" | jq -r '.chart.version')
+  chart_url=$(echo "$chart_info" | jq -r '.chart.url')
+
+  tmp_crds=$(mktemp /tmp/crds-XXXXXX.yaml)
+  trap "rm -f $tmp_crds" RETURN 2>/dev/null || true
+
+  case "$chart_url" in
+    oci://*)
+      helm template "$chart_name" "${chart_url}/${chart_helm_name}" \
+        --version "$chart_version" \
+        --namespace test \
+        --include-crds 2>/dev/null > "$tmp_crds" || true
+      ;;
+    *)
+      repo_name=$(grep "^${chart_url}|" "$repo_mapping_file" | cut -d'|' -f2)
+      helm template "$chart_name" "$repo_name/$chart_helm_name" \
+        --version "$chart_version" \
+        --namespace test \
+        --include-crds 2>/dev/null > "$tmp_crds" || true
+      ;;
+  esac
+
+  python3 - "$tmp_crds" "$CRD_SCHEMAS_DIR" "$OPENAPI2JSONSCHEMA" "$chart_name" <<'PYEOF'
+import sys, yaml, os, subprocess, tempfile
+
+crd_yaml_file = sys.argv[1]
+crd_schemas_dir = sys.argv[2]
+openapi2jsonschema = sys.argv[3]
+chart_name = sys.argv[4]
+
+try:
+    with open(crd_yaml_file) as f:
+        docs = [doc for doc in yaml.safe_load_all(f)
+                if doc and doc.get('kind') == 'CustomResourceDefinition']
+except Exception:
+    docs = []
+
+if not docs:
+    sys.exit(0)
+
+print(f"  {chart_name}: {len(docs)} CRD(s)")
+
+groups = {}
+for doc in docs:
+    group = doc['spec']['group']
+    if group not in groups:
+        groups[group] = []
+    groups[group].append(doc)
+
+for group, crds in groups.items():
+    for crd in crds:
+        kind = crd['spec']['names']['kind']
+        versions = [v['name'] for v in crd['spec'].get('versions', [])]
+        print(f"    {group}/{kind} [{', '.join(versions)}]")
+
+    group_dir = os.path.join(crd_schemas_dir, group)
+    os.makedirs(group_dir, exist_ok=True)
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        yaml.dump_all(crds, f, default_flow_style=False)
+        tmp_group_yaml = f.name
+
+    try:
+        env = os.environ.copy()
+        env['FILENAME_FORMAT'] = '{kind}_{version}'
+        subprocess.run(
+            [sys.executable, openapi2jsonschema, tmp_group_yaml],
+            cwd=group_dir,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+    finally:
+        os.unlink(tmp_group_yaml)
+
+PYEOF
+
+  rm -f "$tmp_crds"
+done
+
+echo ""
+schema_count=$(find "$CRD_SCHEMAS_DIR" -name "*.json" 2>/dev/null | wc -l | tr -d ' ')
+echo "CRD schema extraction complete: ${schema_count} schema file(s) in ${CRD_SCHEMAS_DIR}"
+if [ "$schema_count" -gt 0 ]; then
+  find "$CRD_SCHEMAS_DIR" -name "*.json" | sort | while read -r f; do
+    rel="${f#$CRD_SCHEMAS_DIR/}"
+    echo "  ${rel}"
+  done
+fi

--- a/.taskfiles/kubernetes/scripts/openapi2jsonschema.py
+++ b/.taskfiles/kubernetes/scripts/openapi2jsonschema.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+
+# Derived from https://github.com/instrumenta/openapi2jsonschema
+import yaml
+import json
+import sys
+import os
+import urllib.request
+if 'DISABLE_SSL_CERT_VALIDATION' in os.environ:
+    import ssl
+    ssl._create_default_https_context = ssl._create_unverified_context
+
+def test_additional_properties():
+    for test in iter([{
+        "input": {"something": {"properties": {}}},
+        "expect": {'something': {'properties': {}, "additionalProperties": False}}
+    },{
+        "input": {"something": {"somethingelse": {}}},
+        "expect": {'something': {'somethingelse': {}}}
+    }]):
+        assert additional_properties(test["input"]) == test["expect"]
+
+def additional_properties(data, skip=False):
+    "This recreates the behaviour of kubectl at https://github.com/kubernetes/kubernetes/blob/225b9119d6a8f03fcbe3cc3d590c261965d928d0/pkg/kubectl/validation/schema.go#L312"
+    if isinstance(data, dict):
+        if "properties" in data and not skip:
+            if "additionalProperties" not in data:
+                data["additionalProperties"] = False
+        for _, v in data.items():
+            additional_properties(v)
+    return data
+
+def test_replace_int_or_string():
+    for test in iter([{
+        "input": {"something": {"format": "int-or-string"}},
+        "expect": {'something': {'oneOf': [{'type': 'string'}, {'type': 'integer'}]}}
+    },{
+        "input": {"something": {"format": "string"}},
+        "expect": {"something": {"format": "string"}},
+    }]):
+        assert replace_int_or_string(test["input"]) == test["expect"]
+
+def replace_int_or_string(data):
+    new = {}
+    try:
+        for k, v in iter(data.items()):
+            new_v = v
+            if isinstance(v, dict):
+                if "format" in v and v["format"] == "int-or-string":
+                    new_v = {"oneOf": [{"type": "string"}, {"type": "integer"}]}
+                else:
+                    new_v = replace_int_or_string(v)
+            elif isinstance(v, list):
+                new_v = list()
+                for x in v:
+                    new_v.append(replace_int_or_string(x))
+            else:
+                new_v = v
+            new[k] = new_v
+        return new
+    except AttributeError:
+        return data
+
+def allow_null_optional_fields(data, parent=None, grand_parent=None, key=None):
+    new = {}
+    try:
+        for k, v in iter(data.items()):
+            new_v = v
+            if isinstance(v, dict):
+                new_v = allow_null_optional_fields(v, data, parent, k)
+            elif isinstance(v, list):
+                new_v = list()
+                for x in v:
+                    new_v.append(allow_null_optional_fields(x, v, parent, k))
+            elif isinstance(v, str):
+                is_non_null_type = k == "type" and v != "null"
+                has_required_fields = grand_parent and "required" in grand_parent
+                if is_non_null_type and not has_required_fields:
+                    new_v = [v, "null"]
+            new[k] = new_v
+        return new
+    except AttributeError:
+        return data
+
+
+def append_no_duplicates(obj, key, value):
+    """
+    Given a dictionary, lookup the given key, if it doesn't exist create a new array.
+    Then check if the given value already exists in the array, if it doesn't add it.
+    """
+    if key not in obj:
+        obj[key] = []
+    if value not in obj[key]:
+        obj[key].append(value)
+
+
+def write_schema_file(schema, filename):
+    schemaJSON = ""
+
+    schema = additional_properties(schema, skip=not os.getenv("DENY_ROOT_ADDITIONAL_PROPERTIES"))
+    schema = replace_int_or_string(schema)
+    schemaJSON = json.dumps(schema, indent=2)
+
+    # Dealing with user input here..
+    filename = os.path.basename(filename)
+    f = open(filename, "w")
+    print(schemaJSON, file=f)
+    f.close()
+    print("JSON schema written to {filename}".format(filename=filename))
+
+
+def construct_value(load, node):
+    # Handle nodes that start with '='
+    # See https://github.com/yaml/pyyaml/issues/89
+    if not isinstance(node, yaml.ScalarNode):
+        raise yaml.constructor.ConstructorError(
+            "while constructing a value",
+            node.start_mark,
+            "expected a scalar, but found %s" % node.id, node.start_mark
+        )
+    yield str(node.value)
+
+
+if __name__ == "__main__":
+  if len(sys.argv) < 2:
+      print('Missing FILE parameter.\nUsage: %s [FILE]' % sys.argv[0])
+      exit(1)
+
+  for crdFile in sys.argv[1:]:
+      if crdFile.startswith("http"):
+        f = urllib.request.urlopen(crdFile)
+      else:
+        f = open(crdFile)
+      with f:
+          defs = []
+          yaml.SafeLoader.add_constructor(u'tag:yaml.org,2002:value', construct_value)
+          for y in yaml.load_all(f, Loader=yaml.SafeLoader):
+              if y is None:
+                  continue
+              if "items" in y:
+                  defs.extend(y["items"])
+              if "kind" not in y:
+                  continue
+              if y["kind"] != "CustomResourceDefinition":
+                  continue
+              else:
+                  defs.append(y)
+
+          for y in defs:
+              filename_format = os.getenv("FILENAME_FORMAT", "{kind}_{version}")
+              filename = ""
+              if "spec" in y and "versions" in y["spec"] and y["spec"]["versions"]:
+                  for version in y["spec"]["versions"]:
+                      if "schema" in version and "openAPIV3Schema" in version["schema"]:
+                          filename = filename_format.format(
+                              kind=y["spec"]["names"]["kind"],
+                              group=y["spec"]["group"].split(".")[0],
+                              fullgroup=y["spec"]["group"],
+                              version=version["name"],
+                          ) + ".json"
+
+                          schema = version["schema"]["openAPIV3Schema"]
+                          write_schema_file(schema, filename)
+                      elif "validation" in y["spec"] and "openAPIV3Schema" in y["spec"]["validation"]:
+                          filename = filename_format.format(
+                              kind=y["spec"]["names"]["kind"],
+                              group=y["spec"]["group"].split(".")[0],
+                              fullgroup=y["spec"]["group"],
+                              version=version["name"],
+                          ) + ".json"
+
+                          schema = y["spec"]["validation"]["openAPIV3Schema"]
+                          write_schema_file(schema, filename)
+              elif "spec" in y and "validation" in y["spec"] and "openAPIV3Schema" in y["spec"]["validation"]:
+                  filename = filename_format.format(
+                      kind=y["spec"]["names"]["kind"],
+                      group=y["spec"]["group"].split(".")[0],
+                      fullgroup=y["spec"]["group"],
+                      version=y["spec"]["version"],
+                  ) + ".json"
+
+                  schema = y["spec"]["validation"]["openAPIV3Schema"]
+                  write_schema_file(schema, filename)
+
+  exit(0)


### PR DESCRIPTION
## Summary

- Vendors `openapi2jsonschema.py` (from yannh/kubeconform) to convert CRD YAML to kubeconform-compatible JSON schemas
- Adds `extract-crd-schemas.sh` that templates all Helm charts with `--include-crds` and emits per-group/per-version schema files
- Wires a new `_validate-kubeconform-strict-crs` task into `task k8s:validate` that validates all `kubernetes/platform/config/**` and `kubernetes/clusters/*/config/**` CRs against locally-extracted schemas

## Motivation

The garage-operator Helm bump (v0.3.4 → v0.5.8) introduced a breaking CRD schema change: `GarageBucket.spec.keyPermissions[].keyRef` changed from `type: string` to a structured object `{name, namespace}`. Existing CRs in the repo used the old string format. CI missed it because kubeconform uses `-ignore-missing-schemas` and the community catalog doesn't include `garage.rajsingh.info`. The operator crashlooped in production (fixed in #1065).

## How it works

1. `_extract-crd-schemas` re-templates every chart in `helm-charts.yaml` with `--include-crds` at the pinned version, filters `kind: CustomResourceDefinition`, and runs `openapi2jsonschema.py` to produce `{EXPANDED_DIR}/crd-schemas/{group}/{Kind}_{version}.json`
2. `_validate-kubeconform-strict-crs` runs kubeconform with the local schema dir as a higher-priority `-schema-location` than the community catalog, over all CR source files
3. When a chart bump changes a CRD field type, the new schema is extracted at PR time — CRs using that field get validated against the new schema and fail CI if they don't match

## What it catches

- Field type changes within a served CRD version (string → object, int → string, etc.)
- Required field additions to an existing CRD version
- Any structural schema violation in CRs against the exact chart version the PR proposes

## Known limitation

This gate validates CR content against schema. It does not detect when CRs use an API version that the operator's controller code no longer deserializes correctly (the specific garage failure mode). That would require additionally checking that all CRs use a version marked `served: true` with a working conversion webhook — a follow-up improvement.

## Validation

Ran `extract-crd-schemas.sh` against the current chart set. Confirmed schemas extracted for 130+ CRDs including:
- `garage.rajsingh.info/GarageBucket_v1alpha1.json` (keyRef: string)
- `garage.rajsingh.info/GarageBucket_v1beta1.json` (keyRef: object with required `name`)
- `postgresql.cnpg.io`, `velero.io`, `security.istio.io`, and 15+ other groups

## Test plan

- [ ] CI passes on this PR
- [ ] Verify `task k8s:validate` includes CRD extraction output in logs
- [ ] Confirm `garage.rajsingh.info` schemas appear in extracted output