### PR TITLE
fix: CNPG pooler TLS cert expiry — GitOps remediation and prevention

### DIFF
--- a/kubernetes/clusters/dev/config/velero-restore/restore-platform.yaml
+++ b/kubernetes/clusters/dev/config/velero-restore/restore-platform.yaml
@@ -13,6 +13,7 @@ spec:
   # Restoring the backed-up CR would apply an initdb spec, overriding recovery.
   excludedResources:
     - clusters.postgresql.cnpg.io
+    - secrets
   # garage: PVC restore recovers object storage (including CNPG Barman archives)
   # database: PVC restore recovers CNPG data PVCs (Barman recovery reads WALs from Garage)
   includedNamespaces:

--- a/kubernetes/clusters/live/config/velero-restore/restore-platform.yaml
+++ b/kubernetes/clusters/live/config/velero-restore/restore-platform.yaml
@@ -13,6 +13,7 @@ spec:
   # Restoring the backed-up CR would apply an initdb spec, overriding recovery.
   excludedResources:
     - clusters.postgresql.cnpg.io
+    - secrets
   # garage: PVC restore recovers object storage (including CNPG Barman archives)
   # database: PVC restore recovers CNPG data PVCs (Barman recovery reads WALs from Garage)
   includedNamespaces:

--- a/kubernetes/platform/charts/x509-certificate-exporter.yaml
+++ b/kubernetes/platform/charts/x509-certificate-exporter.yaml
@@ -1,0 +1,7 @@
+watchedSecrets:
+  - name: platform-pooler
+    namespace: database
+prometheusServiceMonitor:
+  enabled: true
+  labels:
+    release: kube-prometheus-stack

--- a/kubernetes/platform/config/database/pooler.yaml
+++ b/kubernetes/platform/config/database/pooler.yaml
@@ -3,6 +3,8 @@ apiVersion: postgresql.cnpg.io/v1
 kind: Pooler
 metadata:
   name: platform-pooler-rw
+  annotations:
+    cnpg.io/reloadedAt: "2026-06-03T12:00:00Z"
 spec:
   cluster:
     name: platform

--- a/kubernetes/platform/config/database/prometheus-rules.yaml
+++ b/kubernetes/platform/config/database/prometheus-rules.yaml
@@ -91,3 +91,31 @@ spec:
               The most recent backup attempt for cluster {{ $labels.cluster }} failed.
               A failed backup is more recent than the last successful one.
               Check CNPG operator logs and barman backup connectivity to Garage.
+
+    - name: cnpg.pooler-cert
+      rules:
+        - alert: CNPGPoolerCertExpiringSoon14d
+          expr: x509_cert_expires_in_seconds{secret="platform-pooler",namespace="database"} < 86400 * 14
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "CNPG pooler TLS cert expires in < 14 days"
+            description: >-
+              platform-pooler cert in namespace database expires in {{ $value | humanizeDuration }}.
+              Check owner reference: kubectl get secret platform-pooler -n database
+              -o jsonpath='{.metadata.ownerReferences}'
+              If missing (Velero restore likely), patch pooler annotation cnpg.io/reloadedAt
+              to trigger CNPG to recreate with correct ownership.
+
+        - alert: CNPGPoolerCertExpiringSoon24h
+          expr: x509_cert_expires_in_seconds{secret="platform-pooler",namespace="database"} < 86400
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: "CNPG pooler TLS cert expires in < 24 hours — P1 incident imminent"
+            description: >-
+              platform-pooler cert expires in {{ $value | humanizeDuration }}.
+              Update cnpg.io/reloadedAt annotation on the platform-pooler-rw Pooler CR
+              in Git to trigger CNPG cert rotation immediately.

--- a/kubernetes/platform/helm-charts.yaml
+++ b/kubernetes/platform/helm-charts.yaml
@@ -259,6 +259,13 @@ spec:
         version: "${dcgm_exporter_version}"
         url: https://nvidia.github.io/dcgm-exporter/helm-charts
       dependsOn: [nvidia-device-plugin, kube-prometheus-stack]
