### PR TITLE
chore: bump memory limits across all workloads

### DIFF
--- a/kubernetes/clusters/live/charts/bazarr.yaml
+++ b/kubernetes/clusters/live/charts/bazarr.yaml
@@ -71,7 +71,7 @@ controllers:
             cpu: 50m
             memory: 256Mi
           limits:
-            memory: 1Gi
+            memory: 2Gi
         probes:
           startup:
             enabled: true

--- a/kubernetes/clusters/live/charts/booter.yaml
+++ b/kubernetes/clusters/live/charts/booter.yaml
@@ -19,7 +19,7 @@ controllers:
             cpu: 50m
             memory: 64Mi
           limits:
-            memory: 256Mi
+            memory: 512Mi
         securityContext:
           capabilities:
             add:

--- a/kubernetes/clusters/live/charts/exportarr.yaml
+++ b/kubernetes/clusters/live/charts/exportarr.yaml
@@ -40,7 +40,7 @@ controllers:
             cpu: 10m
             memory: 64Mi
           limits:
-            memory: 256Mi
+            memory: 512Mi
         probes:
           liveness:
             enabled: true
@@ -96,7 +96,7 @@ controllers:
             cpu: 10m
             memory: 64Mi
           limits:
-            memory: 256Mi
+            memory: 512Mi
         probes:
           liveness:
             enabled: true
@@ -152,7 +152,7 @@ controllers:
             cpu: 10m
             memory: 64Mi
           limits:
-            memory: 256Mi
+            memory: 512Mi
         probes:
           liveness:
             enabled: true
@@ -208,7 +208,7 @@ controllers:
             cpu: 10m
             memory: 64Mi
           limits:
-            memory: 256Mi
+            memory: 512Mi
         probes:
           liveness:
             enabled: true
@@ -264,7 +264,7 @@ controllers:
             cpu: 10m
             memory: 64Mi
           limits:
-            memory: 256Mi
+            memory: 512Mi
         probes:
           liveness:
             enabled: true
@@ -320,7 +320,7 @@ controllers:
             cpu: 10m
             memory: 64Mi
           limits:
-            memory: 256Mi
+            memory: 512Mi
         probes:
           liveness:
             enabled: true
@@ -376,7 +376,7 @@ controllers:
             cpu: 10m
             memory: 64Mi
           limits:
-            memory: 256Mi
+            memory: 512Mi
         probes:
           liveness:
             enabled: true

--- a/kubernetes/clusters/live/charts/factorio.yaml
+++ b/kubernetes/clusters/live/charts/factorio.yaml
@@ -34,7 +34,7 @@ controllers:
             cpu: 500m
             memory: 1Gi
           limits:
-            memory: 4Gi
+            memory: 8Gi
         probes:
           liveness:
             enabled: true

--- a/kubernetes/clusters/live/charts/firefly.yaml
+++ b/kubernetes/clusters/live/charts/firefly.yaml
@@ -45,7 +45,7 @@ controllers:
             cpu: 50m
             memory: 256Mi
           limits:
-            memory: 1Gi
+            memory: 2Gi
         probes:
           startup:
             enabled: true

--- a/kubernetes/clusters/live/charts/immich.yaml
+++ b/kubernetes/clusters/live/charts/immich.yaml
@@ -33,7 +33,7 @@ controllers:
             cpu: 100m
             memory: 512Mi
           limits:
-            memory: 2Gi
+            memory: 4Gi
 
 immich:
   metrics:
@@ -87,7 +87,7 @@ machine-learning:
               cpu: 100m
               memory: 1Gi
             limits:
-              memory: 4Gi
+              memory: 8Gi
               nvidia.com/gpu: 1
   persistence:
     cache:

--- a/kubernetes/clusters/live/charts/it-tools.yaml
+++ b/kubernetes/clusters/live/charts/it-tools.yaml
@@ -16,7 +16,7 @@ controllers:
             cpu: 10m
             memory: 64Mi
           limits:
-            memory: 256Mi
+            memory: 512Mi
         probes:
           liveness:
             enabled: true

--- a/kubernetes/clusters/live/charts/jellyfin-exporter.yaml
+++ b/kubernetes/clusters/live/charts/jellyfin-exporter.yaml
@@ -37,7 +37,7 @@ controllers:
             cpu: 10m
             memory: 32Mi
           limits:
-            memory: 128Mi
+            memory: 256Mi
         probes:
           startup:
             enabled: true

