### PR TITLE
feat(unifi): add gateway routes for Unifi Network and Protect

### DIFF
--- a/kubernetes/platform/config.yaml
+++ b/kubernetes/platform/config.yaml
@@ -94,6 +94,10 @@ spec:
       namespace: ""
       path: kubernetes/platform/config/infrastructure-policies
       dependsOn: [cilium]
+    - name: unifi-config
+      namespace: unifi
+      path: kubernetes/platform/config/unifi
+      dependsOn: [istiod]
   resourcesTemplate: |
     ---
     apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/kubernetes/platform/config/unifi/kustomization.yaml
+++ b/kubernetes/platform/config/unifi/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - unifi-network.yaml
+  - unifi-protect.yaml

--- a/kubernetes/platform/config/unifi/unifi-network.yaml
+++ b/kubernetes/platform/config/unifi/unifi-network.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: unifi-network
+spec:
+  ports:
+    - name: https
+      port: 443
+      targetPort: 443
+      protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: unifi-network
+subsets:
+  - addresses:
+      - ip: 192.168.1.1
+    ports:
+      - name: https
+        port: 443
+        protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/networking.istio.io/destinationrule_v1.json
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: unifi-network
+spec:
+  host: unifi-network.unifi.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      insecureSkipVerify: true
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: unifi-network
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "UniFi Network"
+    gethomepage.dev/group: "Infrastructure"
+    gethomepage.dev/icon: "unifi.svg"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: istio-gateway
+  hostnames:
+    - "network.${internal_domain}"
+  rules:
+    - backendRefs:
+        - name: unifi-network
+          port: 443

--- a/kubernetes/platform/config/unifi/unifi-protect.yaml
+++ b/kubernetes/platform/config/unifi/unifi-protect.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: unifi-protect
+spec:
+  ports:
+    - name: https
+      port: 443
+      targetPort: 443
+      protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: unifi-protect
+subsets:
+  - addresses:
+      - ip: 192.168.1.40
+    ports:
+      - name: https
+        port: 443
+        protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/networking.istio.io/destinationrule_v1.json
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: unifi-protect
+spec:
+  host: unifi-protect.unifi.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      insecureSkipVerify: true
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: unifi-protect
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "UniFi Protect"
+    gethomepage.dev/group: "Infrastructure"
+    gethomepage.dev/icon: "unifi.svg"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: istio-gateway
+  hostnames:
+    - "protect.${internal_domain}"
+  rules:
+    - backendRefs:
+        - name: unifi-protect
+          port: 443

--- a/kubernetes/platform/namespaces.yaml
+++ b/kubernetes/platform/namespaces.yaml
@@ -57,6 +57,10 @@ spec:
       dataplane: ambient
       security: restricted
       networkPolicy: false
+    - name: unifi
+      dataplane: ambient
+      security: restricted
+      networkPolicy: false
     # --- baseline: require some elevated capabilities (e.g. NET_BIND_SERVICE) ---
     - name: istio-gateway
       dataplane: ambient


### PR DESCRIPTION
## Summary

- Add `kubernetes/platform/config/unifi/` with Service, Endpoints, DestinationRule, and HTTPRoute for Unifi Network (192.168.1.1) and Unifi Protect (192.168.1.40)
- Add `unifi` namespace to `namespaces.yaml` (restricted security, ambient dataplane, no pods)
- Add `unifi-config` Kustomization entry to `config.yaml` (dependsOn `istiod` for DestinationRule CRD)

**Routes:**
- `network.${internal_domain}` → `192.168.1.1:443`
- `protect.${internal_domain}` → `192.168.1.40:443`

**How it works:**
The internal gateway terminates TLS using the existing wildcard cert. Service+Endpoints objects give HTTPRoute a cluster-DNS name to reference. The DestinationRule (`mode: SIMPLE`, `insecureSkipVerify: true`) tells Istio to re-encrypt toward the backend using TLS origination, accepting the Unifi self-signed cert. The istio-gateway CNP already permits egress to `world:443` so no network policy changes are needed.

## Test plan

- [ ] Verify `unifi` namespace created and Flux reconciles `unifi-config` Kustomization
- [ ] Confirm HTTPRoutes accepted by internal gateway (`kubectl get httproute -n unifi`)
- [ ] Resolve `network.<internal_domain>` and `protect.<internal_domain>` — expect Unifi UI to load over HTTPS with valid cert