### PR TITLE
fix(istio-csr): opt out of Istio ambient to break cold-start deadlock

### DIFF
--- a/kubernetes/platform/charts/istio-csr.yaml
+++ b/kubernetes/platform/charts/istio-csr.yaml
@@ -70,6 +70,13 @@ volumeMounts:
 podLabels:
   networking/allow-ingress-prometheus: "true"
   networking/allow-cluster-egress: "true"
+  # cert-manager-istio-csr IS the cert provider for the mesh — it cannot
+  # be in the mesh it is bootstrapping. On cold start, ztunnel waits for
+  # istio-csr to issue its certificate while istio-cni blocks the istio-csr
+  # pod sandbox until ztunnel is running, creating a deadlock. Opting out
+  # of ambient here breaks the cycle without affecting mesh functionality.
+  # The label is checked by Istio's CNI plugin at pod sandbox creation.
+  istio.io/dataplane-mode: none
 
 resources:
   requests:


### PR DESCRIPTION
## Summary

- On cold cluster start, `ztunnel` cannot start because it needs a certificate from `cert-manager-istio-csr.cert-manager.svc:443`, and `cert-manager-istio-csr` cannot get a CNI sandbox because `istio-cni` requires `ztunnel` to be running first — a hard deadlock.
- Adding `istio.io/dataplane-mode: none` to the `cert-manager-istio-csr` pod opts it out of Istio ambient interception at CNI sandbox creation time, breaking the cycle.
- `cert-manager-istio-csr` is the certificate provider for the mesh itself, not a mesh consumer — opting it out does not affect mesh functionality or mTLS for any other workload.
- Identified and root-caused during recovery of the dev cluster from the Talos v1.13.3 scheduler.config panic regression.

## Test plan

- [ ] Validate passes: `task k8s:validate` (done locally, clean)
- [ ] After merge, verify `cert-manager-istio-csr` pod starts without waiting on ztunnel on a cold cluster boot
- [ ] Verify ztunnel and istiod come up normally after istio-csr is healthy