### PR TITLE
feat(storage): Longhorn overprovisioning + slow-media SC + monitoring

### DIFF
--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -1,30 +1,35 @@
 ---
 # https://raw.githubusercontent.com/longhorn/charts/master/charts/longhorn/values.yaml
 longhornManager:
-  priorityClass: infrastructure-critical
+  priorityClass: longhorn-critical
 longhornDriver:
-  priorityClass: infrastructure-critical
+  priorityClass: longhorn-critical
 longhornUI:
-  priorityClass: infrastructure-critical
+  priorityClass: longhorn-critical
 longhornAdmissionWebhook:
-  priorityClass: infrastructure-critical
+  priorityClass: longhorn-critical
 longhornRecoveryBackend:
-  priorityClass: infrastructure-critical
+  priorityClass: longhorn-critical
 longhornConversionWebhook:
-  priorityClass: infrastructure-critical
+  priorityClass: longhorn-critical
 persistence:
   defaultFsType: xfs
   defaultClassReplicaCount: ${default_replica_count}
 defaultSettings:
   defaultReplicaCount: ${default_replica_count}
   replicaAutoBalance: best-effort
+  replicaAutoBalanceDiskPressurePercentage: 85
+  replicaSoftAntiAffinity: false
   createDefaultDiskLabeledNodes: true
   storageReservedPercentageForDefaultDisk: 10
   nodeDownPodDeletionPolicy: delete-both-statefulset-and-deployment-pod
-  storageOverProvisioningPercentage: 500
+  storageOverProvisioningPercentage: 700
   storageMinimalAvailablePercentage: 10
   autoCleanupSystemGeneratedSnapshot: true
   snapshotMaxCount: 3
+  concurrentReplicaRebuildPerNodeLimit: 2
+  engineReplicaTimeout: 15
+  priorityClass: longhorn-critical
 csi:
   attacherReplicaCount: ${default_replica_count}
   provisionerReplicaCount: ${default_replica_count}

--- a/kubernetes/platform/config/longhorn/kustomization.yaml
+++ b/kubernetes/platform/config/longhorn/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - storage-classes/fast-ephemeral.yaml
   - storage-classes/fast.yaml
   - storage-classes/slow.yaml
+  - storage-classes/slow-media.yaml

--- a/kubernetes/platform/config/longhorn/prometheus-rules.yaml
+++ b/kubernetes/platform/config/longhorn/prometheus-rules.yaml
@@ -195,3 +195,52 @@ spec:
               The {{ $labels.pool }} storage pool is at {{ $value | humanizePercentage }} capacity.
               New volume scheduling may fail. Immediate action required: expand disks,
               delete unused volumes, or migrate workloads.
+
+    - name: longhorn-media-library-alerts
+      rules:
+        - alert: LonghornShareManagerMemoryHigh
+          expr: container_memory_working_set_bytes{pod=~"share-manager-.*"} > 4294967296
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Longhorn share-manager {{ $labels.pod }} memory > 4 GiB"
+            description: >-
+              Share-manager pod {{ $labels.pod }} working set is {{ $value | humanize1024 }}B.
+              This may indicate the share-manager memory leak (issue #8523). Check pod age and
+              consider restarting if persistent.
+
+        - alert: LonghornDiskUsageHigh
+          expr: max by (disk, node) (longhorn_disk_usage_bytes / longhorn_disk_capacity_bytes) > 0.75
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Longhorn disk {{ $labels.disk }} on {{ $labels.node }} usage > 75%"
+            description: >-
+              Disk {{ $labels.disk }} on node {{ $labels.node }} is at
+              {{ $value | humanizePercentage }} capacity. Procure next disk trio before reaching 85%.
+
+        - alert: LonghornMediaVolumeRobustnessDegraded
+          expr: max by (volume, pvc_namespace) (longhorn_volume_robustness{volume=~"media-library.*"}) != 1
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Longhorn media volume {{ $labels.volume }} is not healthy"
+            description: >-
+              Media volume {{ $labels.volume }} has been in a non-healthy robustness state for 30
+              minutes. Robustness value {{ $value }} (1=Healthy, 2=Degraded, 3=Faulted).
+              Replica loss on media volumes requires immediate attention.
+
+        - alert: LonghornVolumeSchedulingFailed
+          expr: longhorn_volume_condition{condition="Scheduled", status="False"} > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} cannot be scheduled"
+            description: >-
+              Volume {{ $labels.volume }} has an unmet scheduling condition. This usually means
+              insufficient disk space on tagged disks. Check storageOverProvisioningPercentage
+              and available disk capacity.

--- a/kubernetes/platform/config/longhorn/storage-classes/slow-media.yaml
+++ b/kubernetes/platform/config/longhorn/storage-classes/slow-media.yaml
@@ -1,0 +1,17 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: slow-media
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "3"
+  fsType: xfs
+  staleReplicaTimeout: "30"
+  dataLocality: disabled
+  diskSelector: slow
+  recurringJobSelector: '[{"name": "filesystem-trim-daily", "isGroup": true}]'
+  nfsOptions: "soft,timeo=600,retrans=5"

--- a/kubernetes/platform/config/priority-classes/priority-classes.yaml
+++ b/kubernetes/platform/config/priority-classes/priority-classes.yaml
@@ -3,6 +3,19 @@
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
+  name: longhorn-critical
+value: 1000000000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: >-
+  Longhorn data-plane components: share-manager and instance-manager pods.
+  These hold open NFS mounts for all RWX consumers and must not be preempted
+  under any memory or resource pressure in the cluster.
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/scheduling.k8s.io/priorityclass_v1.json
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
   name: infrastructure-critical
 value: 1000000
 preemptionPolicy: PreemptLowerPriority


### PR DESCRIPTION
## Summary

- Raise `storageOverProvisioningPercentage` to 700% — enables 10×10TiB sparse PVCs to schedule on existing 20TB disks (math: 110TiB scheduled / 16.4TiB schedulable = 671%, 700% adds headroom)
- Add `replicaAutoBalanceDiskPressurePercentage: 85` — triggers disk-level replica rebalance when a disk exceeds 85% fill
- Add `longhorn-critical` PriorityClass (value=1,000,000,000) for Longhorn data-plane; update all Longhorn component `priorityClass` from `infrastructure-critical` to `longhorn-critical`
- Add `slow-media` StorageClass — clone of `slow` with `dataLocality: disabled` (RWX/NFS, locality is meaningless) and no `snapshot-frequent` recurring job
- Add 4 new Prometheus alert rules: `LonghornShareManagerMemoryHigh`, `LonghornDiskUsageHigh`, `LonghornMediaVolumeRobustnessDegraded`, `LonghornVolumeSchedulingFailed`

## PR sequence

**This is PR 1/5.** Merge order matters:
1. **PR-1 (this)** — platform prep, zero app impact
2. PR-2 — 10×10TiB PVCs
3. PR-3 — reconciler CronJob (dry-run)
4. PR-4 — app chart persistence updates
5. PR-5 — reconciler enforce mode (~1 week after PR-3)

## Test plan

- [ ] `task k8s:validate` passes (run locally or wait for CI)
- [ ] `task k8s:dry-run-dev` — server-side dry-run against dev cluster
- [ ] Dev smoke test: create 3×1TiB PVCs on `slow-media`-equivalent SC, verify they bind
- [ ] Confirm `longhorn-critical` PriorityClass appears in cluster after merge
- [ ] Confirm no existing `slow` SC PVCs are disrupted