--- a/kubernetes/clusters/live/charts/jellyseerr.yaml
+++ b/kubernetes/clusters/live/charts/jellyseerr.yaml
@@ -41,7 +41,7 @@ controllers:
             cpu: 50m
             memory: 256Mi
           limits:
-            memory: 512Mi
+            memory: 2Gi
         probes:
           startup:
             enabled: true

--- a/kubernetes/clusters/live/charts/jfa-go.yaml
+++ b/kubernetes/clusters/live/charts/jfa-go.yaml
@@ -26,7 +26,7 @@ controllers:
             cpu: 10m
             memory: 64Mi
           limits:
-            memory: 256Mi
+            memory: 512Mi
         probes:
           startup:
             enabled: true

--- a/kubernetes/clusters/live/charts/lldap.yaml
+++ b/kubernetes/clusters/live/charts/lldap.yaml
@@ -66,7 +66,7 @@ controllers:
             cpu: 10m
             memory: 64Mi
           limits:
-            memory: 256Mi
+            memory: 512Mi
         probes:
           liveness:
             enabled: true

--- a/kubernetes/clusters/live/charts/minecraft.yaml
+++ b/kubernetes/clusters/live/charts/minecraft.yaml
@@ -57,7 +57,7 @@ controllers:
             cpu: 500m
             memory: 4Gi
           limits:
-            memory: 6Gi
+            memory: 32Gi
         probes:
           startup:
             enabled: true
@@ -110,7 +110,7 @@ controllers:
             cpu: 50m
             memory: 256Mi
           limits:
-            memory: 512Mi
+            memory: 2Gi
         probes:
           startup:
             enabled: false
@@ -141,7 +141,7 @@ controllers:
             cpu: 10m
             memory: 32Mi
           limits:
-            memory: 128Mi
+            memory: 256Mi
         probes:
           startup:
             enabled: false

--- a/kubernetes/clusters/live/charts/paperless.yaml
+++ b/kubernetes/clusters/live/charts/paperless.yaml
@@ -104,7 +104,7 @@ controllers:
             cpu: 100m
             memory: 512Mi
           limits:
-            memory: 2Gi
+            memory: 4Gi
         probes:
           startup:
             enabled: true

--- a/kubernetes/clusters/live/charts/prowlarr.yaml
+++ b/kubernetes/clusters/live/charts/prowlarr.yaml
@@ -49,7 +49,7 @@ controllers:
             cpu: 50m
             memory: 256Mi
           limits:
-            memory: 512Mi
+            memory: 2Gi
         probes:
           startup:
             enabled: true

--- a/kubernetes/clusters/live/charts/qbittorrent.yaml
+++ b/kubernetes/clusters/live/charts/qbittorrent.yaml
@@ -53,7 +53,7 @@ controllers:
             cpu: 10m
             memory: 64Mi
           limits:
-            memory: 256Mi
+            memory: 512Mi
         probes:
           startup:
             enabled: true
@@ -94,7 +94,7 @@ controllers:
             cpu: 100m
             memory: 512Mi
           limits:
-            memory: 2Gi
+            memory: 8Gi
         probes:
           startup:
             enabled: true
@@ -143,7 +143,7 @@ controllers:
             cpu: 10m
             memory: 32Mi
           limits:
-            memory: 128Mi
+            memory: 256Mi
         probes:
           startup:
             enabled: true

--- a/kubernetes/clusters/live/charts/recyclarr.yaml
+++ b/kubernetes/clusters/live/charts/recyclarr.yaml
@@ -59,7 +59,7 @@ controllers:
             cpu: 10m
             memory: 64Mi
           limits:
-            memory: 128Mi
+            memory: 512Mi
 
 persistence:
   config-dir:

--- a/kubernetes/clusters/live/charts/sabnzbd.yaml
+++ b/kubernetes/clusters/live/charts/sabnzbd.yaml
@@ -48,7 +48,7 @@ controllers:
             cpu: 50m
             memory: 256Mi
           limits:
-            memory: 8Gi
+            memory: 16Gi
         probes:
           startup:
             enabled: true

--- a/kubernetes/clusters/live/charts/tandoor.yaml
+++ b/kubernetes/clusters/live/charts/tandoor.yaml
@@ -92,7 +92,7 @@ controllers:
             cpu: 50m
             memory: 256Mi
           limits:
-            memory: 1Gi
+            memory: 4Gi
         probes:
           startup:
             enabled: true

