### PR TITLE
fix(external-dns): add namespace to ExternalSecret

### DIFF
--- a/kubernetes/clusters/live/config/external-dns/external-secret.yaml
+++ b/kubernetes/clusters/live/config/external-dns/external-secret.yaml
@@ -4,6 +4,7 @@ apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: cloudflare-api-token
+  namespace: external-dns
 spec:
   refreshInterval: 24h
   secretStoreRef:


### PR DESCRIPTION
## Summary
- Adds missing `namespace: external-dns` to the ExternalSecret metadata
- Without it, Flux `cluster-config` Kustomization fails with "namespace not specified" and the secret never gets created, causing the pod to crash with `secret "cloudflare-api-token" not found`

## Root Cause
Platform-layer ExternalSecrets inherit namespace from the Kustomization's `namespace: flux-system` default. Cluster `config/` Kustomizations have no default namespace — resources must declare their own.

## Test plan
- [ ] `cluster-config` Kustomization reconciles successfully
- [ ] ExternalSecret `cloudflare-api-token` appears in `external-dns` namespace
- [ ] Pod reaches `Running` state
- [ ] external-dns logs show Cloudflare sync activity