### PR TITLE
fix(garage): bump garage-operator to v0.6.3

### DIFF
--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -51,7 +51,7 @@ istio_version=1.30.0
 # renovate: datasource=helm depName=cert-manager-istio-csr registryUrl=https://charts.jetstack.io
 istio_csr_version=v0.16.0
 # renovate: datasource=docker depName=garage-operator packageName=ghcr.io/rajsinghtech/charts/garage-operator
-garage_operator_version=0.6.1
+garage_operator_version=0.6.3
 # renovate: datasource=helm depName=cloudnative-pg registryUrl=https://cloudnative-pg.github.io/charts
 cloudnative_pg_version=0.28.2
 # renovate: datasource=docker depName=dragonfly-operator packageName=ghcr.io/dragonflydb/dragonfly-operator/helm/dragonfly-operator versioning=semver


### PR DESCRIPTION
## Summary
- Bumps garage-operator from v0.6.1 to v0.6.3
- v0.6.0 introduced per-node StatefulSet migration which deadlocked due to missing pod-delete RBAC — orphan pods held RWO volumes, new pods couldn't start, service had zero endpoints
- Caused 20+ hour garage outage and broke CNPG WAL archiving for `platform` and `immich-database` clusters
- v0.6.3 fixes: pod-delete RBAC (#200), gateway PDB (#199), edge-gateway RPC fallback (#198)

## Root cause
The operator's ClusterRole only had `get;list;watch` on pods — the migration's orphan pod deletion returned 403. Fixed in [PR #201](https://github.com/rajsinghtech/garage-operator/pull/201).

## Expected behavior after merge
Operator completes legacy STS migration sweep → deletes orphan pods → new per-node pods attach volumes → garage cluster forms quorum → CNPG WAL archiving resumes.

## Test plan
- [ ] Verify operator pod restarts with v0.6.3 image
- [ ] Verify `garage status` shows 3/3 healthy nodes
- [ ] Verify CNPG ContinuousArchiving condition flips to True
- [ ] Monitor for quorum errors in garage logs