### PR TITLE
refactor(dev): introduce apps/ colocation pattern with paperless guinea pig

### DIFF
--- a/kubernetes/clusters/dev/apps.yaml
+++ b/kubernetes/clusters/dev/apps.yaml
@@ -2,14 +2,13 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: cluster-resources
+  name: cluster-apps
   namespace: flux-system
 spec:
   dependsOn:
     - name: platform
-    - name: cluster-apps
   interval: 3m
-  path: kubernetes/clusters/dev/resourcesets
+  path: kubernetes/clusters/dev/apps
   postBuild:
     substituteFrom:
       - kind: ConfigMap

--- a/kubernetes/clusters/dev/apps/kustomization.yaml
+++ b/kubernetes/clusters/dev/apps/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generatorOptions:
+  disableNameSuffixHash: true
+resources:
+  - paperless
+configMapGenerator:
+  - name: cluster-values
+    namespace: flux-system
+    behavior: create
+    files:
+      - paperless.yaml=paperless/values.yaml

--- a/kubernetes/clusters/dev/apps/paperless/data-pvc.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/data-pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-data
+  namespace: paperless
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: fast
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/clusters/dev/apps/paperless/dragonfly-password-replica.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/dragonfly-password-replica.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dragonfly-auth
+  namespace: paperless
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: cache/dragonfly-auth
+data: { }

--- a/kubernetes/clusters/dev/apps/paperless/internal-route.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/internal-route.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: paperless-internal
+  namespace: paperless
+spec:
+  parentRefs:
+    - name: internal
+      namespace: istio-gateway
+  hostnames:
+    - "paperless.${internal_domain}"
+  rules:
+    - backendRefs:
+        - name: paperless
+          port: 8000

--- a/kubernetes/clusters/dev/apps/paperless/kustomization.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - data-pvc.yaml
+  - media-pvc.yaml
+  - paperless-db-credentials.yaml
+  - dragonfly-password-replica.yaml
+  - paperless-secret.yaml
+  - internal-route.yaml

--- a/kubernetes/clusters/dev/apps/paperless/media-pvc.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/media-pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-media
+  namespace: paperless
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: slow
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/clusters/dev/apps/paperless/namespace.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/namespace.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: paperless
+  labels:
+    istio.io/dataplane-mode: ambient
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+    network-policy.homelab/profile: internal
+    access.network-policy.homelab/postgres: "true"
+    access.network-policy.homelab/dragonfly: "true"

--- a/kubernetes/clusters/dev/apps/paperless/paperless-db-credentials.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/paperless-db-credentials.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: paperless-db-credentials
+  namespace: paperless
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: database/paperless-role-password
+type: Opaque
+data: { }

--- a/kubernetes/clusters/dev/apps/paperless/paperless-secret.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/paperless-secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: paperless-secret
+  namespace: paperless
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: secret-key
+    secret-generator.v1.mittwald.de/length: "64"
+    secret-generator.v1.mittwald.de/encoding: hex
+data: { }

--- a/kubernetes/clusters/dev/apps/paperless/values.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/values.yaml
@@ -1,0 +1,135 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+# https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+controllers:
+  paperless:
+    type: deployment
+    replicas: 1
+    annotations:
+      reloader.stakater.com/auto: "true"
+
+    pod:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+    initContainers:
+      init-run:
+        image:
+          repository: busybox
+          tag: latest
+        command:
+          - /bin/sh
+          - -c
+          - chown 1000:1000 /run
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: false
+          runAsUser: 0
+          runAsGroup: 0
+          capabilities:
+            drop: ["ALL"]
+            add: ["CHOWN", "DAC_OVERRIDE", "FOWNER"]
+
+    containers:
+      app:
+        image:
+          repository: ghcr.io/paperless-ngx/paperless-ngx
+          tag: "${paperless_ngx_version}"
+        env:
+          PAPERLESS_URL: "https://paperless.${internal_domain}"
+          PAPERLESS_PORT: "8000"
+          PAPERLESS_TIME_ZONE: "America/Chicago"
+          PAPERLESS_OCR_LANGUAGE: "eng"
+          PAPERLESS_TASK_WORKERS: "2"
+          PAPERLESS_THREADS_PER_WORKER: "2"
+          PAPERLESS_CONSUMER_POLLING: "0"
+          PAPERLESS_SECRET_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: paperless-secret
+                key: secret-key
+          PAPERLESS_DBPASS:
+            valueFrom:
+              secretKeyRef:
+                name: paperless-db-credentials
+                key: password
+          PAPERLESS_DBHOST: platform-pooler-rw.database.svc.cluster.local
+          PAPERLESS_DBPORT: "5432"
+          PAPERLESS_DBNAME: paperless
+          PAPERLESS_DBUSER: paperless
+          DRAGONFLY_PASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: dragonfly-auth
+                key: password
+          PAPERLESS_REDIS:
+            dependsOn: DRAGONFLY_PASSWORD
+            value: "redis://:$(DRAGONFLY_PASSWORD)@dragonfly.cache.svc.cluster.local:6379"
+          PAPERLESS_DATA_DIR: "/data"
+          PAPERLESS_MEDIA_ROOT: "/media"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            memory: 2Gi
+        probes:
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: 8000
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              failureThreshold: 30
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: 8000
+              periodSeconds: 30
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: 8000
+              periodSeconds: 10
+
+service:
+  app:
+    controller: paperless
+    ports:
+      http:
+        port: 8000
+
+persistence:
+  data:
+    existingClaim: paperless-data
+  media:
+    existingClaim: paperless-media
+  tmp:
+    type: emptyDir
+    globalMounts:
+      - path: /tmp
+  run:
+    type: emptyDir
+    globalMounts:
+      - path: /run

