### PR TITLE
fix(garage): complete v1beta1/v1beta2 migration with cross-namespace keys

### DIFF
--- a/kubernetes/clusters/dev/config/garage/dr-test-key.yaml
+++ b/kubernetes/clusters/dev/config/garage/dr-test-key.yaml
@@ -14,4 +14,3 @@ spec:
       write: true
   secretTemplate:
     name: dr-test-s3-credentials
-    namespace: garage

--- a/kubernetes/clusters/live/config/tandoor/garage-bucket.yaml
+++ b/kubernetes/clusters/live/config/tandoor/garage-bucket.yaml
@@ -7,3 +7,9 @@ metadata:
 spec:
   clusterRef:
     name: garage
+  keyPermissions:
+    - keyRef:
+        name: tandoor
+        namespace: tandoor
+      read: true
+      write: true

--- a/kubernetes/clusters/live/config/tandoor/garage-key.yaml
+++ b/kubernetes/clusters/live/config/tandoor/garage-key.yaml
@@ -3,16 +3,17 @@ apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageKey
 metadata:
   name: tandoor
-  namespace: garage
+  namespace: tandoor
 spec:
   clusterRef:
     name: garage
+    namespace: garage
   neverExpires: true
   bucketPermissions:
     - bucketRef:
         name: tandoor
+        namespace: garage
       read: true
       write: true
   secretTemplate:
     name: tandoor-s3-credentials
-    namespace: tandoor

--- a/kubernetes/clusters/live/config/zipline/garage-bucket.yaml
+++ b/kubernetes/clusters/live/config/zipline/garage-bucket.yaml
@@ -7,3 +7,9 @@ metadata:
 spec:
   clusterRef:
     name: garage
+  keyPermissions:
+    - keyRef:
+        name: zipline
+        namespace: zipline
+      read: true
+      write: true

--- a/kubernetes/clusters/live/config/zipline/garage-key.yaml
+++ b/kubernetes/clusters/live/config/zipline/garage-key.yaml
@@ -3,16 +3,17 @@ apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageKey
 metadata:
   name: zipline
-  namespace: garage
+  namespace: zipline
 spec:
   clusterRef:
     name: garage
+    namespace: garage
   neverExpires: true
   bucketPermissions:
     - bucketRef:
         name: zipline
+        namespace: garage
       read: true
       write: true
   secretTemplate:
     name: zipline-s3-credentials
-    namespace: zipline

--- a/kubernetes/platform/config/database/cnpg-immich-key.yaml
+++ b/kubernetes/platform/config/database/cnpg-immich-key.yaml
@@ -2,15 +2,16 @@
 apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageKey
 metadata:
-  name: dragonfly-s3
+  name: cnpg-immich-s3
 spec:
   clusterRef:
     name: garage
+    namespace: garage
   bucketPermissions:
     - bucketRef:
-        name: dragonfly-snapshots
+        name: cnpg-immich-backups
+        namespace: garage
       read: true
       write: true
   secretTemplate:
-    name: dragonfly-s3-credentials
-    namespace: cache
+    name: cnpg-immich-s3-credentials

--- a/kubernetes/platform/config/database/cnpg-platform-key.yaml
+++ b/kubernetes/platform/config/database/cnpg-platform-key.yaml
@@ -2,15 +2,16 @@
 apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageKey
 metadata:
-  name: cnpg-immich-s3
+  name: cnpg-platform-s3
 spec:
   clusterRef:
     name: garage
+    namespace: garage
   bucketPermissions:
     - bucketRef:
-        name: cnpg-immich-backups
+        name: cnpg-platform-backups
+        namespace: garage
       read: true
       write: true
   secretTemplate:
-    name: cnpg-immich-s3-credentials
-    namespace: database
+    name: cnpg-platform-s3-credentials

--- a/kubernetes/platform/config/database/kustomization.yaml
+++ b/kubernetes/platform/config/database/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - scheduled-backup.yaml
   - pooler.yaml
   - prometheus-rules.yaml
+  - cnpg-immich-key.yaml
+  - cnpg-platform-key.yaml

--- a/kubernetes/platform/config/dragonfly/dragonfly-key.yaml
+++ b/kubernetes/platform/config/dragonfly/dragonfly-key.yaml
@@ -2,15 +2,16 @@
 apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageKey
 metadata:
-  name: cnpg-platform-s3
+  name: dragonfly-s3
 spec:
   clusterRef:
     name: garage
