### PR TITLE
feat(monitoring): per-app RED-metric SLO alerts on gateway traffic

### DIFF
--- a/kubernetes/platform/config/gateway/coraza-waf-rules.yaml
+++ b/kubernetes/platform/config/gateway/coraza-waf-rules.yaml
@@ -42,37 +42,3 @@ spec:
           annotations:
             summary: "Coraza WAF blocking >10% of external traffic"
             description: "High 403 rate may indicate attack or WAF false positives. Check waf_filter_tx_interruptions_ruleid_* metrics for triggered rules."
-
-        # Alert if gateway latency is impacting user experience (excludes kromgo which has elevated upstream latency)
-        - alert: CorazaWAFHighLatency
-          expr: |
-            histogram_quantile(0.99,
-              sum(rate(istio_request_duration_milliseconds_bucket{
-                source_workload=~"external-istio",
-                reporter="source",
-                destination_service!~".*kromgo.*"
-              }[5m])) by (le)
-            ) > 200
-          for: 5m
-          labels:
-            severity: warning
-          annotations:
-            summary: "External gateway p99 latency >200ms"
-            description: "Gateway processing overhead is high. Consider WAF rule optimization or increasing paranoia level exclusions."
-
-        # Alert for kromgo backend which has elevated upstream latency (~99ms p99) unrelated to WAF overhead
-        - alert: CorazaWAFKromgoHighLatency
-          expr: |
-            histogram_quantile(0.99,
-              sum(rate(istio_request_duration_milliseconds_bucket{
-                source_workload=~"external-istio",
-                reporter="source",
-                destination_service=~".*kromgo.*"
-              }[5m])) by (le)
-            ) > 200
-          for: 5m
-          labels:
-            severity: warning
-          annotations:
-            summary: "Kromgo upstream p99 latency >200ms"
-            description: "Kromgo backend latency is unusually high. This reflects upstream kromgo service latency, not WAF overhead. Normal p99 is ~99ms."