--- a/kubernetes/clusters/dev/config/database/cluster-roles-patch.yaml
+++ b/kubernetes/clusters/dev/config/database/cluster-roles-patch.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: platform
+spec:
+  managed:
+    roles:
+      - name: paperless
+        ensure: present
+        login: true
+        passwordSecret:
+          name: paperless-role-password

--- a/kubernetes/clusters/dev/config/database/databases.yaml
+++ b/kubernetes/clusters/dev/config/database/databases.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: paperless-database
+  namespace: database
+spec:
+  name: paperless
+  owner: paperless
+  cluster:
+    name: platform
+  databaseReclaimPolicy: retain

--- a/kubernetes/clusters/dev/config/database/kustomization.yaml
+++ b/kubernetes/clusters/dev/config/database/kustomization.yaml
@@ -4,7 +4,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../../platform/config/database
+  - databases.yaml
+  - role-secrets.yaml
 patches:
+  - path: cluster-roles-patch.yaml
   - path: recovery-patch.yaml
     target:
       kind: Cluster

--- a/kubernetes/clusters/dev/config/database/role-secrets.yaml
+++ b/kubernetes/clusters/dev/config/database/role-secrets.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: paperless-role-password
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "paperless"
+type: kubernetes.io/basic-auth
+stringData:
+  username: paperless

--- a/kubernetes/clusters/dev/kustomization.yaml
+++ b/kubernetes/clusters/dev/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - platform.yaml
   - config.yaml
+  - apps.yaml
   - helm-charts.yaml
   - velero-restore.yaml
 configMapGenerator:
@@ -22,9 +23,3 @@ configMapGenerator:
     behavior: create
     envs:
       - versions.env
-  - name: cluster-values
-    options:
-      disableNameSuffixHash: true
-    namespace: flux-system
-    behavior: create
-    files: []

--- a/kubernetes/clusters/dev/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/dev/resourcesets/helm-charts.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSet
+metadata:
+  name: cluster-resources
+  namespace: flux-system
+  annotations:
+    fluxcd.controlplane.io/reconcile: "enabled"
+    fluxcd.controlplane.io/reconcileEvery: "30m"
+    fluxcd.controlplane.io/reconcileTimeout: "10m"
+spec:
+  dependsOn:
+    - apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      name: platform
+      namespace: flux-system
+  inputs:
+    - name: paperless
+      namespace: paperless
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: [cloudnative-pg, secret-generator]
+  resourcesTemplate: |
+    ---
+    apiVersion: source.toolkit.fluxcd.io/v1
+    kind: HelmRepository
+    metadata:
+      name: << inputs.name >>
+      namespace: << inputs.provider.namespace >>
+    spec:
+      interval: 10m
+      <<- if hasPrefix "oci://" inputs.chart.url >>
+      type: oci
+      <<- end >>
+      url: << inputs.chart.url >>
+    ---
+    apiVersion: helm.toolkit.fluxcd.io/v2
+    kind: HelmRelease
+    metadata:
+      name: << inputs.name >>
+      namespace: << inputs.provider.namespace >>
+    spec:
+      <<- if inputs.dependsOn >>
+      dependsOn:
+      <<- range $dep := inputs.dependsOn >>
+        - name: << $dep >>
+      <<- end >>
+      <<- end >>
+      chart:
+        spec:
+          chart: << inputs.chart.name >>
+          version: << inputs.chart.version >>
+          interval: 10m
+          sourceRef:
+            kind: HelmRepository
+            name: << inputs.name >>
+      install:
+        createNamespace: false
+        strategy:
+          name: RetryOnFailure
+        timeout: 10m
+      interval: 10m
+      maxHistory: 3
+      releaseName: << inputs.name >>
+      targetNamespace: << inputs.namespace >>
+      uninstall:
+        keepHistory: false
+      upgrade:
+        crds: CreateReplace
+        strategy:
+          name: RetryOnFailure
+        timeout: 10m
+      valuesFrom:
+        - kind: ConfigMap
+          name: cluster-values
+          valuesKey: << inputs.name >>.yaml
+    ---
+    apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    metadata:
+      name: << inputs.name >>
+      namespace: << inputs.provider.namespace >>
+    spec:
+      <<- if inputs.dependsOn >>
+      dependsOn:
+      <<- range $dep := inputs.dependsOn >>
+        - name: << $dep >>
+      <<- end >>
+      <<- end >>
+      interval: 10m
+      path: kubernetes/clusters/dev/stubs/empty
+      prune: false
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+      healthChecks:
+        - apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          name: << inputs.name >>
+          namespace: << inputs.provider.namespace >>

