### PR TITLE
fix(garage): migrate manifests to v1beta2/v1beta1 API versions

### DIFF
--- a/kubernetes/clusters/dev/config/garage/dr-test-key.yaml
+++ b/kubernetes/clusters/dev/config/garage/dr-test-key.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageKey
 metadata:
   name: dr-test-s3
@@ -8,7 +8,8 @@ spec:
   clusterRef:
     name: garage
   bucketPermissions:
-    - bucketRef: dr-test
+    - bucketRef:
+        name: dr-test
       read: true
       write: true
   secretTemplate:

--- a/kubernetes/clusters/live/config/tandoor/garage-key.yaml
+++ b/kubernetes/clusters/live/config/tandoor/garage-key.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageKey
 metadata:
   name: tandoor
@@ -9,7 +9,8 @@ spec:
     name: garage
   neverExpires: true
   bucketPermissions:
-    - bucketRef: tandoor
+    - bucketRef:
+        name: tandoor
       read: true
       write: true
   secretTemplate:

--- a/kubernetes/clusters/live/config/zipline/garage-key.yaml
+++ b/kubernetes/clusters/live/config/zipline/garage-key.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageKey
 metadata:
   name: zipline
@@ -9,7 +9,8 @@ spec:
     name: garage
   neverExpires: true
   bucketPermissions:
-    - bucketRef: zipline
+    - bucketRef:
+        name: zipline
       read: true
       write: true
   secretTemplate:

--- a/kubernetes/platform/config/garage/cnpg-immich-key.yaml
+++ b/kubernetes/platform/config/garage/cnpg-immich-key.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageKey
 metadata:
   name: cnpg-immich-s3
@@ -7,7 +7,8 @@ spec:
   clusterRef:
     name: garage
   bucketPermissions:
-    - bucketRef: cnpg-immich-backups
+    - bucketRef:
+        name: cnpg-immich-backups
       read: true
       write: true
   secretTemplate:

--- a/kubernetes/platform/config/garage/cnpg-platform-key.yaml
+++ b/kubernetes/platform/config/garage/cnpg-platform-key.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageKey
 metadata:
   name: cnpg-platform-s3
@@ -7,7 +7,8 @@ spec:
   clusterRef:
     name: garage
   bucketPermissions:
-    - bucketRef: cnpg-platform-backups
+    - bucketRef:
+        name: cnpg-platform-backups
       read: true
       write: true
   secretTemplate:

--- a/kubernetes/platform/config/garage/dragonfly-key.yaml
+++ b/kubernetes/platform/config/garage/dragonfly-key.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageKey
 metadata:
   name: dragonfly-s3
@@ -7,7 +7,8 @@ spec:
   clusterRef:
     name: garage
   bucketPermissions:
-    - bucketRef: dragonfly-snapshots
+    - bucketRef:
+        name: dragonfly-snapshots
       read: true
       write: true
   secretTemplate:

--- a/kubernetes/platform/config/garage/garage-cluster.yaml
+++ b/kubernetes/platform/config/garage/garage-cluster.yaml
@@ -1,12 +1,12 @@
 ---
-apiVersion: garage.rajsingh.info/v1alpha1
+apiVersion: garage.rajsingh.info/v1beta2
 kind: GarageCluster
 metadata:
   name: garage
 spec:
   image: dxflrs/garage:${garage_image_version}
-  replicas: ${default_replica_count}
   zone: ${cluster_name}
+  layoutPolicy: Auto
 
   replication:
     factor: ${default_replica_count}
@@ -18,18 +18,29 @@ spec:
       release: kube-prometheus-stack
 
   storage:
+    replicas: ${default_replica_count}
     metadata:
       storageClassName: fast
       size: ${garage_meta_volume_size}
     data:
       storageClassName: fast
       size: ${garage_data_volume_size}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
 
   database:
     engine: lmdb
 
   security:
-    allowWorldReadableSecrets: true
+    allowInsecureSecretPermissions: true
 
   network:
     rpcBindPort: 3901
@@ -46,20 +57,7 @@ spec:
     rootDomain: .web.${internal_domain}
 
   admin:
-    enabled: true
     bindPort: 3903
     adminTokenSecretRef:
       name: garage-admin-token
       key: admin-token
-
-  resources:
-    requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      memory: 1Gi
-
-  securityContext:
-    runAsUser: 1000
-    runAsGroup: 1000
-    fsGroup: 1000


### PR DESCRIPTION
## Summary

- Garage-operator CRDs were upgraded, breaking the data plane. The live cluster was manually patched to restore service. These changes align git with the corrected live state so Flux does not revert the fix.
- **GarageCluster** (`garage-cluster.yaml`): migrated from `v1alpha1` to `v1beta2`. Moved `replicas`, `resources`, and `securityContext` inside `spec.storage`. Renamed `allowWorldReadableSecrets` to `allowInsecureSecretPermissions`. Removed `admin.enabled` (unknown field in v1beta2). Added `layoutPolicy: Auto`.
- **GarageKey** (6 files): migrated from `v1alpha1` to `v1beta1`. Changed `bucketRef` from a plain string to an object with a `name` field.

## Test plan

- [ ] Verify Flux reconciles cleanly on integration (no drift from live state)
- [ ] Confirm garage pods remain healthy after promotion to live
- [ ] Verify S3 bucket access still works for CNPG backups, Dragonfly snapshots, Tandoor, and Zipline