--- a/kubernetes/platform/config/monitoring/gateway-red-alerts.yaml
+++ b/kubernetes/platform/config/monitoring/gateway-red-alerts.yaml
@@ -1,0 +1,1094 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: gateway-red-alerts
+  labels:
+    app.kubernetes.io/name: gateway
+    release: kube-prometheus-stack
+spec:
+  groups:
+    # ── Recording rules ───────────────────────────────────────────────────────
+    # Computed once per scrape interval; alerts reference these cheap metrics.
+    # All rules pin reporter="source" — Ambient mode only produces source-side
+    # metrics from ztunnel; destination-side metrics do not exist.
+    - name: gateway.recording
+      rules:
+        # Total requests ── all four burn-rate windows
+        - record: gateway:requests:rate5m
+          expr: |
+            sum(rate(istio_requests_total{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"authelia|oauth2-proxy|immich-server|kromgo|jellyfin|jellyseerr|jfa-go|tandoor|zipline"
+            }[5m])) by (destination_workload, source_workload)
+
+        - record: gateway:requests:rate30m
+          expr: |
+            sum(rate(istio_requests_total{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"authelia|oauth2-proxy|immich-server|kromgo|jellyfin|jellyseerr|jfa-go|tandoor|zipline"
+            }[30m])) by (destination_workload, source_workload)
+
+        - record: gateway:requests:rate1h
+          expr: |
+            sum(rate(istio_requests_total{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"authelia|oauth2-proxy|immich-server|kromgo|jellyfin|jellyseerr|jfa-go|tandoor|zipline"
+            }[1h])) by (destination_workload, source_workload)
+
+        - record: gateway:requests:rate6h
+          expr: |
+            sum(rate(istio_requests_total{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"authelia|oauth2-proxy|immich-server|kromgo|jellyfin|jellyseerr|jfa-go|tandoor|zipline"
+            }[6h])) by (destination_workload, source_workload)
+
+        # 5xx errors ── all four burn-rate windows
+        - record: gateway:requests_errors:rate5m
+          expr: |
+            sum(rate(istio_requests_total{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"authelia|oauth2-proxy|immich-server|kromgo|jellyfin|jellyseerr|jfa-go|tandoor|zipline",
+              response_code=~"5.."
+            }[5m])) by (destination_workload, source_workload)
+
+        - record: gateway:requests_errors:rate30m
+          expr: |
+            sum(rate(istio_requests_total{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"authelia|oauth2-proxy|immich-server|kromgo|jellyfin|jellyseerr|jfa-go|tandoor|zipline",
+              response_code=~"5.."
+            }[30m])) by (destination_workload, source_workload)
+
+        - record: gateway:requests_errors:rate1h
+          expr: |
+            sum(rate(istio_requests_total{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"authelia|oauth2-proxy|immich-server|kromgo|jellyfin|jellyseerr|jfa-go|tandoor|zipline",
+              response_code=~"5.."
+            }[1h])) by (destination_workload, source_workload)
+
+        - record: gateway:requests_errors:rate6h
+          expr: |
+            sum(rate(istio_requests_total{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"authelia|oauth2-proxy|immich-server|kromgo|jellyfin|jellyseerr|jfa-go|tandoor|zipline",
+              response_code=~"5.."
+            }[6h])) by (destination_workload, source_workload)
+
+        # Fast requests (≤ threshold) ── grouped by shared latency SLO bucket.
+        # Grouping apps by bucket reduces rules from 36 to 16 without any loss
+        # of correctness — each group emits distinct destination_workload labels.
+
+        # 500ms threshold: authelia, oauth2-proxy
+        - record: gateway:requests_fast:rate5m
+          expr: |
+            sum(rate(istio_request_duration_milliseconds_bucket{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"authelia|oauth2-proxy",
+              le="500"
+            }[5m])) by (destination_workload, source_workload)
+
+        - record: gateway:requests_fast:rate30m
+          expr: |
+            sum(rate(istio_request_duration_milliseconds_bucket{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"authelia|oauth2-proxy",
+              le="500"
+            }[30m])) by (destination_workload, source_workload)
+
+        - record: gateway:requests_fast:rate1h
+          expr: |
+            sum(rate(istio_request_duration_milliseconds_bucket{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"authelia|oauth2-proxy",
+              le="500"
+            }[1h])) by (destination_workload, source_workload)
+
+        - record: gateway:requests_fast:rate6h
+          expr: |
+            sum(rate(istio_request_duration_milliseconds_bucket{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"authelia|oauth2-proxy",
+              le="500"
+            }[6h])) by (destination_workload, source_workload)
+
+        # 1000ms threshold: kromgo, jfa-go, tandoor
+        - record: gateway:requests_fast:rate5m
+          expr: |
+            sum(rate(istio_request_duration_milliseconds_bucket{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"kromgo|jfa-go|tandoor",
+              le="1000"
+            }[5m])) by (destination_workload, source_workload)
+
+        - record: gateway:requests_fast:rate30m
+          expr: |
+            sum(rate(istio_request_duration_milliseconds_bucket{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"kromgo|jfa-go|tandoor",
+              le="1000"
+            }[30m])) by (destination_workload, source_workload)
+
+        - record: gateway:requests_fast:rate1h
+          expr: |
+            sum(rate(istio_request_duration_milliseconds_bucket{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"kromgo|jfa-go|tandoor",
+              le="1000"
+            }[1h])) by (destination_workload, source_workload)
+
+        - record: gateway:requests_fast:rate6h
+          expr: |
+            sum(rate(istio_request_duration_milliseconds_bucket{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"kromgo|jfa-go|tandoor",
+              le="1000"
+            }[6h])) by (destination_workload, source_workload)
+
+        # 2500ms threshold: immich-server, jellyseerr, zipline
+        - record: gateway:requests_fast:rate5m
+          expr: |
+            sum(rate(istio_request_duration_milliseconds_bucket{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"immich-server|jellyseerr|zipline",
+              le="2500"
+            }[5m])) by (destination_workload, source_workload)
+
+        - record: gateway:requests_fast:rate30m
+          expr: |
+            sum(rate(istio_request_duration_milliseconds_bucket{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"immich-server|jellyseerr|zipline",
+              le="2500"
+            }[30m])) by (destination_workload, source_workload)
+
+        - record: gateway:requests_fast:rate1h
+          expr: |
+            sum(rate(istio_request_duration_milliseconds_bucket{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"immich-server|jellyseerr|zipline",
+              le="2500"
+            }[1h])) by (destination_workload, source_workload)
+
+        - record: gateway:requests_fast:rate6h
+          expr: |
+            sum(rate(istio_request_duration_milliseconds_bucket{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload=~"immich-server|jellyseerr|zipline",
+              le="2500"
+            }[6h])) by (destination_workload, source_workload)
+
+        # 60000ms threshold: jellyfin (long-lived video streams)
+        - record: gateway:requests_fast:rate5m
+          expr: |
+            sum(rate(istio_request_duration_milliseconds_bucket{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload="jellyfin",
+              le="60000"
+            }[5m])) by (destination_workload, source_workload)
+
+        - record: gateway:requests_fast:rate30m
+          expr: |
+            sum(rate(istio_request_duration_milliseconds_bucket{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload="jellyfin",
+              le="60000"
+            }[30m])) by (destination_workload, source_workload)
+
+        - record: gateway:requests_fast:rate1h
+          expr: |
+            sum(rate(istio_request_duration_milliseconds_bucket{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload="jellyfin",
+              le="60000"
+            }[1h])) by (destination_workload, source_workload)
+
+        - record: gateway:requests_fast:rate6h
+          expr: |
+            sum(rate(istio_request_duration_milliseconds_bucket{
+              reporter="source",
+              source_workload=~"external-istio.*|internal-istio.*",
+              destination_workload="jellyfin",
+              le="60000"
+            }[6h])) by (destination_workload, source_workload)
+
+    # ── Availability SLO alerts ───────────────────────────────────────────────
+    # SLO: 99% of requests must return non-5xx over a 30-day window.
+    # Error budget = 1%. Burn rates: fast=14.4x (2% budget/1h), slow=6x (5%/6h).
+    - name: gateway.slo.availability
+      rules:
+        # Authelia
+        - alert: AutheliaAvailabilityBudgetBurningFast
+          expr: |
+            (
+              gateway:requests_errors:rate1h{destination_workload="authelia"}
+              / gateway:requests:rate1h{destination_workload="authelia"}
+            ) > 0.144
+            and
+            (
+              gateway:requests_errors:rate5m{destination_workload="authelia"}
+              / gateway:requests:rate5m{destination_workload="authelia"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 14.4% for fast burn). At this rate the 30-day error budget
+              will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: AutheliaAvailabilityBudgetBurningSlow
+          expr: |
+            (
+              gateway:requests_errors:rate6h{destination_workload="authelia"}
+              / gateway:requests:rate6h{destination_workload="authelia"}
+            ) > 0.06
+            and
+            (
+              gateway:requests_errors:rate30m{destination_workload="authelia"}
+              / gateway:requests:rate30m{destination_workload="authelia"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 6% for slow burn). At this rate 5% of the 30-day error budget
+              will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+        # oauth2-proxy
+        - alert: Oauth2ProxyAvailabilityBudgetBurningFast
+          expr: |
+            (
+              gateway:requests_errors:rate1h{destination_workload="oauth2-proxy"}
+              / gateway:requests:rate1h{destination_workload="oauth2-proxy"}
+            ) > 0.144
+            and
+            (
+              gateway:requests_errors:rate5m{destination_workload="oauth2-proxy"}
+              / gateway:requests:rate5m{destination_workload="oauth2-proxy"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 14.4% for fast burn). At this rate the 30-day error budget
+              will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: Oauth2ProxyAvailabilityBudgetBurningSlow
+          expr: |
+            (
+              gateway:requests_errors:rate6h{destination_workload="oauth2-proxy"}
+              / gateway:requests:rate6h{destination_workload="oauth2-proxy"}
+            ) > 0.06
+            and
+            (
+              gateway:requests_errors:rate30m{destination_workload="oauth2-proxy"}
+              / gateway:requests:rate30m{destination_workload="oauth2-proxy"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 6% for slow burn). At this rate 5% of the 30-day error budget
+              will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+        # Immich
+        - alert: ImmichAvailabilityBudgetBurningFast
+          expr: |
+            (
+              gateway:requests_errors:rate1h{destination_workload="immich-server"}
+              / gateway:requests:rate1h{destination_workload="immich-server"}
+            ) > 0.144
+            and
+            (
+              gateway:requests_errors:rate5m{destination_workload="immich-server"}
+              / gateway:requests:rate5m{destination_workload="immich-server"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 14.4% for fast burn). At this rate the 30-day error budget
+              will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: ImmichAvailabilityBudgetBurningSlow
+          expr: |
+            (
+              gateway:requests_errors:rate6h{destination_workload="immich-server"}
+              / gateway:requests:rate6h{destination_workload="immich-server"}
+            ) > 0.06
+            and
+            (
+              gateway:requests_errors:rate30m{destination_workload="immich-server"}
+              / gateway:requests:rate30m{destination_workload="immich-server"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 6% for slow burn). At this rate 5% of the 30-day error budget
+              will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+        # Kromgo
+        - alert: KromgoAvailabilityBudgetBurningFast
+          expr: |
+            (
+              gateway:requests_errors:rate1h{destination_workload="kromgo"}
+              / gateway:requests:rate1h{destination_workload="kromgo"}
+            ) > 0.144
+            and
+            (
+              gateway:requests_errors:rate5m{destination_workload="kromgo"}
+              / gateway:requests:rate5m{destination_workload="kromgo"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 14.4% for fast burn). At this rate the 30-day error budget
+              will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: KromgoAvailabilityBudgetBurningSlow
+          expr: |
+            (
+              gateway:requests_errors:rate6h{destination_workload="kromgo"}
+              / gateway:requests:rate6h{destination_workload="kromgo"}
+            ) > 0.06
+            and
+            (
+              gateway:requests_errors:rate30m{destination_workload="kromgo"}
+              / gateway:requests:rate30m{destination_workload="kromgo"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 6% for slow burn). At this rate 5% of the 30-day error budget
+              will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+        # Jellyfin
+        - alert: JellyfinAvailabilityBudgetBurningFast
+          expr: |
+            (
+              gateway:requests_errors:rate1h{destination_workload="jellyfin"}
+              / gateway:requests:rate1h{destination_workload="jellyfin"}
+            ) > 0.144
+            and
+            (
+              gateway:requests_errors:rate5m{destination_workload="jellyfin"}
+              / gateway:requests:rate5m{destination_workload="jellyfin"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 14.4% for fast burn). At this rate the 30-day error budget
+              will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: JellyfinAvailabilityBudgetBurningSlow
+          expr: |
+            (
+              gateway:requests_errors:rate6h{destination_workload="jellyfin"}
+              / gateway:requests:rate6h{destination_workload="jellyfin"}
+            ) > 0.06
+            and
+            (
+              gateway:requests_errors:rate30m{destination_workload="jellyfin"}
+              / gateway:requests:rate30m{destination_workload="jellyfin"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 6% for slow burn). At this rate 5% of the 30-day error budget
+              will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+        # Jellyseerr
+        - alert: JellyseerrAvailabilityBudgetBurningFast
+          expr: |
+            (
+              gateway:requests_errors:rate1h{destination_workload="jellyseerr"}
+              / gateway:requests:rate1h{destination_workload="jellyseerr"}
+            ) > 0.144
+            and
+            (
+              gateway:requests_errors:rate5m{destination_workload="jellyseerr"}
+              / gateway:requests:rate5m{destination_workload="jellyseerr"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 14.4% for fast burn). At this rate the 30-day error budget
+              will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: JellyseerrAvailabilityBudgetBurningSlow
+          expr: |
+            (
+              gateway:requests_errors:rate6h{destination_workload="jellyseerr"}
+              / gateway:requests:rate6h{destination_workload="jellyseerr"}
+            ) > 0.06
+            and
+            (
+              gateway:requests_errors:rate30m{destination_workload="jellyseerr"}
+              / gateway:requests:rate30m{destination_workload="jellyseerr"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 6% for slow burn). At this rate 5% of the 30-day error budget
+              will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+        # jfa-go
+        - alert: JfaGoAvailabilityBudgetBurningFast
+          expr: |
+            (
+              gateway:requests_errors:rate1h{destination_workload="jfa-go"}
+              / gateway:requests:rate1h{destination_workload="jfa-go"}
+            ) > 0.144
+            and
+            (
+              gateway:requests_errors:rate5m{destination_workload="jfa-go"}
+              / gateway:requests:rate5m{destination_workload="jfa-go"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 14.4% for fast burn). At this rate the 30-day error budget
+              will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: JfaGoAvailabilityBudgetBurningSlow
+          expr: |
+            (
+              gateway:requests_errors:rate6h{destination_workload="jfa-go"}
+              / gateway:requests:rate6h{destination_workload="jfa-go"}
+            ) > 0.06
+            and
+            (
+              gateway:requests_errors:rate30m{destination_workload="jfa-go"}
+              / gateway:requests:rate30m{destination_workload="jfa-go"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 6% for slow burn). At this rate 5% of the 30-day error budget
+              will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+        # Tandoor
+        - alert: TandoorAvailabilityBudgetBurningFast
+          expr: |
+            (
+              gateway:requests_errors:rate1h{destination_workload="tandoor"}
+              / gateway:requests:rate1h{destination_workload="tandoor"}
+            ) > 0.144
+            and
+            (
+              gateway:requests_errors:rate5m{destination_workload="tandoor"}
+              / gateway:requests:rate5m{destination_workload="tandoor"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 14.4% for fast burn). At this rate the 30-day error budget
+              will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: TandoorAvailabilityBudgetBurningSlow
+          expr: |
+            (
+              gateway:requests_errors:rate6h{destination_workload="tandoor"}
+              / gateway:requests:rate6h{destination_workload="tandoor"}
+            ) > 0.06
+            and
+            (
+              gateway:requests_errors:rate30m{destination_workload="tandoor"}
+              / gateway:requests:rate30m{destination_workload="tandoor"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 6% for slow burn). At this rate 5% of the 30-day error budget
+              will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+        # Zipline
+        - alert: ZiplineAvailabilityBudgetBurningFast
+          expr: |
+            (
+              gateway:requests_errors:rate1h{destination_workload="zipline"}
+              / gateway:requests:rate1h{destination_workload="zipline"}
+            ) > 0.144
+            and
+            (
+              gateway:requests_errors:rate5m{destination_workload="zipline"}
+              / gateway:requests:rate5m{destination_workload="zipline"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 14.4% for fast burn). At this rate the 30-day error budget
+              will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: ZiplineAvailabilityBudgetBurningSlow
+          expr: |
+            (
+              gateway:requests_errors:rate6h{destination_workload="zipline"}
+              / gateway:requests:rate6h{destination_workload="zipline"}
+            ) > 0.06
+            and
+            (
+              gateway:requests_errors:rate30m{destination_workload="zipline"}
+              / gateway:requests:rate30m{destination_workload="zipline"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} 5xx error budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} is returning 5xx errors at {{ $value | humanizePercentage }}
+              of requests (threshold: 6% for slow burn). At this rate 5% of the 30-day error budget
+              will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+    # ── Latency SLO alerts ────────────────────────────────────────────────────
+    # SLO: 99% of requests must complete within per-app threshold over 30 days.
+    # slow_ratio = 1 - (fast_count / total_count). Burn rates same as above.
+    - name: gateway.slo.latency
+      rules:
+        # Authelia (500ms)
+        - alert: AutheliaLatencyBudgetBurningFast
+          expr: |
+            (
+              1 - gateway:requests_fast:rate1h{destination_workload="authelia"}
+                  / gateway:requests:rate1h{destination_workload="authelia"}
+            ) > 0.144
+            and
+            (
+              1 - gateway:requests_fast:rate5m{destination_workload="authelia"}
+                  / gateway:requests:rate5m{destination_workload="authelia"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 500ms SLO threshold (fast burn limit: 14.4%). At this rate the 30-day
+              latency budget will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: AutheliaLatencyBudgetBurningSlow
+          expr: |
+            (
+              1 - gateway:requests_fast:rate6h{destination_workload="authelia"}
+                  / gateway:requests:rate6h{destination_workload="authelia"}
+            ) > 0.06
+            and
+            (
+              1 - gateway:requests_fast:rate30m{destination_workload="authelia"}
+                  / gateway:requests:rate30m{destination_workload="authelia"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 500ms SLO threshold (slow burn limit: 6%). At this rate 5% of the 30-day
+              latency budget will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+        # oauth2-proxy (500ms)
+        - alert: Oauth2ProxyLatencyBudgetBurningFast
+          expr: |
+            (
+              1 - gateway:requests_fast:rate1h{destination_workload="oauth2-proxy"}
+                  / gateway:requests:rate1h{destination_workload="oauth2-proxy"}
+            ) > 0.144
+            and
+            (
+              1 - gateway:requests_fast:rate5m{destination_workload="oauth2-proxy"}
+                  / gateway:requests:rate5m{destination_workload="oauth2-proxy"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 500ms SLO threshold (fast burn limit: 14.4%). At this rate the 30-day
+              latency budget will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: Oauth2ProxyLatencyBudgetBurningSlow
+          expr: |
+            (
+              1 - gateway:requests_fast:rate6h{destination_workload="oauth2-proxy"}
+                  / gateway:requests:rate6h{destination_workload="oauth2-proxy"}
+            ) > 0.06
+            and
+            (
+              1 - gateway:requests_fast:rate30m{destination_workload="oauth2-proxy"}
+                  / gateway:requests:rate30m{destination_workload="oauth2-proxy"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 500ms SLO threshold (slow burn limit: 6%). At this rate 5% of the 30-day
+              latency budget will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+        # Immich (2500ms)
+        - alert: ImmichLatencyBudgetBurningFast
+          expr: |
+            (
+              1 - gateway:requests_fast:rate1h{destination_workload="immich-server"}
+                  / gateway:requests:rate1h{destination_workload="immich-server"}
+            ) > 0.144
+            and
+            (
+              1 - gateway:requests_fast:rate5m{destination_workload="immich-server"}
+                  / gateway:requests:rate5m{destination_workload="immich-server"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 2500ms SLO threshold (fast burn limit: 14.4%). At this rate the 30-day
+              latency budget will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: ImmichLatencyBudgetBurningSlow
+          expr: |
+            (
+              1 - gateway:requests_fast:rate6h{destination_workload="immich-server"}
+                  / gateway:requests:rate6h{destination_workload="immich-server"}
+            ) > 0.06
+            and
+            (
+              1 - gateway:requests_fast:rate30m{destination_workload="immich-server"}
+                  / gateway:requests:rate30m{destination_workload="immich-server"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 2500ms SLO threshold (slow burn limit: 6%). At this rate 5% of the 30-day
+              latency budget will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+        # Kromgo (1000ms)
+        - alert: KromgoLatencyBudgetBurningFast
+          expr: |
+            (
+              1 - gateway:requests_fast:rate1h{destination_workload="kromgo"}
+                  / gateway:requests:rate1h{destination_workload="kromgo"}
+            ) > 0.144
+            and
+            (
+              1 - gateway:requests_fast:rate5m{destination_workload="kromgo"}
+                  / gateway:requests:rate5m{destination_workload="kromgo"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 1000ms SLO threshold (fast burn limit: 14.4%). At this rate the 30-day
+              latency budget will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: KromgoLatencyBudgetBurningSlow
+          expr: |
+            (
+              1 - gateway:requests_fast:rate6h{destination_workload="kromgo"}
+                  / gateway:requests:rate6h{destination_workload="kromgo"}
+            ) > 0.06
+            and
+            (
+              1 - gateway:requests_fast:rate30m{destination_workload="kromgo"}
+                  / gateway:requests:rate30m{destination_workload="kromgo"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 1000ms SLO threshold (slow burn limit: 6%). At this rate 5% of the 30-day
+              latency budget will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+        # Jellyfin (60000ms — long-lived video streams)
+        - alert: JellyfinLatencyBudgetBurningFast
+          expr: |
+            (
+              1 - gateway:requests_fast:rate1h{destination_workload="jellyfin"}
+                  / gateway:requests:rate1h{destination_workload="jellyfin"}
+            ) > 0.144
+            and
+            (
+              1 - gateway:requests_fast:rate5m{destination_workload="jellyfin"}
+                  / gateway:requests:rate5m{destination_workload="jellyfin"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 60000ms SLO threshold (fast burn limit: 14.4%). At this rate the 30-day
+              latency budget will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: JellyfinLatencyBudgetBurningSlow
+          expr: |
+            (
+              1 - gateway:requests_fast:rate6h{destination_workload="jellyfin"}
+                  / gateway:requests:rate6h{destination_workload="jellyfin"}
+            ) > 0.06
+            and
+            (
+              1 - gateway:requests_fast:rate30m{destination_workload="jellyfin"}
+                  / gateway:requests:rate30m{destination_workload="jellyfin"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 60000ms SLO threshold (slow burn limit: 6%). At this rate 5% of the 30-day
+              latency budget will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+        # Jellyseerr (2500ms)
+        - alert: JellyseerrLatencyBudgetBurningFast
+          expr: |
+            (
+              1 - gateway:requests_fast:rate1h{destination_workload="jellyseerr"}
+                  / gateway:requests:rate1h{destination_workload="jellyseerr"}
+            ) > 0.144
+            and
+            (
+              1 - gateway:requests_fast:rate5m{destination_workload="jellyseerr"}
+                  / gateway:requests:rate5m{destination_workload="jellyseerr"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 2500ms SLO threshold (fast burn limit: 14.4%). At this rate the 30-day
+              latency budget will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: JellyseerrLatencyBudgetBurningSlow
+          expr: |
+            (
+              1 - gateway:requests_fast:rate6h{destination_workload="jellyseerr"}
+                  / gateway:requests:rate6h{destination_workload="jellyseerr"}
+            ) > 0.06
+            and
+            (
+              1 - gateway:requests_fast:rate30m{destination_workload="jellyseerr"}
+                  / gateway:requests:rate30m{destination_workload="jellyseerr"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 2500ms SLO threshold (slow burn limit: 6%). At this rate 5% of the 30-day
+              latency budget will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+        # jfa-go (1000ms)
+        - alert: JfaGoLatencyBudgetBurningFast
+          expr: |
+            (
+              1 - gateway:requests_fast:rate1h{destination_workload="jfa-go"}
+                  / gateway:requests:rate1h{destination_workload="jfa-go"}
+            ) > 0.144
+            and
+            (
+              1 - gateway:requests_fast:rate5m{destination_workload="jfa-go"}
+                  / gateway:requests:rate5m{destination_workload="jfa-go"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 1000ms SLO threshold (fast burn limit: 14.4%). At this rate the 30-day
+              latency budget will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: JfaGoLatencyBudgetBurningSlow
+          expr: |
+            (
+              1 - gateway:requests_fast:rate6h{destination_workload="jfa-go"}
+                  / gateway:requests:rate6h{destination_workload="jfa-go"}
+            ) > 0.06
+            and
+            (
+              1 - gateway:requests_fast:rate30m{destination_workload="jfa-go"}
+                  / gateway:requests:rate30m{destination_workload="jfa-go"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 1000ms SLO threshold (slow burn limit: 6%). At this rate 5% of the 30-day
+              latency budget will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+        # Tandoor (1000ms)
+        - alert: TandoorLatencyBudgetBurningFast
+          expr: |
+            (
+              1 - gateway:requests_fast:rate1h{destination_workload="tandoor"}
+                  / gateway:requests:rate1h{destination_workload="tandoor"}
+            ) > 0.144
+            and
+            (
+              1 - gateway:requests_fast:rate5m{destination_workload="tandoor"}
+                  / gateway:requests:rate5m{destination_workload="tandoor"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 1000ms SLO threshold (fast burn limit: 14.4%). At this rate the 30-day
+              latency budget will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: TandoorLatencyBudgetBurningSlow
+          expr: |
+            (
+              1 - gateway:requests_fast:rate6h{destination_workload="tandoor"}
+                  / gateway:requests:rate6h{destination_workload="tandoor"}
+            ) > 0.06
+            and
+            (
+              1 - gateway:requests_fast:rate30m{destination_workload="tandoor"}
+                  / gateway:requests:rate30m{destination_workload="tandoor"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 1000ms SLO threshold (slow burn limit: 6%). At this rate 5% of the 30-day
+              latency budget will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.
+
+        # Zipline (2500ms)
+        - alert: ZiplineLatencyBudgetBurningFast
+          expr: |
+            (
+              1 - gateway:requests_fast:rate1h{destination_workload="zipline"}
+                  / gateway:requests:rate1h{destination_workload="zipline"}
+            ) > 0.144
+            and
+            (
+              1 - gateway:requests_fast:rate5m{destination_workload="zipline"}
+                  / gateway:requests:rate5m{destination_workload="zipline"}
+            ) > 0.144
+          for: 2m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning fast via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 2500ms SLO threshold (fast burn limit: 14.4%). At this rate the 30-day
+              latency budget will be exhausted in under 2 hours. Gateway: {{ $labels.source_workload }}.
+
+        - alert: ZiplineLatencyBudgetBurningSlow
+          expr: |
+            (
+              1 - gateway:requests_fast:rate6h{destination_workload="zipline"}
+                  / gateway:requests:rate6h{destination_workload="zipline"}
+            ) > 0.06
+            and
+            (
+              1 - gateway:requests_fast:rate30m{destination_workload="zipline"}
+                  / gateway:requests:rate30m{destination_workload="zipline"}
+            ) > 0.06
+          for: 15m
+          labels:
+            severity: warning
+            app: '{{ $labels.destination_workload }}'
+            gateway: '{{ $labels.source_workload }}'
+          annotations:
+            summary: "{{ $labels.destination_workload }} latency budget burning slow via {{ $labels.source_workload }}"
+            description: >-
+              {{ $labels.destination_workload }} has {{ $value | humanizePercentage }} of requests
+              exceeding the 2500ms SLO threshold (slow burn limit: 6%). At this rate 5% of the 30-day
+              latency budget will be consumed in 6 hours. Gateway: {{ $labels.source_workload }}.

--- a/kubernetes/platform/config/monitoring/kustomization.yaml
+++ b/kubernetes/platform/config/monitoring/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - cilium-alerts.yaml
   - istio-servicemonitors.yaml
   - istio-alerts.yaml
+  - gateway-red-alerts.yaml
   - external-secrets-alerts.yaml
   - grafana-alerts.yaml
   - loki-mixin-alerts.yaml


### PR DESCRIPTION
## Summary

- Deletes `CorazaWAFHighLatency` and `CorazaWAFKromgoHighLatency` — these measured end-to-end upstream latency (not WAF overhead), were impossible to fix under Ambient mode (no `reporter=destination`), and triggered on legitimate Immich ML / Jellyfin streaming latency rather than real incidents
- Adds `gateway-red-alerts.yaml`: hand-rolled burn-rate SLO alerts covering 9 user-facing workloads on both gateways
- Retains `CorazaWAFDegraded` and `CorazaWAFHighBlockRate`

## Design

**SLO**: 99% availability (non-5xx) and 99% latency (per-app threshold) over a 30-day window.

**Burn-rate alerts** (2 per SLI per app = 36 total, all `severity: warning`):
- Fast burn: `error_ratio > 14.4%` over `[1h] AND [5m]` — consumes 2% budget/1h, detects within ~5m
- Slow burn: `error_ratio > 6%` over `[6h] AND [30m]` — catches gradual degradation

**Per-app latency thresholds** (aligned to Istio histogram buckets):
| App | Threshold |
|---|---|
| authelia, oauth2-proxy | 500ms |
| kromgo, jfa-go, tandoor | 1000ms |
| immich-server, jellyseerr, zipline | 2500ms |
| jellyfin | 60000ms |

**Recording rules** (`gateway.recording` group): pre-compute `gateway:requests:rate{5m,30m,1h,6h}`, `gateway:requests_errors:rate*`, and `gateway:requests_fast:rate*` per `(destination_workload, source_workload)`. Fast rules group apps by shared threshold (4 groups × 4 windows = 16 rules vs 36). All pin `reporter="source"` for Ambient mode compatibility.

## Test plan

- [x] `task k8s:validate` passes (YAML lint + schema + Helm templating + deprecation check)
- [ ] `task k8s:dry-run-dev` — server-side admission dry-run against dev cluster
- [ ] After Flux reconcile on dev: query each recording rule via Prometheus port-forward to verify data
- [ ] Synthetic burn: brief network policy block on `tandoor` → confirm `TandoorAvailabilityBudgetBurningFast` fires within ~5m and resolves on revert
- [ ] Confirm `ALERTS{alertstate="firing"}` has no new false positives on baseline traffic
- [ ] Verify `CorazaWAFHighLatency` no longer appears in `ALERTS`