### PR TITLE
fix(alerts): resolve 3 flapping alert root causes

### DIFF
--- a/infrastructure/modules/bootstrap/resources/instance-oci.yaml.tftpl
+++ b/infrastructure/modules/bootstrap/resources/instance-oci.yaml.tftpl
@@ -31,6 +31,6 @@ instance:
         patch: |
           - op: add
             path: /spec/template/spec/containers/0/args/-
-            value: --helm-cache-max-size=32
+            value: --helm-cache-max-size=128
 healthcheck:
   enabled: true

--- a/infrastructure/modules/bootstrap/resources/instance.yaml.tftpl
+++ b/infrastructure/modules/bootstrap/resources/instance.yaml.tftpl
@@ -26,7 +26,7 @@ instance:
         patch: |
           - op: add
             path: /spec/template/spec/containers/0/args/-
-            value: --helm-cache-max-size=32
+            value: --helm-cache-max-size=128
 healthcheck:
   enabled: true
 

--- a/kubernetes/clusters/live/charts/jellyfin-exporter.yaml
+++ b/kubernetes/clusters/live/charts/jellyfin-exporter.yaml
@@ -48,7 +48,8 @@ controllers:
                 port: 9594
               initialDelaySeconds: 5
               periodSeconds: 5
-              failureThreshold: 10
+              timeoutSeconds: 30
+              failureThreshold: 20
           liveness:
             enabled: true
             custom: true

--- a/kubernetes/platform/config/gateway/coraza-waf-rules.yaml
+++ b/kubernetes/platform/config/gateway/coraza-waf-rules.yaml
@@ -52,12 +52,12 @@ spec:
                 reporter="source",
                 destination_service!~".*kromgo.*"
               }[5m])) by (le)
-            ) > 50
+            ) > 200
           for: 5m
           labels:
             severity: warning
           annotations:
-            summary: "External gateway p99 latency >50ms"
+            summary: "External gateway p99 latency >200ms"
             description: "Gateway processing overhead is high. Consider WAF rule optimization or increasing paranoia level exclusions."
 
         # Alert for kromgo backend which has elevated upstream latency (~99ms p99) unrelated to WAF overhead


### PR DESCRIPTION
## Summary

Three independent fixes for flapping alerts observed on the live cluster over 5 days:

- **Fix 1 (jellyfin-exporter startup probe)**: Raises `timeoutSeconds` from 1s to 30s and `failureThreshold` from 10 to 20. The exporter makes synchronous Jellyfin API calls to serve `/metrics`; when Jellyfin is under load (media scan, disk pressure) the probe kills the pod before it can respond. This caused 101 restarts in 5 days and cascaded into TargetDown, CanaryCheckFailure, and CorazaWAFHighLatency alerts.

- **Fix 2 (source-controller helm cache)**: Increases `--helm-cache-max-size` from 32 to 128 in both OCI and Git FluxInstance bootstrap templates. The cache is permanently exhausted at 32 entries (logs show `"Cache is full"` on every reconcile), contributing to FluxKustomizationFailing churn. The Terragrunt bootstrap module generates the FluxInstance Helm values; this change takes effect on next `tg:apply` or cluster rebuild.

- **Fix 3 (CorazaWAFHighLatency threshold)**: Raises p99 latency threshold from 50ms to 200ms. Normal WAF p99 latency is 25–48ms, leaving almost no headroom at 50ms and causing 34 flap cycles in 24h. The new threshold aligns with the existing `CorazaWAFKromgoHighLatency` threshold and provides adequate headroom without masking genuine WAF overhead issues.

## Files changed

| File | Change |
|------|--------|
| `kubernetes/clusters/live/charts/jellyfin-exporter.yaml` | Startup probe: `timeoutSeconds: 30`, `failureThreshold: 20` |
| `kubernetes/platform/config/gateway/coraza-waf-rules.yaml` | `CorazaWAFHighLatency`: threshold `> 50` → `> 200`, summary updated |
| `infrastructure/modules/bootstrap/resources/instance-oci.yaml.tftpl` | `--helm-cache-max-size=32` → `128` |
| `infrastructure/modules/bootstrap/resources/instance.yaml.tftpl` | `--helm-cache-max-size=32` → `128` |

## Test plan

- [ ] `task k8s:validate` passes (confirmed: 0 invalid, 0 errors)
- [ ] After merge: jellyfin-exporter pod in `media` namespace no longer crash-loops during Jellyfin media scans
- [ ] After merge: `source-controller` logs no longer show `"Cache is full"` on every reconcile
- [ ] After merge: `CorazaWAFHighLatency` alert stops flapping during normal operation
- [ ] Fix 2 (helm cache) fully applies on next Terragrunt bootstrap apply or cluster rebuild — the live FluxInstance is currently patched directly; the template change ensures new clusters and rebuilds pick up the correct value