### PR TITLE
fix(homepage): resolve dashboard errors and redesign layout

### DIFF
--- a/kubernetes/clusters/live/charts/homepage.yaml
+++ b/kubernetes/clusters/live/charts/homepage.yaml
@@ -93,6 +93,16 @@ controllers:
               secretKeyRef:
                 name: homepage-firefly-api-key
                 key: api-key
+          HOMEPAGE_VAR_SONARR4K_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: sonarr4k-api-key
+                key: api-key
+          HOMEPAGE_VAR_RADARR4K_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: radarr4k-api-key
+                key: api-key
         resources:
           requests:
             cpu: 10m
@@ -160,20 +170,22 @@ configMaps:
         statusStyle: dot
         hideVersion: true
         layout:
-          - Platform:
-              icon: mdi-server
-              columns: 4
           - Media:
               icon: mdi-multimedia
+              style: row
               columns: 4
           - Apps:
               icon: mdi-apps
+              style: row
               columns: 3
-          - AI:
-              icon: mdi-robot
+          - Platform:
+              icon: mdi-server
+              style: row
+              columns: 4
           - Gaming:
               icon: mdi-gamepad-variant
-              columns: 4
+              style: row
+              columns: 2
       widgets.yaml: |
         - search:
             provider: google
@@ -188,18 +200,10 @@ configMaps:
               label: live
             nodes:
               show: false
-        - longhorn:
-            expanded: true
-            total: true
-            labels: true
-            nodes: true
         - openmeteo:
             timezone: America/New_York
             units: imperial
             cache: 15
-        - healthchecks:
-            url: https://healthchecks.io
-            key: "{{`{{HOMEPAGE_VAR_HEALTHCHECKS_API_KEY}}`}}"
       services.yaml: |
         - Gaming:
             - Minecraft:
@@ -250,7 +254,20 @@ configMaps:
                   href: https://healthchecks.io
       docker.yaml: ""
       proxmox.yaml: ""
-      custom.css: ""
+      custom.css: |
+        #information-widgets .information-widget-resource .resource-value {
+          font-size: 0.85rem;
+        }
+        .service-card {
+          padding: 0.5rem !important;
+        }
+        .services-group .service .status-indicator {
+          opacity: 0.4;
+          transition: opacity 0.2s ease;
+        }
+        .services-group .service:hover .status-indicator {
+          opacity: 1;
+        }
       custom.js: ""
 
 persistence:

--- a/kubernetes/clusters/live/config/homepage/internal-route.yaml
+++ b/kubernetes/clusters/live/config/homepage/internal-route.yaml
@@ -9,7 +9,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: "Home"
     gethomepage.dev/group: "Platform"
-    gethomepage.dev/icon: "homepage.svg"
+    gethomepage.dev/icon: "mdi-home"
     gethomepage.dev/pod-selector: "app.kubernetes.io/name=homepage"
 spec:
   parentRefs:

--- a/kubernetes/clusters/live/config/homepage/network-policy.yaml
+++ b/kubernetes/clusters/live/config/homepage/network-policy.yaml
@@ -90,6 +90,13 @@ spec:
         - ports:
             - port: "34197"
               protocol: UDP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: firefly
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
     - toFQDNs:
         - matchName: "healthchecks.io"
       toPorts:

--- a/kubernetes/clusters/live/config/homepage/secrets.yaml
+++ b/kubernetes/clusters/live/config/homepage/secrets.yaml
@@ -29,6 +29,24 @@ data: { }
 apiVersion: v1
 kind: Secret
 metadata:
+  name: sonarr4k-api-key
+  namespace: homepage
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: media/sonarr4k-api-key
+data: { }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: radarr4k-api-key
+  namespace: homepage
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: media/radarr4k-api-key
+data: { }
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: jellyfin-api-token
   namespace: homepage
   annotations:


### PR DESCRIPTION
## Summary

- **4K API keys**: Add `sonarr4k-api-key` and `radarr4k-api-key` replicated secrets + env vars so Sonarr 4K / Radarr 4K widgets can authenticate
- **Firefly egress**: Add missing network policy rule for `firefly` namespace port 8080
- **Broken icon**: Fix Home entry icon from non-existent `homepage.svg` to `mdi-home`
- **Remove empty AI section**: Layout defined `AI` but Open WebUI annotation puts it in `Apps` — dead section removed
- **Remove broken header widgets**: Longhorn (HTTP 400) and Healthchecks ("Missing") removed from header bar until root cause investigated
- **Layout redesign**: Add `style: row` to all sections for horizontal grid rendering, reorder by usage frequency (Media → Apps → Platform → Gaming)
- **Custom CSS**: Tighter card padding, muted status dots with hover reveal

## Phase 3 (post-merge investigation)

These require live cluster access to debug:

| Issue | Next step |
|-------|-----------|
| All widgets show "-" | Check pod logs for API errors |
| Longhorn HTTP 400 | Test API endpoint compatibility with v1.11.2 |
| Healthchecks "Missing" | Verify ExternalSecret sync |
| Missing status dots | Check RBAC / pod-selector labels |
| Factorio 500 | Check if server pod running |

Re-add Longhorn/Healthchecks widgets after investigation fixes root causes.

## Test plan

- [ ] After Flux reconcile, reload `home.internal.tomnowak.work`
- [ ] Header bar: no "API Error", no "Missing healthchecks"
- [ ] Home entry shows proper icon
- [ ] No empty AI section
- [ ] Layout uses horizontal grid rows
- [ ] Sonarr 4K / Radarr 4K widgets attempt to load
- [ ] Firefly III widget attempts to load