### PR TITLE
fix(platform): roll back Talos to v1.13.2

### DIFF
--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -7,7 +7,7 @@
 
 # Infrastructure versions (Terragrunt + Tuppr)
 # renovate: datasource=github-releases depName=talos packageName=siderolabs/talos
-talos_version=v1.13.3
+talos_version=v1.13.2
 # renovate: datasource=github-tags depName=kubernetes packageName=kubernetes/kubernetes extractVersion=^v(?<version>.*)$
 kubernetes_version=1.36.1
 # renovate: datasource=github-releases depName=cilium packageName=cilium/cilium extractVersion=^v(?<version>.*)$


### PR DESCRIPTION
## Summary

- Rolls back `talos_version` from `v1.13.3` to `v1.13.2` in `kubernetes/platform/versions.env`
- v1.13.3 introduced a regression in `RenderConfigsStaticPodController` that panics with `cannot deep copy int` when any custom `scheduler.config` contains integer fields (e.g. `maxSkew: 1`, `weight: 5`), preventing kube-apiserver from starting
- Fix is tracked upstream at https://github.com/siderolabs/talos/issues/13445 and targeted for v1.13.4
- v1.13.2 is already running on live and working — rolling back protects live from being upgraded into the broken release

## Test plan

- [ ] Confirm `talos_version=v1.13.2` in `kubernetes/platform/versions.env`
- [ ] Confirm no other fields in `versions.env` were changed
- [ ] Pipeline promotes through integration to live as normal
- [ ] Tuppr does not attempt an upgrade (version matches current live state)