### PR TITLE
fix(bazarr): sync API key via init container

### DIFF
--- a/kubernetes/clusters/live/charts/bazarr.yaml
+++ b/kubernetes/clusters/live/charts/bazarr.yaml
@@ -18,6 +18,29 @@ controllers:
         seccompProfile:
           type: RuntimeDefault
 
+    initContainers:
+      config-patch:
+        image:
+          repository: docker.io/mikefarah/yq
+          tag: "${yq_version}"
+        args:
+          - sh
+          - -c
+          - |
+            [ -f /config/config/config.yaml ] &&
+            yq -i '.auth.apikey = strenv(BAZARR_API_KEY)' /config/config/config.yaml
+        env:
+          BAZARR_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: bazarr-api-key
+                key: api-key
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+
     containers:
       app:
         image:
@@ -93,6 +116,8 @@ persistence:
     storageClass: fast
     advancedMounts:
       bazarr:
+        config-patch:
+          - path: /config
         app:
           - path: /config
   media-library:

--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -126,7 +126,7 @@ spec:
         name: app-template
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
-      dependsOn: []
+      dependsOn: [secret-generator]
     - name: radarr
       namespace: media
       chart:

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -50,6 +50,8 @@ tandoor_version=2.6.9
 recyclarr_version=8.6.0
 # renovate: datasource=docker depName=bazarr packageName=ghcr.io/home-operations/bazarr
 bazarr_version=1.5.6
+# renovate: datasource=docker depName=yq packageName=mikefarah/yq
+yq_version=4.45.4
 # renovate: datasource=docker depName=paperless-ngx packageName=ghcr.io/paperless-ngx/paperless-ngx
 paperless_ngx_version=2.20.15
 # renovate: datasource=docker depName=vaultwarden packageName=vaultwarden/server


### PR DESCRIPTION
## Summary
- Bazarr ignores `BAZARR__AUTH__APIKEY` env var — its Dynaconf config uses `core_loaders=['YAML']`, skipping env var loading entirely
- This causes exportarr and homepage to auth with the secret-generator key while bazarr uses its own self-generated key from the PVC config
- Add a `yq` init container that patches `auth.apikey` in `/config/config/config.yaml` before bazarr starts, making the secret-generator value authoritative
- Add missing `secret-generator` dependency to the bazarr HelmRelease (other *arr apps already have this)
- Add `yq_version` to `versions.env` for Renovate tracking

## Test plan
- [ ] Verify bazarr pod starts with init container completing successfully
- [ ] Confirm `/config/config/config.yaml` contains the secret-generator API key after boot
- [ ] Verify exportarr can authenticate to bazarr API
- [ ] Verify homepage widget shows bazarr status correctly
- [ ] Confirm first-boot scenario (no existing config.yaml) still works — init container skips, bazarr generates config, next restart patches it