### PR TITLE
fix(garage): remove keyPermissions from tandoor/zipline buckets

### DIFF
--- a/kubernetes/clusters/live/config/tandoor/garage-bucket.yaml
+++ b/kubernetes/clusters/live/config/tandoor/garage-bucket.yaml
@@ -7,9 +7,3 @@ metadata:
 spec:
   clusterRef:
     name: garage
-  keyPermissions:
-    - keyRef:
-        name: tandoor
-        namespace: tandoor
-      read: true
-      write: true

--- a/kubernetes/clusters/live/config/zipline/garage-bucket.yaml
+++ b/kubernetes/clusters/live/config/zipline/garage-bucket.yaml
@@ -7,9 +7,3 @@ metadata:
 spec:
   clusterRef:
     name: garage
-  keyPermissions:
-    - keyRef:
-        name: zipline
-        namespace: zipline
-      read: true
-      write: true


### PR DESCRIPTION
## Summary

- Remove `keyPermissions` from tandoor/zipline buckets added in #1087
- These buckets never had keyPermissions — permissions handled by `bucketPermissions` on the key side
- Object-form `keyRef` triggered SSA conversion failure (v1alpha1 string → v1beta1 object) during Flux dry-run

Also cleared stale `kustomize-controller` v1alpha1 managed field entries on live cluster for:
- `garagecluster/garage`
- `garagebucket/tandoor`
- `garagebucket/zipline`

## Test plan

- [ ] `flux get kustomization garage-config` → Ready
- [ ] `flux get kustomization cluster-config` → Ready
- [ ] `flux get kustomization database-config` → Ready
- [ ] `flux get kustomization dragonfly-config` → Ready