### PR TITLE
fix: escape Homepage widget.key template vars in route annotations

### DIFF
--- a/kubernetes/clusters/live/charts/bazarr.yaml
+++ b/kubernetes/clusters/live/charts/bazarr.yaml
@@ -117,7 +117,7 @@ route:
       gethomepage.dev/icon: "bazarr.svg"
       gethomepage.dev/widget.type: "bazarr"
       gethomepage.dev/widget.url: "http://bazarr.media.svc:6767"
-      gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_BAZARR_API_KEY}}"
+      gethomepage.dev/widget.key: "{{`{{HOMEPAGE_VAR_BAZARR_API_KEY}}`}}"
       gethomepage.dev/pod-selector: "app.kubernetes.io/name=bazarr"
     parentRefs:
       - name: internal

--- a/kubernetes/clusters/live/charts/firefly.yaml
+++ b/kubernetes/clusters/live/charts/firefly.yaml
@@ -92,7 +92,7 @@ route:
       gethomepage.dev/pod-selector: "app.kubernetes.io/name=firefly"
       gethomepage.dev/widget.type: "firefly"
       gethomepage.dev/widget.url: "http://firefly.firefly.svc:8080"
-      gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_FIREFLY_API_KEY}}"
+      gethomepage.dev/widget.key: "{{`{{HOMEPAGE_VAR_FIREFLY_API_KEY}}`}}"
     parentRefs:
       - name: internal
         namespace: istio-gateway

--- a/kubernetes/clusters/live/charts/jellyfin.yaml
+++ b/kubernetes/clusters/live/charts/jellyfin.yaml
@@ -80,7 +80,7 @@ route:
       gethomepage.dev/icon: "jellyfin.svg"
       gethomepage.dev/widget.type: "jellyfin"
       gethomepage.dev/widget.url: "http://jellyfin.media.svc:8096"
-      gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_JELLYFIN_API_KEY}}"
+      gethomepage.dev/widget.key: "{{`{{HOMEPAGE_VAR_JELLYFIN_API_KEY}}`}}"
       gethomepage.dev/widget.enableNowPlaying: "true"
       gethomepage.dev/pod-selector: "app.kubernetes.io/name=jellyfin"
     parentRefs:

--- a/kubernetes/clusters/live/charts/jellyseerr.yaml
+++ b/kubernetes/clusters/live/charts/jellyseerr.yaml
@@ -87,7 +87,7 @@ route:
       gethomepage.dev/icon: "jellyseerr.svg"
       gethomepage.dev/widget.type: "jellyseerr"
       gethomepage.dev/widget.url: "http://jellyseerr.media.svc:5055"
-      gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_JELLYSEERR_API_KEY}}"
+      gethomepage.dev/widget.key: "{{`{{HOMEPAGE_VAR_JELLYSEERR_API_KEY}}`}}"
       gethomepage.dev/pod-selector: "app.kubernetes.io/name=jellyseerr"
     parentRefs:
       - name: external

--- a/kubernetes/clusters/live/charts/paperless.yaml
+++ b/kubernetes/clusters/live/charts/paperless.yaml
@@ -150,7 +150,7 @@ route:
       gethomepage.dev/icon: "paperless-ngx.svg"
       gethomepage.dev/widget.type: "paperlessngx"
       gethomepage.dev/widget.url: "http://paperless.paperless.svc:8000"
-      gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_PAPERLESS_API_KEY}}"
+      gethomepage.dev/widget.key: "{{`{{HOMEPAGE_VAR_PAPERLESS_API_KEY}}`}}"
       gethomepage.dev/pod-selector: "app.kubernetes.io/name=paperless"
     parentRefs:
       - name: internal

--- a/kubernetes/clusters/live/charts/prowlarr.yaml
+++ b/kubernetes/clusters/live/charts/prowlarr.yaml
@@ -95,7 +95,7 @@ route:
       gethomepage.dev/icon: "prowlarr.svg"
       gethomepage.dev/widget.type: "prowlarr"
       gethomepage.dev/widget.url: "http://prowlarr.media.svc:9696"
