### PR TITLE
feat(external-dns): route public IP via SSM + --default-targets

### DIFF
--- a/kubernetes/clusters/live/charts/external-dns.yaml
+++ b/kubernetes/clusters/live/charts/external-dns.yaml
@@ -35,6 +35,14 @@ env:
       secretKeyRef:
         name: cloudflare-api-token
         key: token
+  - name: PUBLIC_IP
+    valueFrom:
+      secretKeyRef:
+        name: cluster-public-ip
+        key: ip
+
+extraArgs:
+  - --default-targets=$(PUBLIC_IP)
 
 serviceMonitor:
   enabled: true

--- a/kubernetes/clusters/live/charts/external-dns.yaml
+++ b/kubernetes/clusters/live/charts/external-dns.yaml
@@ -6,7 +6,6 @@ provider:
 
 sources:
   - gateway-httproute
-  - gateway
 
 domainFilters:
   - ${external_domain}

--- a/kubernetes/clusters/live/config/external-dns/external-secret.yaml
+++ b/kubernetes/clusters/live/config/external-dns/external-secret.yaml
@@ -17,3 +17,22 @@ spec:
       remoteRef:
         key: /homelab/kubernetes/${cluster_name}/cloudflare-api-token
         property: token
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cluster-public-ip
+  namespace: external-dns
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: cluster-public-ip
+  data:
+    - secretKey: ip
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/public-ip
+        property: ip


### PR DESCRIPTION
## Summary

- Adds `ExternalSecret` (`cluster-public-ip`) that pulls the cluster's public IP from AWS SSM parameter `/homelab/kubernetes/${cluster_name}/public-ip`
- Injects the IP as `PUBLIC_IP` env var into the external-dns pod
- Passes `--default-targets=$(PUBLIC_IP)` via `extraArgs` so Cloudflare DNS records point at the public IP instead of the internal Gateway address (`192.168.10.23`)

## Prerequisites

Before merging, add the SSM parameter manually:
```
/homelab/kubernetes/live/public-ip  →  { "ip": "<your-public-ip>" }
```

## Test plan

- [ ] `ExternalSecret` `cluster-public-ip` in `external-dns` namespace shows `SecretSynced: True`
- [ ] external-dns pod restarts and reaches `Running`
- [ ] `kubectl logs -n external-dns` shows records updated with public IP (not `192.168.10.23`)
- [ ] `dig photos.ionfury.tv` returns public IP