### PR TITLE
fix(dev): use fast storage class for paperless-media PVC

### DIFF
--- a/kubernetes/clusters/dev/apps/paperless/media-pvc.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/media-pvc.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: slow
+  storageClassName: fast
   resources:
     requests:
       storage: 5Gi


### PR DESCRIPTION
## Summary

- Dev node45 has no `slow`-tagged Longhorn disks — only `fast` storage available on single-node dev
- `paperless-media` PVC stuck Pending because StorageClass `slow` can't provision (disk tag doesn't exist)
- Change to `fast` storage class

Follow-up to #1122.

## Test plan

- [ ] PVC binds successfully after merge
- [ ] Paperless pod starts with both volumes mounted