-      gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_PROWLARR_API_KEY}}"
+      gethomepage.dev/widget.key: "{{`{{HOMEPAGE_VAR_PROWLARR_API_KEY}}`}}"
       gethomepage.dev/pod-selector: "app.kubernetes.io/name=prowlarr"
     parentRefs:
       - name: internal

--- a/kubernetes/clusters/live/charts/radarr.yaml
+++ b/kubernetes/clusters/live/charts/radarr.yaml
@@ -96,7 +96,7 @@ route:
       gethomepage.dev/icon: "radarr.svg"
       gethomepage.dev/widget.type: "radarr"
       gethomepage.dev/widget.url: "http://radarr.media.svc:7878"
-      gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_RADARR_API_KEY}}"
+      gethomepage.dev/widget.key: "{{`{{HOMEPAGE_VAR_RADARR_API_KEY}}`}}"
       gethomepage.dev/pod-selector: "app.kubernetes.io/name=radarr"
     parentRefs:
       - name: internal

--- a/kubernetes/clusters/live/charts/radarr4k.yaml
+++ b/kubernetes/clusters/live/charts/radarr4k.yaml
@@ -96,7 +96,7 @@ route:
       gethomepage.dev/icon: "radarr.svg"
       gethomepage.dev/widget.type: "radarr"
       gethomepage.dev/widget.url: "http://radarr4k-app.media.svc:7878"
-      gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_RADARR4K_API_KEY}}"
+      gethomepage.dev/widget.key: "{{`{{HOMEPAGE_VAR_RADARR4K_API_KEY}}`}}"
       gethomepage.dev/pod-selector: "app.kubernetes.io/name=radarr4k"
     parentRefs:
       - name: internal

--- a/kubernetes/clusters/live/charts/sonarr.yaml
+++ b/kubernetes/clusters/live/charts/sonarr.yaml
@@ -96,7 +96,7 @@ route:
       gethomepage.dev/icon: "sonarr.svg"
       gethomepage.dev/widget.type: "sonarr"
       gethomepage.dev/widget.url: "http://sonarr.media.svc:8989"
-      gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_SONARR_API_KEY}}"
+      gethomepage.dev/widget.key: "{{`{{HOMEPAGE_VAR_SONARR_API_KEY}}`}}"
       gethomepage.dev/pod-selector: "app.kubernetes.io/name=sonarr"
     parentRefs:
       - name: internal

--- a/kubernetes/clusters/live/charts/sonarr4k.yaml
+++ b/kubernetes/clusters/live/charts/sonarr4k.yaml
@@ -96,7 +96,7 @@ route:
       gethomepage.dev/icon: "sonarr.svg"
       gethomepage.dev/widget.type: "sonarr"
       gethomepage.dev/widget.url: "http://sonarr4k-app.media.svc:8989"
-      gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_SONARR4K_API_KEY}}"
+      gethomepage.dev/widget.key: "{{`{{HOMEPAGE_VAR_SONARR4K_API_KEY}}`}}"
       gethomepage.dev/pod-selector: "app.kubernetes.io/name=sonarr4k"
     parentRefs:
       - name: internal


### PR DESCRIPTION
## Summary
- Fix Helm template rendering failure for 10 HelmReleases introduced by #1119
- `{{HOMEPAGE_VAR_*}}` in route annotations was interpreted as Go template functions by app-template's `tpl` call
- Wrapped in backtick raw-string delimiters: `{{` + backtick + `{{HOMEPAGE_VAR_*}}` + backtick + `}}`

## Affected releases
bazarr, firefly, jellyfin, jellyseerr, paperless, prowlarr, radarr, radarr4k, sonarr, sonarr4k

## Test plan
- [ ] All 10 HelmReleases reconcile successfully
- [ ] HTTPRoutes created with correct `{{HOMEPAGE_VAR_*}}` annotation values
- [ ] Homepage dashboard widgets load API data correctly