### PR TITLE
feat(k8s): deploy houndarr

### DIFF
--- a/kubernetes/clusters/live/charts/houndarr.yaml
+++ b/kubernetes/clusters/live/charts/houndarr.yaml
@@ -1,0 +1,104 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+# https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+controllers:
+  houndarr:
+    type: deployment
+    replicas: 1
+
+    annotations:
+      reloader.stakater.com/auto: "true"
+
+    pod:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+    containers:
+      app:
+        image:
+          repository: ghcr.io/av1155/houndarr
+          # renovate: datasource=docker depName=ghcr.io/av1155/houndarr
+          tag: "${houndarr_version}"
+        env:
+          TZ: America/New_York
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 128Mi
+          limits:
+            memory: 512Mi
+        probes:
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api/health
+                port: 8877
+              initialDelaySeconds: 10
+              periodSeconds: 5
+              failureThreshold: 30
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api/health
+                port: 8877
+              periodSeconds: 30
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api/health
+                port: 8877
+              periodSeconds: 10
+
+service:
+  app:
+    controller: houndarr
+    ports:
+      http:
+        port: 8877
+
+route:
+  internal:
+    enabled: true
+    annotations:
+      gethomepage.dev/enabled: "true"
+      gethomepage.dev/name: "Houndarr"
+      gethomepage.dev/group: "Media"
+      gethomepage.dev/icon: "sonarr.svg"
+      gethomepage.dev/pod-selector: "app.kubernetes.io/name=houndarr"
+    parentRefs:
+      - name: internal
+        namespace: istio-gateway
+    hostnames:
+      - "houndarr.${internal_domain}"
+    rules:
+      - backendRefs:
+          - identifier: app
+            port: 8877
+
+persistence:
+  data:
+    type: persistentVolumeClaim
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    storageClass: fast
+    advancedMounts:
+      houndarr:
+        app:
+          - path: /data

--- a/kubernetes/clusters/live/charts/kustomization.yaml
+++ b/kubernetes/clusters/live/charts/kustomization.yaml
@@ -17,6 +17,7 @@ configMapGenerator:
       - flaresolverr.yaml
       - firefly.yaml
       - homepage.yaml
+      - houndarr.yaml
       - immich.yaml
       - it-tools.yaml
       - jellyfin-exporter.yaml

--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -253,6 +253,13 @@ spec:
         version: "${open_webui_version}"
         url: "https://helm.openwebui.com"
       dependsOn: [ollama, cloudnative-pg, secret-generator]
+    - name: houndarr
+      namespace: media
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: []
   resourcesTemplate: |
     ---
     apiVersion: source.toolkit.fluxcd.io/v1

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -58,6 +58,8 @@ paperless_ngx_version=2.20.15
 vaultwarden_version=1.36.0-alpine
 # renovate: datasource=docker depName=homepage packageName=ghcr.io/gethomepage/homepage
 homepage_version=v1.13.1
+# renovate: datasource=docker depName=ghcr.io/av1155/houndarr
+houndarr_version=v1.12.0
 # renovate: datasource=docker depName=ollama packageName=ollama/ollama
 ollama_version=0.24.0
 # renovate: datasource=docker depName=exportarr packageName=ghcr.io/onedr0p/exportarr


### PR DESCRIPTION
## Summary

- Adds [houndarr](https://github.com/av1155/houndarr) (v1.12.0) to the live cluster in the `media` namespace
- Houndarr is an *arr companion that automates searches for missing media and quality upgrades across Sonarr, Radarr, Lidarr, and Readarr in configurable rate-limited batches
- Uses the official upstream image `ghcr.io/av1155/houndarr` — no linuxserver.io
- Deployed via app-template + cluster ResourceSet, following the existing media app pattern
- Accessible internally at `houndarr.<internal_domain>` via the internal Istio gateway
- 1Gi PVC on the `fast` storageClass for SQLite database and master encryption key persistence
- Renovate annotation wired up for automatic version tracking

## Test plan

- [ ] Verify HelmRelease reconciles successfully: `kubectl --context live get helmrelease houndarr -n media`
- [ ] Verify pod is Running and health check passes: `kubectl --context live get pods -n media -l app.kubernetes.io/name=houndarr`
- [ ] Verify internal route resolves and web UI is reachable at `houndarr.<internal_domain>`
- [ ] Complete initial setup wizard (create admin account on first visit)
- [ ] Add *arr API keys via the houndarr dashboard and confirm search automation starts