### PR TITLE
fix(jellyfin): extend startup probe and add Renovate maintenance window

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -195,6 +195,18 @@
       ],
       "groupName": "hardware monitoring exporters"
     },
+    {
+      // Jellyfin: restrict upgrades to off-peak hours to avoid SLA impact.
+      // Recreate strategy causes hard downtime on every pod restart; scheduling
+      // updates during low-traffic hours minimises user-visible disruption.
+      "matchDepNames": [
+        "jellyfin"
+      ],
+      "groupName": "jellyfin",
+      "schedule": [
+        "after 2am and before 6am on Monday"
+      ]
+    },
     // ============================================================
     // Version holds — upstream regressions (see .github/version-holds.yaml)
     // ============================================================

--- a/kubernetes/clusters/live/charts/jellyfin.yaml
+++ b/kubernetes/clusters/live/charts/jellyfin.yaml
@@ -45,7 +45,7 @@ controllers:
                 port: 8096
               initialDelaySeconds: 10
               periodSeconds: 5
-              failureThreshold: 30
+              failureThreshold: 60
           liveness:
             enabled: true
             custom: true


### PR DESCRIPTION
## Summary

Jellyfin currently sits at ~98% availability. Two root causes are addressed here:

1. **Startup probe kills**: the existing `failureThreshold: 30` allows only 160 s for Jellyfin to start. As the library grows, startup time is growing past that window — June 4 recorded 28 failed canary probes in a 2 h window. Kubernetes kills the pod and the `Recreate` strategy then causes another full cold-start cycle, compounding downtime.
2. **Uncontrolled upgrade timing**: Renovate can open and automerge a Jellyfin update at any time. Because `Recreate` causes a hard outage on every pod restart, upgrades during peak hours directly degrade SLA.

## Changes

### Fix 1 — Startup probe (`kubernetes/clusters/live/charts/jellyfin.yaml`)

Raises `failureThreshold` from `30` → `60`.

| | Before | After |
|---|---|---|
| Allowed startup window | `10 + 5×30 = 160 s` | `10 + 5×60 = 310 s` |
| `initialDelaySeconds` | 10 (unchanged) | 10 (unchanged) |
| `periodSeconds` | 5 (unchanged) | 5 (unchanged) |

This prevents secondary liveness-kill cascades that occur when Jellyfin's media-scan startup exceeds the old threshold.

### Fix 2 — Renovate schedule (`.github/renovate.json5`)

Adds a `jellyfin` package rule that restricts upgrades to **Monday 02:00–06:00** (America/New_York, inherited from root config). Renovate will only open Jellyfin update PRs during that window, ensuring automerge-triggered restarts never happen during peak viewing hours.

## SLA Impact

Target: 98% → >99% availability. Fewer unexpected kills during startup and zero peak-hour upgrade restarts are the two highest-leverage levers available without changing the deployment strategy.

## Test Plan

- [ ] `task k8s:validate` passes (confirmed locally)
- [ ] `task renovate:validate` passes (confirmed locally — "Config validated successfully")
- [ ] After merge, verify Flux reconciles the live Jellyfin HelmRelease and the pod restarts cleanly within 310 s
- [ ] Confirm next Renovate run does not open a Jellyfin PR outside the Mon 02:00–06:00 window