### PR TITLE
fix(bazarr): mount /tmp for yq init container

### DIFF
--- a/kubernetes/clusters/live/charts/bazarr.yaml
+++ b/kubernetes/clusters/live/charts/bazarr.yaml
@@ -130,5 +130,7 @@ persistence:
     type: emptyDir
     advancedMounts:
       bazarr:
+        config-patch:
+          - path: /tmp
         app:
           - path: /tmp

--- a/kubernetes/clusters/live/charts/bazarr.yaml
+++ b/kubernetes/clusters/live/charts/bazarr.yaml
@@ -23,9 +23,8 @@ controllers:
         image:
           repository: docker.io/mikefarah/yq
           tag: "${yq_version}"
+        command: [sh, -c]
         args:
-          - sh
-          - -c
           - |
             [ -f /config/config/config.yaml ] &&
             yq -i '.auth.apikey = strenv(BAZARR_API_KEY)' /config/config/config.yaml


### PR DESCRIPTION
## Summary
- `yq -i` writes a temp file to `/tmp` before atomic rename
- Init container has `readOnlyRootFilesystem: true` but no `/tmp` emptyDir mount
- Add the existing `tmp` emptyDir to the `config-patch` init container's `advancedMounts`
- Follow-up to #1094

## Test plan
- [ ] Init container exits 0
- [ ] bazarr pod reaches Running/Ready
- [ ] API key in config.yaml matches secret-generator value