### PR TITLE
fix(renovate): block talos v1.13.3 scheduler.config panic regression

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -207,6 +207,14 @@
       "allowedVersions": "!/^v3\\.41\\./"
     },
     {
+      // talos v1.13.3: RenderConfigsStaticPodController panics on scheduler.config integer fields
+      // Upstream: https://github.com/siderolabs/talos/issues/13445
+      "matchDepNames": [
+        "talos"
+      ],
+      "allowedVersions": "!/^v1\\.13\\.3$/"
+    },
+    {
       // siderolabs/talos terraform provider 0.11.0: on_destroy.reset unknown value
       // causes Value Conversion Error on plan/validate
       // Upstream: https://github.com/siderolabs/terraform-provider-talos/issues/334

--- a/.github/version-holds.yaml
+++ b/.github/version-holds.yaml
@@ -14,3 +14,8 @@ holds:
     reason: "0.11.0 on_destroy.reset Value Conversion Error causes all plan/validate operations to fail"
     upstream_issue: https://github.com/siderolabs/terraform-provider-talos/issues/334
     created: "2026-05-06"
+  - dep: talos
+    constraint: "!/^v1\\.13\\.3$/"
+    reason: "v1.13.3 RenderConfigsStaticPodController panics with 'cannot deep copy int' on any custom scheduler.config with integer fields, breaking kube-apiserver"
+    upstream_issue: https://github.com/siderolabs/talos/issues/13445
+    created: "2026-05-28"


### PR DESCRIPTION
## Summary

- Adds a Renovate `allowedVersions` package rule to block Talos v1.13.3 from being re-proposed after the rollback PR (#1141) merges
- Adds corresponding entry to `.github/version-holds.yaml` for the automated issue-tracking workflow
- Allows v1.13.4+ when it ships (constraint is an exact-version exclusion: `!/^v1\.13\.3$/`)

## Why

Talos v1.13.3 introduced a regression where `RenderConfigsStaticPodController` panics with `cannot deep copy int` on any custom `scheduler.config` containing integer fields. This breaks kube-apiserver startup. Upstream: https://github.com/siderolabs/talos/issues/13445

A fix is expected in v1.13.4. This hold ensures Renovate does not re-open a PR for the broken version once removed.

## Test plan

- [x] `task renovate:validate` passes with no errors
- [ ] Confirm rollback PR #1141 is merged before or alongside this PR
- [ ] After v1.13.4 ships and upstream issue closes, remove this hold following `docs/runbooks/version-holds.md`