### PR TITLE
fix(external-dns): remove invalid 'gateway' source

### DIFF
--- a/kubernetes/clusters/live/charts/external-dns.yaml
+++ b/kubernetes/clusters/live/charts/external-dns.yaml
@@ -6,7 +6,6 @@ provider:
 
 sources:
   - gateway-httproute
-  - gateway
 
 domainFilters:
   - ${external_domain}


### PR DESCRIPTION
## Summary
- Removes `gateway` from `sources` — not a valid external-dns source type
- Pod crashlooping: `enum value must be one of ..., got 'gateway'`
- Only `gateway-httproute` needed for this setup

## Test plan
- [ ] Pod reaches `Running` state
- [ ] external-dns logs show Cloudflare sync