### PR TITLE
fix(monitoring): drop high-cardinality apiserver histogram buckets

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -24,6 +24,10 @@ kubeApiServer:
       matchLabels:
         component: apiserver
         provider: kubernetes
+    metricRelabelings:
+      - action: drop
+        sourceLabels: [__name__]
+        regex: 'apiserver_(request_body_size_bytes|watch_list_duration_seconds|watch_cache_read_wait_seconds|response_sizes|watch_events_sizes|request_sli_duration_seconds)_bucket|etcd_request_duration_seconds_bucket'
 kubeScheduler:
   service:
     selector:


### PR DESCRIPTION
## Summary

- Adds `metricRelabelings` to the `kubeApiServer.serviceMonitor` in `kube-prometheus-stack.yaml` to drop 7 high-cardinality histogram `_bucket` metrics from the `apiserver` scrape job
- Expected to reduce active series by ~80k (~21% of the 381k total), directly addressing the root-cause cardinality problem identified after the live cluster Prometheus PVC hit 155% utilization
- `apiserver_request_duration_seconds_bucket` is intentionally **not** dropped — it backs USE/RED dashboards and SLO alert expressions

## Metrics dropped

Single `drop` action with a regex alternation for compactness:

```
apiserver_request_body_size_bytes_bucket
apiserver_watch_list_duration_seconds_bucket
apiserver_watch_cache_read_wait_seconds_bucket
apiserver_response_sizes_bucket
apiserver_watch_events_sizes_bucket
apiserver_request_sli_duration_seconds_bucket
etcd_request_duration_seconds_bucket
```

## Verification findings

`grep -r` across `kubernetes/` for all 7 metric names returned **zero matches** — none are referenced by any PrometheusRule, recording rule, or Grafana dashboard ConfigMap in this repository. Safe to drop.

## Related

- PR #1131 added `retention: 7d` + `retentionSize: 40GB` as a ceiling; this PR fixes the underlying ingest volume so the ceiling is not perpetually under pressure.

## Test plan

- [x] `task k8s:validate` passes (YAML lint, ResourceSet expansion, Helm templating, deprecation check — all clean)
- [ ] After merge: Flux reconciles `kube-prometheus-stack` HelmRelease; on next apiserver scrape cycle Prometheus stops ingesting the dropped metrics; series count drops ~80k
- [ ] Verify in Prometheus UI: `count({job="apiserver"})` should decrease noticeably within 15 minutes of reconciliation