### PR TITLE
fix(bazarr): override yq entrypoint in init container

### DIFF
--- a/kubernetes/clusters/live/charts/bazarr.yaml
+++ b/kubernetes/clusters/live/charts/bazarr.yaml
@@ -23,9 +23,8 @@ controllers:
         image:
           repository: docker.io/mikefarah/yq
           tag: "${yq_version}"
+        command: [sh, -c]
         args:
-          - sh
-          - -c
           - |
             [ -f /config/config/config.yaml ] &&
             yq -i '.auth.apikey = strenv(BAZARR_API_KEY)' /config/config/config.yaml


### PR DESCRIPTION
## Summary
- The `mikefarah/yq` image has `ENTRYPOINT ["/usr/bin/yq"]`, so passing `sh -c` as `args` runs `yq sh -c ...` instead of `sh -c ...`
- Fix: use `command: [sh, -c]` to override the entrypoint, with the script as `args`
- Follow-up to #1093

## Test plan
- [ ] Init container exits 0
- [ ] bazarr pod reaches Running/Ready
- [ ] Exportarr can authenticate to bazarr API