+    - name: x509-certificate-exporter
+      namespace: monitoring
+      chart:
+        name: x509-certificate-exporter
+        version: "${x509_certificate_exporter_version}"
+        url: https://charts.enix.io
+      dependsOn: [kube-prometheus-stack]
   resourcesTemplate: |
     ---
     apiVersion: source.toolkit.fluxcd.io/v1

--- a/kubernetes/platform/kustomization.yaml
+++ b/kubernetes/platform/kustomization.yaml
@@ -47,3 +47,4 @@ configMapGenerator:
       - prometheus-smartctl-exporter.yaml=charts/prometheus-smartctl-exporter.yaml
       - nvidia-device-plugin.yaml=charts/nvidia-device-plugin.yaml
       - dcgm-exporter.yaml=charts/dcgm-exporter.yaml
+      - x509-certificate-exporter.yaml=charts/x509-certificate-exporter.yaml

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -86,6 +86,8 @@ velero_version=12.0.2
 nvidia_device_plugin_version=0.19.2
 # renovate: datasource=helm depName=dcgm-exporter registryUrl=https://nvidia.github.io/dcgm-exporter/helm-charts
 dcgm_exporter_version=4.8.2
+# renovate: datasource=helm depName=x509-certificate-exporter registryUrl=https://charts.enix.io
+x509_certificate_exporter_version=3.18.0
 
 # Container image versions (Flux substitution into platform config CRs)
 # renovate: datasource=docker depName=garage packageName=dxflrs/garage


### PR DESCRIPTION
## Summary

- **Track 1 (immediate)**: Add `cnpg.io/reloadedAt` annotation to `platform-pooler-rw` Pooler CR — triggers CNPG reconciliation, which detects the orphaned expired secret (no owner reference, stripped by Velero restore) and recreates it with fresh 90-day cert + correct owner reference
- **Track 2a (prevention)**: Exclude `secrets` from Velero restore in both `live` and `dev` clusters — CNPG/Garage/secret-generator managed secrets lose owner references when restored from snapshots, causing silent cert expiry on next rotation cycle
- **Track 2b (monitoring)**: Deploy `enix/x509-certificate-exporter` scoped to `platform-pooler` secret + `PrometheusRule` alerts at 14d (warning) and 24h (critical) — fills monitoring gap where cert-manager alerts are blind to CNPG-managed TLS secrets

## Root Cause

CNPG auto-generates a 90-day TLS cert (`platform-pooler` secret) when the Pooler CR is created. A prior Velero restore overwrote this secret from snapshot, stripping its owner reference. CNPG's `reconcileCertificates` loop only rotates secrets it **owns** — orphaned secret → no rotation → silent expiry → 5 apps down (vaultwarden, paperless, open-webui, firefly, tandoor).

## Test plan

- [ ] Confirm Flux reconciles `database-config` Kustomization after merge
- [ ] `kubectl get secret platform-pooler -n database --context live -o jsonpath='{.metadata.ownerReferences}' | jq .` — expect owner ref pointing to `platform-pooler-rw`
- [ ] `kubectl get secret platform-pooler -n database --context live -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -enddate` — expect ~90d validity from today
- [ ] Verify affected apps recover: vaultwarden, paperless, open-webui, firefly, tandoor pods Running
- [ ] `kubectl get pods -n monitoring -l app.kubernetes.io/name=x509-certificate-exporter --context dev` — exporter pod Running
- [ ] Prometheus query `x509_cert_expires_in_seconds{secret="platform-pooler",namespace="database"}` returns data
- [ ] `kubectl get prometheusrule cnpg-alerts -n database --context dev -o jsonpath='{.spec.groups[*].name}'` — includes `cnpg.pooler-cert`