### PR TITLE
fix(garage): downgrade GarageCluster to v1beta1 and remove bucket keyPermissions

### DIFF
--- a/kubernetes/clusters/live/config/tandoor/garage-bucket.yaml
+++ b/kubernetes/clusters/live/config/tandoor/garage-bucket.yaml
@@ -7,9 +7,3 @@ metadata:
 spec:
   clusterRef:
     name: garage
-  keyPermissions:
-    - keyRef:
-        name: tandoor
-        namespace: tandoor
-      read: true
-      write: true

--- a/kubernetes/clusters/live/config/zipline/garage-bucket.yaml
+++ b/kubernetes/clusters/live/config/zipline/garage-bucket.yaml
@@ -7,9 +7,3 @@ metadata:
 spec:
   clusterRef:
     name: garage
-  keyPermissions:
-    - keyRef:
-        name: zipline
-        namespace: zipline
-      read: true
-      write: true

--- a/kubernetes/platform/config/garage/garage-cluster.yaml
+++ b/kubernetes/platform/config/garage/garage-cluster.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: garage.rajsingh.info/v1beta1
+apiVersion: garage.rajsingh.info/v1beta2
 kind: GarageCluster
 metadata:
   name: garage
@@ -7,7 +7,6 @@ spec:
   image: dxflrs/garage:${garage_image_version}
   zone: ${cluster_name}
   layoutPolicy: Auto
-  replicas: ${default_replica_count}
 
   replication:
     factor: ${default_replica_count}
@@ -19,24 +18,23 @@ spec:
       release: kube-prometheus-stack
 
   storage:
+    replicas: ${default_replica_count}
     metadata:
       storageClassName: fast
       size: ${garage_meta_volume_size}
     data:
       storageClassName: fast
       size: ${garage_data_volume_size}
-
-  resources:
-    requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      memory: 1Gi
-
-  securityContext:
-    runAsUser: 1000
-    runAsGroup: 1000
-    fsGroup: 1000
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
 
   database:
     engine: lmdb

--- a/kubernetes/platform/config/garage/garage-cluster.yaml
+++ b/kubernetes/platform/config/garage/garage-cluster.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: garage.rajsingh.info/v1beta2
+apiVersion: garage.rajsingh.info/v1beta1
 kind: GarageCluster
 metadata:
   name: garage
@@ -7,6 +7,7 @@ spec:
   image: dxflrs/garage:${garage_image_version}
   zone: ${cluster_name}
   layoutPolicy: Auto
+  replicas: ${default_replica_count}
 
   replication:
     factor: ${default_replica_count}
@@ -18,23 +19,24 @@ spec:
       release: kube-prometheus-stack
 
   storage:
-    replicas: ${default_replica_count}
     metadata:
       storageClassName: fast
       size: ${garage_meta_volume_size}
     data:
       storageClassName: fast
       size: ${garage_data_volume_size}
-    resources:
-      requests:
-        cpu: 100m
-        memory: 256Mi
-      limits:
-        memory: 1Gi
-    securityContext:
-      runAsUser: 1000
-      runAsGroup: 1000
-      fsGroup: 1000
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
 
   database:
     engine: lmdb


### PR DESCRIPTION
## Summary

- Downgrade GarageCluster apiVersion from v1beta2 to v1beta1 — operator webhooks only intercept at v1beta1, causing lossy round-trip conversion that nullifies `storage.metadata`/`storage.data`
- Move `replicas`, `resources`, `securityContext` from `spec.storage.*` to `spec.*` (v1beta1 schema)
- Remove `keyPermissions` from tandoor/zipline buckets — never had them, object-form `keyRef` triggers SSA conversion failure

## Context

PR #1087 migrated garage manifests but hit two issues:
1. GarageCluster v1beta2 → v1beta1 webhook conversion loses storage PVC fields
2. Tandoor/zipline bucket `keyRef` object form can't convert from v1alpha1 string form

Stale v1alpha1 SSA managed fields already cleared on live cluster.

## Test plan

- [ ] `flux get kustomization garage-config` → Ready
- [ ] `flux get kustomization cluster-config` → Ready
- [ ] `flux get kustomization database-config` → Ready
- [ ] `flux get kustomization dragonfly-config` → Ready
- [ ] `kubectl get garageclusters -A` → Ready
- [ ] `kubectl get garagekeys -A` → all Ready