--- a/kubernetes/clusters/live/charts/tdarr-node.yaml
+++ b/kubernetes/clusters/live/charts/tdarr-node.yaml
@@ -53,7 +53,7 @@ controllers:
             cpu: 500m
             memory: 2Gi
           limits:
-            memory: 4Gi
+            memory: 16Gi
             nvidia.com/gpu: 1
         probes:
           # Tdarr_Node v2.x is a purely outbound worker — it connects to the

--- a/kubernetes/clusters/live/charts/valheim.yaml
+++ b/kubernetes/clusters/live/charts/valheim.yaml
@@ -49,7 +49,7 @@ controllers:
             cpu: "4"
             memory: 6Gi
           limits:
-            memory: 6Gi
+            memory: 8Gi
         probes:
           startup:
             enabled: true

--- a/kubernetes/clusters/live/charts/vaultwarden.yaml
+++ b/kubernetes/clusters/live/charts/vaultwarden.yaml
@@ -75,7 +75,7 @@ controllers:
             cpu: 10m
             memory: 128Mi
           limits:
-            memory: 512Mi
+            memory: 1Gi
         probes:
           startup:
             enabled: true

--- a/kubernetes/clusters/live/charts/zipline.yaml
+++ b/kubernetes/clusters/live/charts/zipline.yaml
@@ -69,7 +69,7 @@ controllers:
             cpu: 50m
             memory: 256Mi
           limits:
-            memory: 512Mi
+            memory: 2Gi
         probes:
           startup:
             enabled: true

--- a/kubernetes/clusters/live/config/immich/immich-cluster.yaml
+++ b/kubernetes/clusters/live/config/immich/immich-cluster.yaml
@@ -59,7 +59,7 @@ spec:
       cpu: 50m
       memory: 256Mi
     limits:
-      memory: 1Gi
+      memory: 2Gi
 
   monitoring:
     enablePodMonitor: true

--- a/kubernetes/platform/charts/cloudnative-pg.yaml
+++ b/kubernetes/platform/charts/cloudnative-pg.yaml
@@ -15,4 +15,4 @@ resources:
     cpu: 10m
     memory: 100Mi
   limits:
-    memory: 256Mi
+    memory: 800Mi

--- a/kubernetes/platform/charts/dragonfly-operator.yaml
+++ b/kubernetes/platform/charts/dragonfly-operator.yaml
@@ -13,7 +13,7 @@ resources:
     cpu: 10m
     memory: 128Mi
   limits:
-    memory: 256Mi
+    memory: 1Gi
 
 # Disable kube-rbac-proxy sidecar so the manager binds metrics to 0.0.0.0:8080
 # instead of 127.0.0.1:8080, allowing Prometheus to scrape directly.

--- a/kubernetes/platform/charts/garage-operator.yaml
+++ b/kubernetes/platform/charts/garage-operator.yaml
@@ -5,7 +5,7 @@ resources:
     cpu: 10m
     memory: 128Mi
   limits:
-    memory: 256Mi
+    memory: 1Gi
 
 metrics:
   enabled: true

--- a/kubernetes/platform/charts/grafana-loki-single-binary.yaml
+++ b/kubernetes/platform/charts/grafana-loki-single-binary.yaml
@@ -32,6 +32,12 @@ loki:
 singleBinary:
   replicas: 1
   priorityClassName: platform
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 4Gi
   persistence:
     enabled: true
     storageClass: fast

--- a/kubernetes/platform/charts/grafana.yaml
+++ b/kubernetes/platform/charts/grafana.yaml
@@ -323,7 +323,7 @@ imageRenderer:
       cpu: 50m
       memory: 128Mi
     limits:
-      memory: 512Mi
+      memory: 2Gi
   serviceMonitor:
     enabled: true
     labels:

--- a/kubernetes/platform/charts/istio-csr.yaml
+++ b/kubernetes/platform/charts/istio-csr.yaml
@@ -76,4 +76,4 @@ resources:
     cpu: 10m
     memory: 32Mi
   limits:
-    memory: 128Mi
+    memory: 256Mi

--- a/kubernetes/platform/charts/kromgo.yaml
+++ b/kubernetes/platform/charts/kromgo.yaml
@@ -42,7 +42,7 @@ controllers:
             cpu: 10m
             memory: 32Mi
           limits:
-            memory: 128Mi
+            memory: 256Mi
         probes:
           liveness:
             enabled: true

--- a/kubernetes/platform/charts/oauth2-proxy.yaml
+++ b/kubernetes/platform/charts/oauth2-proxy.yaml
@@ -72,4 +72,4 @@ resources:
     cpu: 10m
     memory: 32Mi
   limits:
