### PR TITLE
feat(monitoring): improve Discord alertmanager message formatting

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -5,6 +5,27 @@ crds:
 cleanPrometheusOperatorObjectNames: true
 alertmanager:
   enabled: true
+  templateFiles:
+    discord.tmpl: |-
+      {{ define "homelab.discord.title" -}}
+      {{ if eq .Status "firing" }}🔥 FIRING{{ else }}✅ RESOLVED{{ end }}{{ if gt (len .Alerts.Firing) 1 }} ×{{ len .Alerts.Firing }}{{ end }}: {{ .CommonLabels.alertname }} [{{ .CommonLabels.severity | toUpper }}]
+      {{- end }}
+
+      {{ define "homelab.discord.message" -}}
+      {{ range $i, $a := .Alerts -}}
+      {{ if gt $i 0 }}─────────────────
+      {{ end -}}
+      {{ if $a.Annotations.summary }}**{{ $a.Annotations.summary }}**
+      {{ end -}}
+      {{ if $a.Annotations.description }}{{ $a.Annotations.description | reReplaceAll " on cluster [^.]*\\." "" }}
+      {{ end -}}
+      {{ if or $a.Labels.namespace $a.Labels.deployment $a.Labels.statefulset $a.Labels.daemonset $a.Labels.pod $a.Labels.kubernetes_node -}}
+      **Context:** {{ if $a.Labels.namespace }}`ns/{{ $a.Labels.namespace }}`{{ end }}{{ if $a.Labels.deployment }} `deploy/{{ $a.Labels.deployment }}`{{ end }}{{ if $a.Labels.statefulset }} `sts/{{ $a.Labels.statefulset }}`{{ end }}{{ if $a.Labels.daemonset }} `ds/{{ $a.Labels.daemonset }}`{{ end }}{{ if and $a.Labels.pod (not (or $a.Labels.deployment $a.Labels.statefulset $a.Labels.daemonset)) }} `pod/{{ $a.Labels.pod }}`{{ end }}{{ if $a.Labels.kubernetes_node }} `node/{{ $a.Labels.kubernetes_node }}`{{ end }}
+      {{ end -}}
+      {{ if $a.Annotations.runbook_url }}[📖 Runbook]({{ $a.Annotations.runbook_url }})
+      {{ end -}}
+      {{ end -}}
+      {{- end }}
   alertmanagerSpec:
     priorityClassName: platform
     podMetadata:

--- a/kubernetes/platform/config/monitoring/alertmanager-config.yaml
+++ b/kubernetes/platform/config/monitoring/alertmanager-config.yaml
@@ -43,3 +43,5 @@ spec:
             key: url
             name: alertmanager-discord-webhook
           sendResolved: true
+          title: '{{ template "homelab.discord.title" . }}'
+          message: '{{ template "homelab.discord.message" . }}'


### PR DESCRIPTION
## Summary

- Adds a `homelab.discord.title` + `homelab.discord.message` Go template to the kube-prometheus-stack `templateFiles`
- Wires `title` and `message` fields in `AlertmanagerConfig` discordConfigs to reference those templates
- Template improvements over the default noisy format:
  - 🔥/✅ status emoji + alert name + severity in title
  - Summary as bold lead; description with `on cluster X.` suffix stripped
  - Context line shows only useful labels: `ns/` `deploy/` `sts/` `ds/` `pod/` `node/`
  - Pod label hidden when a workload label (deployment/statefulset/daemonset) is present
  - Runbook rendered as a clickable link instead of a raw URL
  - Internal Prometheus source URL removed entirely
  - Multi-alert groups rendered as visually separated blocks

## Notes

- `color` field (red firing / green resolved) is not in `AlertmanagerConfig` v1alpha1 CRD schema — excluded until the CRD exposes it
- Template lives in `alertmanager.templateFiles` so it is globally available across all `AlertmanagerConfig` receivers

## Test plan

- [ ] Merge to dev, trigger a test alert, verify Discord message matches expected format
- [ ] Verify resolved notification renders with ✅ and same body structure
- [ ] Verify multi-alert group renders with `─────────────────` separator between blocks