### PR TITLE
fix(garage): remove wait from garage-config kustomization

### DIFF
--- a/kubernetes/platform/config.yaml
+++ b/kubernetes/platform/config.yaml
@@ -34,7 +34,6 @@ spec:
       namespace: garage
       path: kubernetes/platform/config/garage
       dependsOn: [garage-operator, canary-checker]
-      wait: true
     - name: gateway
       namespace: istio-gateway
       path: kubernetes/platform/config/gateway


### PR DESCRIPTION
## Summary

- Remove `wait: true` from garage-config in `config.yaml` ResourceSet
- Flux health checker can't evaluate GarageCluster/GarageReferenceGrant CRDs → timeout → garage-config stuck NotReady → blocks database-config and dragonfly-config

## Why this is safe

- `dependsOn` ordering preserved: database-config/dragonfly-config still wait for garage-config to be applied
- garage-operator (CRD provider) is a separate dependency — CRDs exist before garage-config runs
- Without `wait`, Flux marks Ready after successful apply, not after health-checking all resources
- GarageCluster and GarageReferenceGrant are already healthy on the cluster

## Context

Follow-up to #1091. Removing `keyPermissions` fixed the circular dependency, but Flux still can't reconcile garage-config because its health checker doesn't recognize garage CRD kinds.

## Test plan

- [ ] `flux --context live get kustomization garage-config` → Ready
- [ ] `flux --context live get kustomization database-config` → Ready (unblocked)
- [ ] `flux --context live get kustomization dragonfly-config` → Ready (unblocked)
- [ ] `kubectl --context live get garagebuckets -A` → all Ready
- [ ] `kubectl --context live get garagekeys -A` → keys in database/cache namespaces