### PR TITLE
fix(monitoring): nest discord template ref under alertmanagerConfiguration

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -37,6 +37,10 @@ alertmanager:
       global:
         resolveTimeout: 5m
     externalUrl: https://alertmanager.${external_domain}
+    templates:
+      - secret:
+          name: alertmanager-kube-prometheus-stack
+          key: discord.tmpl
     storage:
       emptyDir: { }
 kubeApiServer:

--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -5,6 +5,27 @@ crds:
 cleanPrometheusOperatorObjectNames: true
 alertmanager:
   enabled: true
+  templateFiles:
+    discord.tmpl: |-
+      {{ define "homelab.discord.title" -}}
+      {{ if eq .Status "firing" }}🔥 FIRING{{ else }}✅ RESOLVED{{ end }}{{ if gt (len .Alerts.Firing) 1 }} ×{{ len .Alerts.Firing }}{{ end }}: {{ .CommonLabels.alertname }} [{{ .CommonLabels.severity | toUpper }}]
+      {{- end }}
+
+      {{ define "homelab.discord.message" -}}
+      {{ range $i, $a := .Alerts -}}
+      {{ if gt $i 0 }}─────────────────
+      {{ end -}}
+      {{ if $a.Annotations.summary }}**{{ $a.Annotations.summary }}**
+      {{ end -}}
+      {{ if $a.Annotations.description }}{{ $a.Annotations.description | reReplaceAll " on cluster [^.]*\\." "" }}
+      {{ end -}}
+      {{ if or $a.Labels.namespace $a.Labels.deployment $a.Labels.statefulset $a.Labels.daemonset $a.Labels.pod $a.Labels.kubernetes_node -}}
+      **Context:** {{ if $a.Labels.namespace }}`ns/{{ $a.Labels.namespace }}`{{ end }}{{ if $a.Labels.deployment }} `deploy/{{ $a.Labels.deployment }}`{{ end }}{{ if $a.Labels.statefulset }} `sts/{{ $a.Labels.statefulset }}`{{ end }}{{ if $a.Labels.daemonset }} `ds/{{ $a.Labels.daemonset }}`{{ end }}{{ if and $a.Labels.pod (not (or $a.Labels.deployment $a.Labels.statefulset $a.Labels.daemonset)) }} `pod/{{ $a.Labels.pod }}`{{ end }}{{ if $a.Labels.kubernetes_node }} `node/{{ $a.Labels.kubernetes_node }}`{{ end }}
+      {{ end -}}
+      {{ if $a.Annotations.runbook_url }}[📖 Runbook]({{ $a.Annotations.runbook_url }})
+      {{ end -}}
+      {{ end -}}
+      {{- end }}
   alertmanagerSpec:
     priorityClassName: platform
     podMetadata:

--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -36,11 +36,11 @@ alertmanager:
       name: alertmanager
       global:
         resolveTimeout: 5m
+      templates:
+        - secret:
+            name: alertmanager-kube-prometheus-stack
+            key: discord.tmpl
     externalUrl: https://alertmanager.${external_domain}
-    templates:
-      - secret:
-          name: alertmanager-kube-prometheus-stack
-          key: discord.tmpl
     storage:
       emptyDir: { }
 kubeApiServer:

--- a/kubernetes/platform/config/monitoring/alertmanager-config.yaml
+++ b/kubernetes/platform/config/monitoring/alertmanager-config.yaml
@@ -43,3 +43,5 @@ spec:
             key: url
             name: alertmanager-discord-webhook
           sendResolved: true
+          title: '{{ template "homelab.discord.title" . }}'
+          message: '{{ template "homelab.discord.message" . }}'


### PR DESCRIPTION
## Summary

Third attempt to wire the Discord template into Alertmanager. Previous PR #1163 put the reference at `alertmanagerSpec.templates`, which the chart silently drops (not a hardcoded passthrough) and the CRD schema rejects ("additional properties 'templates' not allowed at /spec").

Root cause investigation:
- `kube-prometheus-stack/templates/alertmanager/alertmanager.yaml` renders the `Alertmanager` CRD by hardcoded fields, not generic `toYaml`. Unknown spec keys are dropped.
- The Prometheus Operator `Alertmanager` CRD has **no** `spec.templates` field.
- The CRD's `spec.alertmanagerConfiguration` struct has its own `templates` sub-field, which the Operator uses to mount template files into the pod and inject the path into the generated config's `templates:` list.
- The chart **does** pass `alertmanagerConfiguration` through via `toYaml`, so nested fields flow through to the CRD.

This PR moves the template ref under `alertmanagerConfiguration.templates`.

## Verified

- Rendered `Alertmanager` CRD now contains the expected nested field
- `task k8s:validate` passes (schema accepts it under `alertmanagerConfiguration`)

## Test plan

- [ ] After merge: `kubectl exec alertmanager-kube-prometheus-stack-0 -- zcat /etc/alertmanager/config/alertmanager.yaml.gz | grep -A2 templates` should show the `.tmpl` path (not `[]`)
- [ ] Fire a test alert via `amtool alert add`, verify Discord formatting matches the design