-    memory: 64Mi
+    memory: 256Mi

--- a/kubernetes/platform/charts/prometheus-ipmi-exporter.yaml
+++ b/kubernetes/platform/charts/prometheus-ipmi-exporter.yaml
@@ -18,4 +18,4 @@ resources:
     # leaks through Helm deep-merge). Set a generous limit instead — ipmitool
     # subprocesses cause brief CPU spikes that throttle heavily at 100m.
     cpu: "1"
-    memory: 128Mi
+    memory: 512Mi

--- a/kubernetes/platform/charts/prometheus-snmp-exporter.yaml
+++ b/kubernetes/platform/charts/prometheus-snmp-exporter.yaml
@@ -8,4 +8,4 @@ resources:
     cpu: 10m
     memory: 100Mi
   limits:
-    memory: 256Mi
+    memory: 800Mi

--- a/kubernetes/platform/charts/silence-operator.yaml
+++ b/kubernetes/platform/charts/silence-operator.yaml
@@ -25,4 +25,4 @@ resources:
     cpu: 10m
     memory: 32Mi
   limits:
-    memory: 64Mi
+    memory: 256Mi

--- a/kubernetes/platform/charts/velero.yaml
+++ b/kubernetes/platform/charts/velero.yaml
@@ -30,7 +30,7 @@ nodeAgent:
       cpu: 50m
       memory: 128Mi
     limits:
-      memory: 512Mi
+      memory: 1Gi
 
 configuration:
   features: EnableCSI

--- a/kubernetes/platform/config/database/cluster.yaml
+++ b/kubernetes/platform/config/database/cluster.yaml
@@ -53,7 +53,7 @@ spec:
       cpu: 100m
       memory: 512Mi
     limits:
-      memory: 2Gi
+      memory: 4Gi
 
   monitoring:
     enablePodMonitor: true

--- a/kubernetes/platform/config/dragonfly/dragonfly-instance.yaml
+++ b/kubernetes/platform/config/dragonfly/dragonfly-instance.yaml
@@ -31,7 +31,7 @@ spec:
       cpu: 100m
       memory: 256Mi
     limits:
-      memory: 1Gi
+      memory: 2Gi
 
   args:
     - "--maxmemory"

--- a/kubernetes/platform/config/garage/garage-cluster.yaml
+++ b/kubernetes/platform/config/garage/garage-cluster.yaml
@@ -30,7 +30,7 @@ spec:
         cpu: 100m
         memory: 256Mi
       limits:
-        memory: 1Gi
+        memory: 2Gi
     securityContext:
       runAsUser: 1000
       runAsGroup: 1000


### PR DESCRIPTION
## Summary

- Apply generous 8× request-to-limit ratio across all workloads as baseline
- Hot spots (minecraft, qbittorrent, sabnzbd, tandoor, grafana) get extra headroom based on observed usage
- Add missing memory limits for grafana-loki (4Gi) and prometheus-ipmi-exporter (512Mi)
- Nodes at 18-41% memory utilization — plenty of room for generous limits

Limits exist to catch runaway leaks, not to constrain normal operation. No HPAs in use — vertical scaling only.

## Changes (38 files)

**Hot spots (near current limits):**
| App | Actual Use | Old Limit | New Limit |
|-----|-----------|-----------|-----------|
| minecraft | 4.9Gi | 6Gi | 32Gi |
| qbittorrent | 1.8Gi | 2Gi | 8Gi |
| sabnzbd | 3.4Gi | 8Gi | 16Gi |
| tandoor | 683Mi | 1Gi | 4Gi |
| grafana | 342Mi | 512Mi | 2Gi |

**Standard bumps (8× requests):**
bazarr, booter, exportarr, factorio, firefly, immich (server+ML+DB), it-tools, jellyfin-exporter, jellyseerr, jfa-go, lldap, paperless, prowlarr, recyclarr, tdarr-node, valheim, vaultwarden, zipline, cloudnative-pg, cnpg-cluster, dragonfly-operator, dragonfly-instance, garage-operator, garage-cluster, istio-csr, kromgo, oauth2-proxy, snmp-exporter, silence-operator, velero

**New limits added:**
- grafana-loki: requests 100m/512Mi, limit 4Gi
- prometheus-ipmi-exporter: memory limit 512Mi

## Test plan
- [ ] Flux reconciles all HelmReleases successfully
- [ ] No OOMKills after rollout
- [ ] `kubectl top pods -A` shows all pods well within new limits