### PR TITLE
fix(monitoring): wire discord templates into alertmanager generated config

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -37,6 +37,10 @@ alertmanager:
       global:
         resolveTimeout: 5m
     externalUrl: https://alertmanager.${external_domain}
+    templates:
+      - secret:
+          name: alertmanager-kube-prometheus-stack
+          key: discord.tmpl
     storage:
       emptyDir: { }
 kubeApiServer:

--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -5,6 +5,27 @@ crds:
 cleanPrometheusOperatorObjectNames: true
 alertmanager:
   enabled: true
+  templateFiles:
+    discord.tmpl: |-
+      {{ define "homelab.discord.title" -}}
+      {{ if eq .Status "firing" }}🔥 FIRING{{ else }}✅ RESOLVED{{ end }}{{ if gt (len .Alerts.Firing) 1 }} ×{{ len .Alerts.Firing }}{{ end }}: {{ .CommonLabels.alertname }} [{{ .CommonLabels.severity | toUpper }}]
+      {{- end }}
+
+      {{ define "homelab.discord.message" -}}
+      {{ range $i, $a := .Alerts -}}
+      {{ if gt $i 0 }}─────────────────
+      {{ end -}}
+      {{ if $a.Annotations.summary }}**{{ $a.Annotations.summary }}**
+      {{ end -}}
+      {{ if $a.Annotations.description }}{{ $a.Annotations.description | reReplaceAll " on cluster [^.]*\\." "" }}
+      {{ end -}}
+      {{ if or $a.Labels.namespace $a.Labels.deployment $a.Labels.statefulset $a.Labels.daemonset $a.Labels.pod $a.Labels.kubernetes_node -}}
+      **Context:** {{ if $a.Labels.namespace }}`ns/{{ $a.Labels.namespace }}`{{ end }}{{ if $a.Labels.deployment }} `deploy/{{ $a.Labels.deployment }}`{{ end }}{{ if $a.Labels.statefulset }} `sts/{{ $a.Labels.statefulset }}`{{ end }}{{ if $a.Labels.daemonset }} `ds/{{ $a.Labels.daemonset }}`{{ end }}{{ if and $a.Labels.pod (not (or $a.Labels.deployment $a.Labels.statefulset $a.Labels.daemonset)) }} `pod/{{ $a.Labels.pod }}`{{ end }}{{ if $a.Labels.kubernetes_node }} `node/{{ $a.Labels.kubernetes_node }}`{{ end }}
+      {{ end -}}
+      {{ if $a.Annotations.runbook_url }}[📖 Runbook]({{ $a.Annotations.runbook_url }})
+      {{ end -}}
+      {{ end -}}
+      {{- end }}
   alertmanagerSpec:
     priorityClassName: platform
     podMetadata:

--- a/kubernetes/platform/config/monitoring/alertmanager-config.yaml
+++ b/kubernetes/platform/config/monitoring/alertmanager-config.yaml
@@ -43,3 +43,5 @@ spec:
             key: url
             name: alertmanager-discord-webhook
           sendResolved: true
+          title: '{{ template "homelab.discord.title" . }}'
+          message: '{{ template "homelab.discord.message" . }}'


### PR DESCRIPTION
## Summary

Follow-up to #1162. The template file existed in the secret but Alertmanager wasn't loading it.

- `alertmanager.templateFiles` stores content in the base secret but doesn't add the path to the Prometheus Operator-generated config
- `alertmanagerSpec.templates` is required to reference the secret key so the Operator includes the file path in `templates:` in the generated alertmanager config
- Without this, `templates: []` in the running config and the `homelab.discord.*` template definitions are never loaded — alerts fall back to default formatting

## Test plan

- [ ] After merge: `kubectl exec alertmanager-kube-prometheus-stack-0 -- zcat /etc/alertmanager/config/alertmanager.yaml.gz | grep templates` should show the `.tmpl` path
- [ ] Fire a test alert, verify Discord message uses new format