### PR TITLE
fix(renovate): disable automerge for garage-operator

### DIFF
--- a/.renovate/automerge.json5
+++ b/.renovate/automerge.json5
@@ -50,6 +50,15 @@
       "minimumReleaseAge": "1 day"
     },
     // EXCLUSIONS LAST (later rules override earlier - these take precedence)
+    // garage-operator upgrades have caused repeated outages due to migration issues
+    // (e.g., v0.5.11 -> v0.6.1 in PR #1108). Require manual review before merge.
+    {
+      "description": "Never automerge garage-operator — version bumps cause migration-related outages",
+      "matchDepNames": [
+        "garage-operator"
+      ],
+      "automerge": false
+    },
     // Never automerge major updates - breaking changes need review
     {
       "description": "Never automerge major updates",


### PR DESCRIPTION
## Summary

- Adds a packageRule to `.renovate/automerge.json5` that disables automerge for `garage-operator`
- Renovate will still create PRs for garage-operator updates, but they will no longer be auto-merged
- Motivated by repeated outages from auto-merged version bumps (e.g., v0.5.11 to v0.6.1 in PR #1108) caused by migration-related issues

## Test plan

- [x] `task renovate:validate` passes
- [ ] Verify next Renovate PR for garage-operator does not have automerge enabled