### PR TITLE
fix(homepage): remove broken widgets and gaming section

### DIFF
--- a/kubernetes/clusters/live/charts/homepage.yaml
+++ b/kubernetes/clusters/live/charts/homepage.yaml
@@ -112,10 +112,6 @@ configMaps:
               icon: mdi-server
               style: row
               columns: 4
-          - Gaming:
-              icon: mdi-gamepad-variant
-              style: row
-              columns: 2
       widgets.yaml: |
         - search:
             provider: google
@@ -134,40 +130,7 @@ configMaps:
             timezone: America/New_York
             units: imperial
             cache: 15
-      services.yaml: |
-        - Gaming:
-            - Minecraft:
-                icon: minecraft.svg
-                description: Java + Bedrock crossplay
-                widget:
-                  type: gamedig
-                  serverType: minecraft
-                  host: minecraft.minecraft.svc.cluster.local
-                  port: 25565
-            - Valheim:
-                icon: valheim.svg
-                description: Dedicated server
-                widget:
-                  type: gamedig
-                  serverType: valheim
-                  host: valheim.valheim.svc.cluster.local
-                  port: 2457
-            - Satisfactory:
-                icon: satisfactory.svg
-                description: Dedicated server
-                widget:
-                  type: gamedig
-                  serverType: satisfactory
-                  host: satisfactory.satisfactory.svc.cluster.local
-                  port: 7777
-            - Factorio:
-                icon: factorio.svg
-                description: Space Age
-                widget:
-                  type: gamedig
-                  serverType: factorio
-                  host: factorio.factorio.svc.cluster.local
-                  port: 34197
+      services.yaml: ""
       bookmarks.yaml: |
         - Infrastructure:
             - GitHub:

--- a/kubernetes/clusters/live/charts/qbittorrent.yaml
+++ b/kubernetes/clusters/live/charts/qbittorrent.yaml
@@ -191,8 +191,6 @@ route:
       gethomepage.dev/name: "qBittorrent"
       gethomepage.dev/group: "Media"
       gethomepage.dev/icon: "qbittorrent.svg"
-      gethomepage.dev/widget.type: "qbittorrent"
-      gethomepage.dev/widget.url: "http://qbittorrent.media.svc:8080"
       gethomepage.dev/pod-selector: "app.kubernetes.io/name=qbittorrent"
     parentRefs:
       - name: internal

--- a/kubernetes/clusters/live/charts/sabnzbd.yaml
+++ b/kubernetes/clusters/live/charts/sabnzbd.yaml
@@ -92,8 +92,6 @@ route:
       gethomepage.dev/name: "SABnzbd"
       gethomepage.dev/group: "Media"
       gethomepage.dev/icon: "sabnzbd.svg"
-      gethomepage.dev/widget.type: "sabnzbd"
-      gethomepage.dev/widget.url: "http://sabnzbd.media.svc:8080"
       gethomepage.dev/pod-selector: "app.kubernetes.io/name=sabnzbd"
     parentRefs:
       - name: internal

--- a/kubernetes/clusters/live/charts/tdarr.yaml
+++ b/kubernetes/clusters/live/charts/tdarr.yaml
@@ -92,8 +92,6 @@ route:
       gethomepage.dev/name: "Tdarr"
       gethomepage.dev/group: "Media"
       gethomepage.dev/icon: "tdarr.svg"
-      gethomepage.dev/widget.type: "tdarr"
-      gethomepage.dev/widget.url: "http://tdarr.media.svc:8265"
       gethomepage.dev/pod-selector: "app.kubernetes.io/name=tdarr"
     parentRefs:
       - name: internal

--- a/kubernetes/platform/config/monitoring/prometheus-route.yaml
+++ b/kubernetes/platform/config/monitoring/prometheus-route.yaml
@@ -9,8 +9,6 @@ metadata:
     gethomepage.dev/name: "Prometheus"
     gethomepage.dev/group: "Platform"
     gethomepage.dev/icon: "prometheus.svg"
-    gethomepage.dev/widget.type: "prometheus"
-    gethomepage.dev/widget.url: "http://prometheus-operated.monitoring.svc:9090"
 spec:
   parentRefs:
     - name: internal


### PR DESCRIPTION
## Summary

- Drop `widget.type` / `widget.url` annotations from qBittorrent, SABnzbd, Tdarr, and Prometheus HTTPRoutes — tiles remain visible with icon + pod status dot, but the stats-polling sidecar calls that produce red error banners are eliminated
- Remove the `Gaming` layout section and all four `gamedig` service entries (Minecraft, Valheim, Satisfactory, Factorio) — no game-server namespaces or deployments exist in-cluster, so these widgets can never resolve
- Collapse `services.yaml` to `""` matching the existing pattern used for `docker.yaml` / `proxmox.yaml`

## Test plan

- [ ] After merge → live converges → reload `home.internal.tomnowak.work`: qBittorrent / SABnzbd / Tdarr / Prometheus cards show name + status dot only, no stats panel, no red error banner
- [ ] Gaming section header and all four cards absent from the page
- [ ] Media / Apps / Platform / Infrastructure sections unchanged
- [ ] `kubectl --context live -n homepage logs deploy/homepage` — no `widget` fetch errors for removed integrations