### PR TITLE
feat(monitoring): add silence and prometheus query links to discord alerts

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -41,10 +41,6 @@ alertmanager:
             name: alertmanager-kube-prometheus-stack
             key: discord.tmpl
     externalUrl: https://alertmanager.${external_domain}
-    templates:
-      - secret:
-          name: alertmanager-kube-prometheus-stack
-          key: discord.tmpl
     storage:
       emptyDir: { }
 kubeApiServer:

--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -22,8 +22,16 @@ alertmanager:
       {{ if or $a.Labels.namespace $a.Labels.deployment $a.Labels.statefulset $a.Labels.daemonset $a.Labels.pod $a.Labels.kubernetes_node -}}
       **Context:** {{ if $a.Labels.namespace }}`ns/{{ $a.Labels.namespace }}`{{ end }}{{ if $a.Labels.deployment }} `deploy/{{ $a.Labels.deployment }}`{{ end }}{{ if $a.Labels.statefulset }} `sts/{{ $a.Labels.statefulset }}`{{ end }}{{ if $a.Labels.daemonset }} `ds/{{ $a.Labels.daemonset }}`{{ end }}{{ if and $a.Labels.pod (not (or $a.Labels.deployment $a.Labels.statefulset $a.Labels.daemonset)) }} `pod/{{ $a.Labels.pod }}`{{ end }}{{ if $a.Labels.kubernetes_node }} `node/{{ $a.Labels.kubernetes_node }}`{{ end }}
       {{ end -}}
-      {{ if $a.Annotations.runbook_url }}[📖 Runbook]({{ $a.Annotations.runbook_url }})
-      {{ end -}}
+      {{ $matchers := printf "{alertname=\"%s\"" $a.Labels.alertname -}}
+      {{ if $a.Labels.namespace }}{{ $matchers = printf "%s,namespace=\"%s\"" $matchers $a.Labels.namespace }}{{ end -}}
+      {{ if $a.Labels.deployment }}{{ $matchers = printf "%s,deployment=\"%s\"" $matchers $a.Labels.deployment }}{{ end -}}
+      {{ if $a.Labels.statefulset }}{{ $matchers = printf "%s,statefulset=\"%s\"" $matchers $a.Labels.statefulset }}{{ end -}}
+      {{ if $a.Labels.daemonset }}{{ $matchers = printf "%s,daemonset=\"%s\"" $matchers $a.Labels.daemonset }}{{ end -}}
+      {{ if and $a.Labels.pod (not (or $a.Labels.deployment $a.Labels.statefulset $a.Labels.daemonset)) }}{{ $matchers = printf "%s,pod=\"%s\"" $matchers $a.Labels.pod }}{{ end -}}
+      {{ if $a.Labels.kubernetes_node }}{{ $matchers = printf "%s,kubernetes_node=\"%s\"" $matchers $a.Labels.kubernetes_node }}{{ end -}}
+      {{ $matchers = printf "%s}" $matchers -}}
+      {{ if $a.Annotations.runbook_url }}[📖 Runbook]({{ $a.Annotations.runbook_url }}) · {{ end -}}
+      [🔕 Silence](https://alertmanager.${internal_domain}/#/silences/new?filter={{ $matchers | urlquery }}){{ if $a.GeneratorURL }} · [📈 Query]({{ $a.GeneratorURL | reReplaceAll "^[^?]+" "https://prometheus.${internal_domain}/query" }}){{ end }}
       {{ end -}}
       {{- end }}
   alertmanagerSpec:


### PR DESCRIPTION
## Summary

Iterates on the Discord alert template (PRs #1162-#1164). Each alert now ends with three actions:

- **📖 Runbook** — existing, shown only when `runbook_url` annotation is present
- **🔕 Silence** — new, deep-links to Alertmanager's silence form with matchers pre-filled
- **📈 Query** — new, opens the alert's Prometheus expression in the external Prometheus UI

## How it works

**Silence link** builds a PromQL-style matcher string from the most identifying labels — `alertname`, plus `namespace`, `deployment`/`statefulset`/`daemonset`/`pod`/`kubernetes_node` when present — then URL-encodes via `urlquery` and appends to `https://alertmanager.${internal_domain}/#/silences/new?filter=`.

Example for `KubeDeploymentReplicasMismatch` on `paperless`:
```
filter={alertname="KubeDeploymentReplicasMismatch",namespace="paperless",deployment="paperless",kubernetes_node="node45"}
```

**Query link** takes the alert's `.GeneratorURL` (set by Prometheus to its internal URL like `http://kube-prometheus-stack-prometheus.monitoring:9090/graph?g0.expr=...`) and uses `reReplaceAll "^[^?]+"` to swap the host+path prefix to `https://prometheus.${internal_domain}/query`, preserving the query string. Hidden when `GeneratorURL` is empty (amtool-injected test alerts).

## Test plan

- [ ] Reconcile dev, fire a real alert (scale a deployment to wrong replica count), verify both links resolve correctly
- [ ] Click Silence link, confirm form is pre-filled with the expected matchers
- [ ] Click Query link, confirm Prometheus shows the alert's expression