### PR TITLE
feat(k8s): deploy external-dns with Cloudflare Gateway API provider

### DIFF
--- a/kubernetes/platform/charts/external-dns.yaml
+++ b/kubernetes/platform/charts/external-dns.yaml
@@ -1,0 +1,47 @@
+---
+# https://github.com/kubernetes-sigs/external-dns/blob/master/charts/external-dns/values.yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kubernetes-sigs/external-dns/master/charts/external-dns/values.schema.json
+provider:
+  name: cloudflare
+
+sources:
+  - gateway-httproute
+  - gateway
+
+domainFilters:
+  - ${external_domain}
+
+policy: sync
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  fsGroup: 65534
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65534
+  seccompProfile:
+    type: RuntimeDefault
+
+env:
+  - name: CF_API_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: cloudflare-api-token
+        key: token
+
+serviceMonitor:
+  enabled: true
+  interval: 1m
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 64Mi

--- a/kubernetes/platform/config.yaml
+++ b/kubernetes/platform/config.yaml
@@ -94,6 +94,10 @@ spec:
       namespace: ""
       path: kubernetes/platform/config/infrastructure-policies
       dependsOn: [cilium]
+    - name: external-dns-config
+      namespace: external-dns
+      path: kubernetes/platform/config/external-dns
+      dependsOn: [external-dns, external-secrets-stores]
   resourcesTemplate: |
     ---
     apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/kubernetes/platform/config/external-dns/external-secret.yaml
+++ b/kubernetes/platform/config/external-dns/external-secret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-api-token
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: cloudflare-api-token
+  data:
+    - secretKey: token
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/cloudflare-api-token
+        property: token

--- a/kubernetes/platform/config/external-dns/kustomization.yaml
+++ b/kubernetes/platform/config/external-dns/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secret.yaml

--- a/kubernetes/platform/helm-charts.yaml
+++ b/kubernetes/platform/helm-charts.yaml
@@ -266,6 +266,13 @@ spec:
         version: "${x509_certificate_exporter_version}"
         url: https://charts.enix.io
       dependsOn: [kube-prometheus-stack]
+    - name: external-dns
+      namespace: external-dns
+      chart:
+        name: external-dns
+        version: "${external_dns_version}"
+        url: https://kubernetes-sigs.github.io/external-dns/
+      dependsOn: [external-secrets, kube-prometheus-stack-crds]
   resourcesTemplate: |
     ---
     apiVersion: source.toolkit.fluxcd.io/v1

--- a/kubernetes/platform/kustomization.yaml
+++ b/kubernetes/platform/kustomization.yaml
@@ -18,6 +18,7 @@ configMapGenerator:
       - cloudnative-pg.yaml=charts/cloudnative-pg.yaml
       - dragonfly-operator.yaml=charts/dragonfly-operator.yaml
       - descheduler.yaml=charts/descheduler.yaml
+      - external-dns.yaml=charts/external-dns.yaml
       - external-secrets.yaml=charts/external-secrets.yaml
       - garage-operator.yaml=charts/garage-operator.yaml
       - grafana-loki-single-binary.yaml=charts/grafana-loki-single-binary.yaml

--- a/kubernetes/platform/namespaces.yaml
+++ b/kubernetes/platform/namespaces.yaml
@@ -38,6 +38,13 @@ spec:
       dataplane: ambient
       security: restricted
       networkPolicy: false
+    - name: external-dns
+      dataplane: ambient
+      security: restricted
+      networkPolicy:
+        profile: internal-egress
+        enforcement: ""
+      kubeApiAccess: true
     - name: oauth2-proxy
       dataplane: ambient
       security: restricted

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -72,6 +72,8 @@ prometheus_ipmi_exporter_version=0.8.0
 prometheus_smartctl_exporter_version=0.16.1
 # renovate: datasource=helm depName=oauth2-proxy registryUrl=https://oauth2-proxy.github.io/manifests
 oauth2_proxy_version=10.1.3
+# renovate: datasource=helm depName=external-dns registryUrl=https://kubernetes-sigs.github.io/external-dns/
+external_dns_version=1.21.1
 
 # CSI Snapshot Controller
 # renovate: datasource=helm depName=snapshot-controller registryUrl=https://piraeus.io/helm-charts


### PR DESCRIPTION
## Summary

- Deploys `external-dns` v1.21.1 as a platform service that automatically creates/updates/deletes Cloudflare DNS records for the external domain
- Sources: `gateway` and `gateway-httproute` — watches Gateway API resources to detect hostnames
- Policy: `sync` — creates and removes records to match live state
- Reuses the existing Cloudflare API token from AWS SSM via a new ExternalSecret in the `external-dns` namespace (same SSM path as cert-manager)

## Architecture decisions

- **Namespace security**: `restricted` (matches other platform controllers) with `internal-egress` network policy profile for Cloudflare API HTTPS egress, plus `kube-api` access label for watching Gateway/HTTPRoute resources
- **Secret**: Separate ExternalSecret in `external-dns` namespace — secrets cannot cross namespaces; the cert-manager one is scoped to `cert-manager`
- **Dependency**: `external-dns` HelmRelease depends on `external-secrets` (ClusterSecretStore must exist before ExternalSecret can sync) and `kube-prometheus-stack-crds` (ServiceMonitor CRD)
- **Config kustomization** (`external-dns-config`) depends on both `external-dns` (HelmRelease) and `external-secrets-stores` (ClusterSecretStore)

## Test plan

- [ ] Confirm Flux reconciles `platform-resources` ResourceSet with `external-dns` entry
- [ ] Confirm `external-dns` HelmRelease reaches `Ready: True` in `external-dns` namespace
- [ ] Confirm ExternalSecret `cloudflare-api-token` syncs successfully in `external-dns` namespace
- [ ] Deploy a test HTTPRoute with an `${external_domain}` hostname and verify DNS record is created in Cloudflare
- [ ] Remove the test HTTPRoute and verify DNS record is deleted (sync policy)
- [ ] Confirm ServiceMonitor is scraped by Prometheus