### PR TITLE
fix: add cnpg.io/reloadedAt to Cluster CR to trigger pgBouncer cert recreation

### DIFF
--- a/kubernetes/platform/config/database/cluster.yaml
+++ b/kubernetes/platform/config/database/cluster.yaml
@@ -3,6 +3,8 @@ apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
   name: platform
+  annotations:
+    cnpg.io/reloadedAt: "2026-06-03T15:00:00Z"
 spec:
   description: "Shared platform PostgreSQL cluster"
   env:


### PR DESCRIPTION
## Summary

- `platform-pooler` secret (CN=`cnpg_pooler_pgbouncer`) was deleted from live cluster to clear orphaned state (Velero-restored, no owner reference)
- CNPG Pooler controller is now looping `AuthUserSecret not found, waiting 30 seconds` — it does **not** create this secret itself; the Cluster controller does
- `kubectl get cluster platform -n database -o jsonpath='{.status.poolerIntegrations}'` returns `{}` — Cluster controller has not processed the Pooler association since Velero restore
- Adding `cnpg.io/reloadedAt` to the Cluster CR forces the Cluster controller to reconcile, detect the associated Pooler CR, and recreate `platform-pooler` with a fresh cert + correct owner reference

## Context

Part of ongoing P1 incident: `platform-pooler` TLS cert expired Jun 3 02:44 UTC, taking down vaultwarden, paperless, open-webui, firefly, tandoor. Prior fix (PR #1170) added the annotation to the Pooler CR but targeted the wrong controller — cert is owned by the Cluster controller, not the Pooler controller.

## After merge

CNPG Cluster controller recreates `platform-pooler` → Pooler controller unblocks → pgBouncer pods (already rolling) pick up new cert on restart → apps recover.

> Note: YAML diagnostics in IDE show false-positive RKE schema errors on `cluster.yaml` — this is a CNPG `Cluster` CR, not an RKE cluster config. Schema mismatch in language server only.