### PR TITLE
feat(media): pre-template 10×10TiB media-library PVCs on slow-media SC

### DIFF
--- a/kubernetes/clusters/live/config/media-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - media-library-pvc.yaml
+  - media-library-pvcs.yaml
   - sabnzbd-downloads-pvc.yaml
   - qbittorrent-downloads-pvc.yaml
   - secrets.yaml

--- a/kubernetes/clusters/live/config/media-prereqs/media-library-pvcs.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/media-library-pvcs.yaml
@@ -1,0 +1,150 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: media-library-01
+  namespace: media
+  labels:
+    velero.io/exclude-from-backup: "true"
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: slow-media
+  resources:
+    requests:
+      storage: 10Ti
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: media-library-02
+  namespace: media
+  labels:
+    velero.io/exclude-from-backup: "true"
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: slow-media
+  resources:
+    requests:
+      storage: 10Ti
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: media-library-03
+  namespace: media
+  labels:
+    velero.io/exclude-from-backup: "true"
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: slow-media
+  resources:
+    requests:
+      storage: 10Ti
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: media-library-04
+  namespace: media
+  labels:
+    velero.io/exclude-from-backup: "true"
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: slow-media
+  resources:
+    requests:
+      storage: 10Ti
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: media-library-05
+  namespace: media
+  labels:
+    velero.io/exclude-from-backup: "true"
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: slow-media
+  resources:
+    requests:
+      storage: 10Ti
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: media-library-06
+  namespace: media
+  labels:
+    velero.io/exclude-from-backup: "true"
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: slow-media
+  resources:
+    requests:
+      storage: 10Ti
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: media-library-07
+  namespace: media
+  labels:
+    velero.io/exclude-from-backup: "true"
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: slow-media
+  resources:
+    requests:
+      storage: 10Ti
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: media-library-08
+  namespace: media
+  labels:
+    velero.io/exclude-from-backup: "true"
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: slow-media
+  resources:
+    requests:
+      storage: 10Ti
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: media-library-09
+  namespace: media
+  labels:
+    velero.io/exclude-from-backup: "true"
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: slow-media
+  resources:
+    requests:
+      storage: 10Ti
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: media-library-10
+  namespace: media
+  labels:
+    velero.io/exclude-from-backup: "true"
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: slow-media
+  resources:
+    requests:
+      storage: 10Ti


### PR DESCRIPTION
## Summary

- Creates `media-library-01` through `media-library-10` — 10 PVCs, each 10TiB RWX on `slow-media` StorageClass
- All marked `velero.io/exclude-from-backup: "true"` (bulk media, not backup candidates)
- Existing `media-library` PVC (disk-00) is **untouched** — existing content preserved

## PR sequence

**This is PR 2/5.** Merge after PR-1 (`slow-media` SC must exist first).

1. PR-1 — platform prep ✓
2. **PR-2 (this)** — 10×10TiB PVCs
3. PR-3 — reconciler CronJob (dry-run)
4. PR-4 — app chart persistence updates
5. PR-5 — reconciler enforce mode

## Test plan

- [ ] `task k8s:validate` passes
- [ ] After merge: `kubectl get pvc -n media | grep media-library` shows all 11 PVCs `Bound`
- [ ] Confirm Longhorn UI shows all 10 new volumes scheduled on slow disks
- [ ] Confirm no Longhorn scheduling errors (`LonghornVolumeSchedulingFailed` not firing)