### PR TITLE
feat(descheduler): remove failed job pods after 1 day

### DIFF
--- a/kubernetes/platform/charts/descheduler.yaml
+++ b/kubernetes/platform/charts/descheduler.yaml
@@ -33,10 +33,8 @@ deschedulerPolicy:
               - ScheduleAnyway
         - name: RemoveFailedPods
           args:
-            excludeOwnerKinds:
-              - Job
             includingInitContainers: true
-            minPodLifetimeSeconds: 3600
+            minPodLifetimeSeconds: 86400
         - name: PodLifeTime
           args:
             maxPodLifeTimeSeconds: 86400


### PR DESCRIPTION
## Summary

- Removed `Job` from `RemoveFailedPods.excludeOwnerKinds` so failed pods owned by Jobs are now eligible for eviction
- Set `minPodLifetimeSeconds: 86400` (1 day) — previously 3600s (1h) applied only to non-Job pods; now 1 day applies to all failed pods including Job-owned

## Test plan

- [ ] Verify descheduler reconciles without errors after merge
- [ ] Confirm failed Job pods older than 24h are evicted by descheduler