+    namespace: garage
   bucketPermissions:
     - bucketRef:
-        name: cnpg-platform-backups
+        name: dragonfly-snapshots
+        namespace: garage
       read: true
       write: true
   secretTemplate:
-    name: cnpg-platform-s3-credentials
-    namespace: database
+    name: dragonfly-s3-credentials

--- a/kubernetes/platform/config/dragonfly/kustomization.yaml
+++ b/kubernetes/platform/config/dragonfly/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - dragonfly-instance.yaml
   - podmonitor.yaml
   - prometheus-rules.yaml
+  - dragonfly-key.yaml

--- a/kubernetes/platform/config/garage/cnpg-immich-bucket.yaml
+++ b/kubernetes/platform/config/garage/cnpg-immich-bucket.yaml
@@ -11,5 +11,6 @@ spec:
   keyPermissions:
     - keyRef:
         name: cnpg-immich-s3
+        namespace: database
       read: true
       write: true

--- a/kubernetes/platform/config/garage/cnpg-platform-bucket.yaml
+++ b/kubernetes/platform/config/garage/cnpg-platform-bucket.yaml
@@ -11,5 +11,6 @@ spec:
   keyPermissions:
     - keyRef:
         name: cnpg-platform-s3
+        namespace: database
       read: true
       write: true

--- a/kubernetes/platform/config/garage/dragonfly-bucket.yaml
+++ b/kubernetes/platform/config/garage/dragonfly-bucket.yaml
@@ -11,5 +11,6 @@ spec:
   keyPermissions:
     - keyRef:
         name: dragonfly-s3
+        namespace: cache
       read: true
       write: true

--- a/kubernetes/platform/config/garage/kustomization.yaml
+++ b/kubernetes/platform/config/garage/kustomization.yaml
@@ -9,8 +9,9 @@ resources:
   - garage-route.yaml
   - garage-canary.yaml
   - cnpg-platform-bucket.yaml
-  - cnpg-platform-key.yaml
   - cnpg-immich-bucket.yaml
-  - cnpg-immich-key.yaml
   - dragonfly-bucket.yaml
-  - dragonfly-key.yaml
+  - reference-grant-database.yaml
+  - reference-grant-cache.yaml
+  - reference-grant-tandoor.yaml
+  - reference-grant-zipline.yaml

--- a/kubernetes/platform/config/garage/reference-grant-cache.yaml
+++ b/kubernetes/platform/config/garage/reference-grant-cache.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: allow-cache
+spec:
+  from:
+    - kind: GarageKey
+      namespace: cache

--- a/kubernetes/platform/config/garage/reference-grant-database.yaml
+++ b/kubernetes/platform/config/garage/reference-grant-database.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: allow-database
+spec:
+  from:
+    - kind: GarageKey
+      namespace: database

--- a/kubernetes/platform/config/garage/reference-grant-tandoor.yaml
+++ b/kubernetes/platform/config/garage/reference-grant-tandoor.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: allow-tandoor
+spec:
+  from:
+    - kind: GarageKey
+      namespace: tandoor

--- a/kubernetes/platform/config/garage/reference-grant-zipline.yaml
+++ b/kubernetes/platform/config/garage/reference-grant-zipline.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: allow-zipline
+spec:
+  from:
+    - kind: GarageKey
+      namespace: zipline


### PR DESCRIPTION
## Summary

- Move GarageKeys from `garage` namespace to consuming namespaces (`database`, `cache`, `tandoor`, `zipline`) — v1beta1 removed `secretTemplate.namespace` for cross-ns secret creation
- Create GarageReferenceGrants in `garage` ns to authorize cross-namespace `clusterRef`/`bucketRef` references
- Add explicit `namespace` to all cross-ns `clusterRef`, `bucketRef`, and `keyRef` fields
- Remove `secretTemplate.namespace` from all GarageKey resources

Supersedes #1076 which updated apiVersions but missed the `secretTemplate.namespace` removal.

## Test plan

- [ ] `flux resume kustomization garage-config -n flux-system` → Ready
- [ ] `flux get kustomization database-config` → Ready (no drift)
- [ ] `flux get kustomization dragonfly-config` → Ready (no drift)
- [ ] `kubectl get garagekeys -A` → all Ready, keys in correct namespaces
- [ ] `kubectl get garagebuckets -A` → all Ready
- [ ] Verify secrets: `kubectl get secret cnpg-immich-s3-credentials -n database`
- [ ] Verify secrets: `kubectl get secret dragonfly-s3-credentials -n cache`