--- a/kubernetes/clusters/dev/resourcesets/kustomization.yaml
+++ b/kubernetes/clusters/dev/resourcesets/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system
+resources:
+  - helm-charts.yaml

--- a/kubernetes/clusters/dev/versions.env
+++ b/kubernetes/clusters/dev/versions.env
@@ -2,4 +2,6 @@
 # - Cluster-specific app versions go here (not in kubernetes/platform/versions.env)
 # - Platform-shared versions (app_template, talos, etc.) remain in kubernetes/platform/versions.env
 # - Renovate updates this file (via inline comment annotations)
-# - Currently empty — dev has no cluster-specific releases
+
+# renovate: datasource=docker depName=paperless-ngx packageName=ghcr.io/paperless-ngx/paperless-ngx
+paperless_ngx_version=2.20.15


### PR DESCRIPTION
## Summary

Guinea pig for #581 — colocate chart values and config resources into `apps/<name>/` directories on the dev cluster using Paperless-NGX as the test app.

- **New `apps/paperless/` directory** contains `values.yaml` (chart values) and all config resources (namespace, PVCs, secrets, HTTPRoute) in a single directory — eliminating the `charts/` + `config/` split
- **`apps/kustomization.yaml`** generates `cluster-values` ConfigMap inside a Flux Kustomization with `postBuild.substituteFrom`, ensuring `${internal_domain}` and `${paperless_ngx_version}` are resolved before the ConfigMap hits the cluster
- **`helm-charts.yaml` restructured** from bare ResourceSet to Flux Kustomization wrapper pointing at `resourcesets/` — matches live cluster pattern and enables `${app_template_version}` substitution
- **Dependency chain**: `platform` → `cluster-apps` → `cluster-resources` ensures ConfigMap exists before HelmRelease reads it
- **DB provisioning** added to `config/database/` (CNPG managed role, role secret, Database CRD)

### Key design decisions

| Decision | Rationale |
|----------|-----------|
| Separate `apps.yaml` Flux Kustomization (not merging into `config.yaml`) | Avoids disrupting existing silences/garage/database config on dev |
| DB provisioning stays in `config/database/` | Infrastructure concern (CNPG cluster patches), not app-level |
| ConfigMap generation in `apps/kustomization.yaml` | Must be inside Flux Kustomization with `substituteFrom` for variable resolution |
| No OIDC/canary on dev | No Authelia on dev; canary skipped for initial validation |

### New directory structure
```
clusters/dev/
├── apps/
│   ├── kustomization.yaml           # configMapGenerator + resource listing
│   └── paperless/
│       ├── values.yaml              # Chart values (was charts/paperless.yaml)
│       ├── kustomization.yaml       # Config resources
│       ├── namespace.yaml
│       ├── data-pvc.yaml
│       ├── media-pvc.yaml
│       ├── paperless-db-credentials.yaml
│       ├── dragonfly-password-replica.yaml
│       ├── paperless-secret.yaml
│       └── internal-route.yaml
├── resourcesets/
│   ├── kustomization.yaml
│   └── helm-charts.yaml             # ResourceSet (moved from root)
├── apps.yaml                        # Flux Kustomization for apps/
├── helm-charts.yaml                 # Now a Flux Kustomization wrapper
└── ...
```

Closes #581 (partially — dev cluster only, live migration to follow)

## Test plan

- [x] `task k8s:validate` passes
- [x] `kustomize build kubernetes/clusters/dev` produces correct output
- [x] `kustomize build kubernetes/clusters/dev/apps` generates `cluster-values` ConfigMap with paperless values
- [x] `task k8s:dry-run-dev` — only pre-existing `${source_kind}` errors (same as main)
- [ ] Flux reconciliation succeeds on dev cluster after merge
- [ ] Paperless pod reaches Running state
- [ ] `paperless.internal.dev.tomnowak.work` accessible via internal gateway