### PR TITLE
fix(garage): remove keyPermissions to break circular dependency

### DIFF
--- a/kubernetes/platform/config/garage/cnpg-immich-bucket.yaml
+++ b/kubernetes/platform/config/garage/cnpg-immich-bucket.yaml
@@ -8,8 +8,3 @@ spec:
     name: garage
   quotas:
     maxSize: "50Gi"
-  keyPermissions:
-    - keyRef:
-        name: cnpg-immich-s3
-      read: true
-      write: true

--- a/kubernetes/platform/config/garage/cnpg-platform-bucket.yaml
+++ b/kubernetes/platform/config/garage/cnpg-platform-bucket.yaml
@@ -8,8 +8,3 @@ spec:
     name: garage
   quotas:
     maxSize: "50Gi"
-  keyPermissions:
-    - keyRef:
-        name: cnpg-platform-s3
-      read: true
-      write: true

--- a/kubernetes/platform/config/garage/dragonfly-bucket.yaml
+++ b/kubernetes/platform/config/garage/dragonfly-bucket.yaml
@@ -8,8 +8,3 @@ spec:
     name: garage
   quotas:
     maxSize: "10Gi"
-  keyPermissions:
-    - keyRef:
-        name: dragonfly-s3
-      read: true
-      write: true


### PR DESCRIPTION
## Summary

- Remove `keyPermissions` from cnpg-immich-backups, cnpg-platform-backups, and dragonfly-snapshots buckets
- Breaks circular dependency: garage-config (wait: true) → buckets wait for keys → keys in database-config/dragonfly-config → dependsOn garage-config
- Permissions already defined on key side via `bucketPermissions`, making bucket-side `keyPermissions` redundant

## Context

After the v1alpha1 → v1beta1/v1beta2 migration (PRs #1076, #1087, #1089), Flux cannot reconcile garage-config because:
1. Buckets reference cross-namespace keys via `keyPermissions` that don't exist yet (deployed by database-config/dragonfly-config)
2. Those kustomizations `dependsOn: garage-config`, which uses `wait: true` — deadlock

Removing `keyPermissions` eliminates the cross-namespace reference, letting buckets go Ready without waiting for keys in other namespaces. The tandoor/zipline buckets already work this way.

## Test plan

- [ ] `flux --context live reconcile kustomization garage-config` — applies and goes Ready
- [ ] `kubectl --context live get garagebuckets -A` — all buckets Ready
- [ ] `flux --context live get kustomization database-config` — unblocked, goes Ready
- [ ] `flux --context live get kustomization dragonfly-config` — unblocked, goes Ready
- [ ] If garage-config health check still fails (GarageReferenceGrant/GarageCluster unknown kind), escalate to Option A/B from plan