### PR TITLE
fix: kubectl-guard false positive on argument values

### DIFF
--- a/.claude/hooks/kubectl-guard.sh
+++ b/.claude/hooks/kubectl-guard.sh
@@ -23,9 +23,11 @@ if [ -z "$KUBECTL_INVOCATIONS" ]; then
   exit 0
 fi
 
-# Only intercept mutating subcommands
-MUTATING='\b(apply|delete|patch|edit|replace|create|scale|drain|taint|cordon|uncordon|label|annotate|set)\b'
-if ! echo "$KUBECTL_INVOCATIONS" | grep -qE "$MUTATING"; then
+# Extract kubectl subcommands (first non-flag token after kubectl and optional --context/--namespace args)
+SUBCOMMANDS=$(echo "$KUBECTL_INVOCATIONS" | sed -E 's/.*kubectl[[:space:]]+(--[a-z]+[[:space:]]+[^[:space:]]+[[:space:]]+)*//; s/[[:space:]].*//')
+
+MUTATING='^(apply|delete|patch|edit|replace|create|scale|drain|taint|cordon|uncordon|label|annotate|set)$'
+if ! echo "$SUBCOMMANDS" | grep -qE "$MUTATING"; then
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- `\bpatch\b` regex matched `patch` inside argument values like `config-patch` (hyphen is a word boundary)
- This blocked read-only commands like `kubectl logs --context live -c config-patch`
- Fix: extract the kubectl subcommand (first positional arg) before matching, instead of grepping the full command line

## Test plan
- [ ] `kubectl logs --context live -c config-patch` → allowed
- [ ] `kubectl patch --context live deployment foo` → blocked
- [ ] `kubectl delete --context live pod foo` → blocked
- [ ] `kubectl get --context live pods` → allowed