### PR TITLE
feat(media): mount all 11 media disks in consumer app pods

### DIFF
--- a/kubernetes/clusters/live/charts/bazarr.yaml
+++ b/kubernetes/clusters/live/charts/bazarr.yaml
@@ -144,7 +144,77 @@ persistence:
     advancedMounts:
       bazarr:
         app:
-          - path: /media/library
+          - path: /media/library/disk-00
+  media-library-01:
+    type: persistentVolumeClaim
+    existingClaim: media-library-01
+    advancedMounts:
+      bazarr:
+        app:
+          - path: /media/library/disk-01
+  media-library-02:
+    type: persistentVolumeClaim
+    existingClaim: media-library-02
+    advancedMounts:
+      bazarr:
+        app:
+          - path: /media/library/disk-02
+  media-library-03:
+    type: persistentVolumeClaim
+    existingClaim: media-library-03
+    advancedMounts:
+      bazarr:
+        app:
+          - path: /media/library/disk-03
+  media-library-04:
+    type: persistentVolumeClaim
+    existingClaim: media-library-04
+    advancedMounts:
+      bazarr:
+        app:
+          - path: /media/library/disk-04
+  media-library-05:
+    type: persistentVolumeClaim
+    existingClaim: media-library-05
+    advancedMounts:
+      bazarr:
+        app:
+          - path: /media/library/disk-05
+  media-library-06:
+    type: persistentVolumeClaim
+    existingClaim: media-library-06
+    advancedMounts:
+      bazarr:
+        app:
+          - path: /media/library/disk-06
+  media-library-07:
+    type: persistentVolumeClaim
+    existingClaim: media-library-07
+    advancedMounts:
+      bazarr:
+        app:
+          - path: /media/library/disk-07
+  media-library-08:
+    type: persistentVolumeClaim
+    existingClaim: media-library-08
+    advancedMounts:
+      bazarr:
+        app:
+          - path: /media/library/disk-08
+  media-library-09:
+    type: persistentVolumeClaim
+    existingClaim: media-library-09
+    advancedMounts:
+      bazarr:
+        app:
+          - path: /media/library/disk-09
+  media-library-10:
+    type: persistentVolumeClaim
+    existingClaim: media-library-10
+    advancedMounts:
+      bazarr:
+        app:
+          - path: /media/library/disk-10
   tmp:
     type: emptyDir
     advancedMounts:

--- a/kubernetes/clusters/live/charts/jellyfin.yaml
+++ b/kubernetes/clusters/live/charts/jellyfin.yaml
@@ -23,6 +23,8 @@ controllers:
         image:
           repository: jellyfin/jellyfin
           tag: "${jellyfin_version}"
+        env:
+          ParallelLibraryScanLimit: "3"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
@@ -123,4 +125,74 @@ persistence:
     advancedMounts:
       jellyfin:
         app:
-          - path: /media/library
+          - path: /media/library/disk-00
+  media-library-01:
+    type: persistentVolumeClaim
+    existingClaim: media-library-01
+    advancedMounts:
+      jellyfin:
+        app:
+          - path: /media/library/disk-01
+  media-library-02:
+    type: persistentVolumeClaim
+    existingClaim: media-library-02
+    advancedMounts:
+      jellyfin:
+        app:
+          - path: /media/library/disk-02
+  media-library-03:
+    type: persistentVolumeClaim
+    existingClaim: media-library-03
+    advancedMounts:
+      jellyfin:
+        app:
+          - path: /media/library/disk-03
+  media-library-04:
+    type: persistentVolumeClaim
+    existingClaim: media-library-04
+    advancedMounts:
+      jellyfin:
+        app:
+          - path: /media/library/disk-04
+  media-library-05:
+    type: persistentVolumeClaim
+    existingClaim: media-library-05
+    advancedMounts:
+      jellyfin:
+        app:
+          - path: /media/library/disk-05
+  media-library-06:
+    type: persistentVolumeClaim
+    existingClaim: media-library-06
+    advancedMounts:
+      jellyfin:
+        app:
+          - path: /media/library/disk-06
+  media-library-07:
+    type: persistentVolumeClaim
+    existingClaim: media-library-07
+    advancedMounts:
+      jellyfin:
+        app:
+          - path: /media/library/disk-07
+  media-library-08:
+    type: persistentVolumeClaim
+    existingClaim: media-library-08
+    advancedMounts:
+      jellyfin:
+        app:
+          - path: /media/library/disk-08
+  media-library-09:
+    type: persistentVolumeClaim
+    existingClaim: media-library-09
+    advancedMounts:
+      jellyfin:
+        app:
+          - path: /media/library/disk-09
+  media-library-10:
+    type: persistentVolumeClaim
+    existingClaim: media-library-10
+    advancedMounts:
+      jellyfin:
+        app:
+          - path: /media/library/disk-10

--- a/kubernetes/clusters/live/charts/radarr.yaml
+++ b/kubernetes/clusters/live/charts/radarr.yaml
@@ -143,4 +143,74 @@ persistence:
     advancedMounts:
       radarr:
         app:
-          - path: /media/library
+          - path: /media/library/disk-00
+  media-library-01:
+    type: persistentVolumeClaim
+    existingClaim: media-library-01
+    advancedMounts:
+      radarr:
+        app:
+          - path: /media/library/disk-01
+  media-library-02:
+    type: persistentVolumeClaim
+    existingClaim: media-library-02
+    advancedMounts:
+      radarr:
+        app:
+          - path: /media/library/disk-02
+  media-library-03:
+    type: persistentVolumeClaim
+    existingClaim: media-library-03
+    advancedMounts:
+      radarr:
+        app:
+          - path: /media/library/disk-03
+  media-library-04:
+    type: persistentVolumeClaim
+    existingClaim: media-library-04
+    advancedMounts:
+      radarr:
+        app:
+          - path: /media/library/disk-04
+  media-library-05:
+    type: persistentVolumeClaim
+    existingClaim: media-library-05
+    advancedMounts:
+      radarr:
+        app:
+          - path: /media/library/disk-05
+  media-library-06:
+    type: persistentVolumeClaim
+    existingClaim: media-library-06
+    advancedMounts:
+      radarr:
+        app:
+          - path: /media/library/disk-06
+  media-library-07:
+    type: persistentVolumeClaim
+    existingClaim: media-library-07
+    advancedMounts:
+      radarr:
+        app:
+          - path: /media/library/disk-07
+  media-library-08:
+    type: persistentVolumeClaim
+    existingClaim: media-library-08
+    advancedMounts:
+      radarr:
+        app:
+          - path: /media/library/disk-08
+  media-library-09:
+    type: persistentVolumeClaim
+    existingClaim: media-library-09
+    advancedMounts:
+      radarr:
+        app:
+          - path: /media/library/disk-09
+  media-library-10:
+    type: persistentVolumeClaim
+    existingClaim: media-library-10
+    advancedMounts:
+      radarr:
+        app:
+          - path: /media/library/disk-10

--- a/kubernetes/clusters/live/charts/radarr4k.yaml
+++ b/kubernetes/clusters/live/charts/radarr4k.yaml
@@ -143,4 +143,74 @@ persistence:
     advancedMounts:
       radarr4k:
         app:
-          - path: /media/library
+          - path: /media/library/disk-00
+  media-library-01:
+    type: persistentVolumeClaim
+    existingClaim: media-library-01
+    advancedMounts:
+      radarr4k:
+        app:
+          - path: /media/library/disk-01
+  media-library-02:
+    type: persistentVolumeClaim
+    existingClaim: media-library-02
+    advancedMounts:
+      radarr4k:
+        app:
+          - path: /media/library/disk-02
+  media-library-03:
+    type: persistentVolumeClaim
+    existingClaim: media-library-03
+    advancedMounts:
+      radarr4k:
+        app:
+          - path: /media/library/disk-03
+  media-library-04:
+    type: persistentVolumeClaim
+    existingClaim: media-library-04
+    advancedMounts:
+      radarr4k:
+        app:
+          - path: /media/library/disk-04
+  media-library-05:
+    type: persistentVolumeClaim
+    existingClaim: media-library-05
+    advancedMounts:
+      radarr4k:
+        app:
+          - path: /media/library/disk-05
+  media-library-06:
+    type: persistentVolumeClaim
+    existingClaim: media-library-06
+    advancedMounts:
+      radarr4k:
+        app:
+          - path: /media/library/disk-06
+  media-library-07:
+    type: persistentVolumeClaim
+    existingClaim: media-library-07
+    advancedMounts:
+      radarr4k:
+        app:
+          - path: /media/library/disk-07
+  media-library-08:
+    type: persistentVolumeClaim
+    existingClaim: media-library-08
+    advancedMounts:
+      radarr4k:
+        app:
+          - path: /media/library/disk-08
+  media-library-09:
+    type: persistentVolumeClaim
+    existingClaim: media-library-09
+    advancedMounts:
+      radarr4k:
+        app:
+          - path: /media/library/disk-09
+  media-library-10:
+    type: persistentVolumeClaim
+    existingClaim: media-library-10
+    advancedMounts:
+      radarr4k:
+        app:
+          - path: /media/library/disk-10

--- a/kubernetes/clusters/live/charts/sonarr.yaml
+++ b/kubernetes/clusters/live/charts/sonarr.yaml
@@ -143,4 +143,74 @@ persistence:
     advancedMounts:
       sonarr:
         app:
-          - path: /media/library
+          - path: /media/library/disk-00
+  media-library-01:
+    type: persistentVolumeClaim
+    existingClaim: media-library-01
+    advancedMounts:
+      sonarr:
+        app:
+          - path: /media/library/disk-01
+  media-library-02:
+    type: persistentVolumeClaim
+    existingClaim: media-library-02
+    advancedMounts:
+      sonarr:
+        app:
+          - path: /media/library/disk-02
+  media-library-03:
+    type: persistentVolumeClaim
+    existingClaim: media-library-03
+    advancedMounts:
+      sonarr:
+        app:
+          - path: /media/library/disk-03
+  media-library-04:
+    type: persistentVolumeClaim
+    existingClaim: media-library-04
+    advancedMounts:
+      sonarr:
+        app:
+          - path: /media/library/disk-04
+  media-library-05:
+    type: persistentVolumeClaim
+    existingClaim: media-library-05
+    advancedMounts:
+      sonarr:
+        app:
+          - path: /media/library/disk-05
+  media-library-06:
+    type: persistentVolumeClaim
+    existingClaim: media-library-06
+    advancedMounts:
+      sonarr:
+        app:
+          - path: /media/library/disk-06
+  media-library-07:
+    type: persistentVolumeClaim
+    existingClaim: media-library-07
+    advancedMounts:
+      sonarr:
+        app:
+          - path: /media/library/disk-07
+  media-library-08:
+    type: persistentVolumeClaim
+    existingClaim: media-library-08
+    advancedMounts:
+      sonarr:
+        app:
+          - path: /media/library/disk-08
+  media-library-09:
+    type: persistentVolumeClaim
+    existingClaim: media-library-09
+    advancedMounts:
+      sonarr:
+        app:
+          - path: /media/library/disk-09
+  media-library-10:
+    type: persistentVolumeClaim
+    existingClaim: media-library-10
+    advancedMounts:
+      sonarr:
+        app:
+          - path: /media/library/disk-10

--- a/kubernetes/clusters/live/charts/sonarr4k.yaml
+++ b/kubernetes/clusters/live/charts/sonarr4k.yaml
@@ -143,4 +143,74 @@ persistence:
     advancedMounts:
       sonarr4k:
         app:
-          - path: /media/library
+          - path: /media/library/disk-00
+  media-library-01:
+    type: persistentVolumeClaim
+    existingClaim: media-library-01
+    advancedMounts:
+      sonarr4k:
+        app:
+          - path: /media/library/disk-01
+  media-library-02:
+    type: persistentVolumeClaim
+    existingClaim: media-library-02
+    advancedMounts:
+      sonarr4k:
+        app:
+          - path: /media/library/disk-02
+  media-library-03:
+    type: persistentVolumeClaim
+    existingClaim: media-library-03
+    advancedMounts:
+      sonarr4k:
+        app:
+          - path: /media/library/disk-03
+  media-library-04:
+    type: persistentVolumeClaim
+    existingClaim: media-library-04
+    advancedMounts:
+      sonarr4k:
+        app:
+          - path: /media/library/disk-04
+  media-library-05:
+    type: persistentVolumeClaim
+    existingClaim: media-library-05
+    advancedMounts:
+      sonarr4k:
+        app:
+          - path: /media/library/disk-05
+  media-library-06:
+    type: persistentVolumeClaim
+    existingClaim: media-library-06
+    advancedMounts:
+      sonarr4k:
+        app:
+          - path: /media/library/disk-06
+  media-library-07:
+    type: persistentVolumeClaim
+    existingClaim: media-library-07
+    advancedMounts:
+      sonarr4k:
+        app:
+          - path: /media/library/disk-07
+  media-library-08:
+    type: persistentVolumeClaim
+    existingClaim: media-library-08
+    advancedMounts:
+      sonarr4k:
+        app:
+          - path: /media/library/disk-08
+  media-library-09:
+    type: persistentVolumeClaim
+    existingClaim: media-library-09
+    advancedMounts:
+      sonarr4k:
+        app:
+          - path: /media/library/disk-09
+  media-library-10:
+    type: persistentVolumeClaim
+    existingClaim: media-library-10
+    advancedMounts:
+      sonarr4k:
+        app:
+          - path: /media/library/disk-10

--- a/kubernetes/clusters/live/charts/tdarr-node.yaml
+++ b/kubernetes/clusters/live/charts/tdarr-node.yaml
@@ -73,7 +73,77 @@ persistence:
     advancedMounts:
       tdarr-node:
         app:
-          - path: /media/library
+          - path: /media/library/disk-00
+  media-library-01:
+    type: persistentVolumeClaim
+    existingClaim: media-library-01
+    advancedMounts:
+      tdarr-node:
+        app:
+          - path: /media/library/disk-01
+  media-library-02:
+    type: persistentVolumeClaim
+    existingClaim: media-library-02
+    advancedMounts:
+      tdarr-node:
+        app:
+          - path: /media/library/disk-02
+  media-library-03:
+    type: persistentVolumeClaim
+    existingClaim: media-library-03
+    advancedMounts:
+      tdarr-node:
+        app:
+          - path: /media/library/disk-03
+  media-library-04:
+    type: persistentVolumeClaim
+    existingClaim: media-library-04
+    advancedMounts:
+      tdarr-node:
+        app:
+          - path: /media/library/disk-04
+  media-library-05:
+    type: persistentVolumeClaim
+    existingClaim: media-library-05
+    advancedMounts:
+      tdarr-node:
+        app:
+          - path: /media/library/disk-05
+  media-library-06:
+    type: persistentVolumeClaim
+    existingClaim: media-library-06
+    advancedMounts:
+      tdarr-node:
+        app:
+          - path: /media/library/disk-06
+  media-library-07:
+    type: persistentVolumeClaim
+    existingClaim: media-library-07
+    advancedMounts:
+      tdarr-node:
+        app:
+          - path: /media/library/disk-07
+  media-library-08:
+    type: persistentVolumeClaim
+    existingClaim: media-library-08
+    advancedMounts:
+      tdarr-node:
+        app:
+          - path: /media/library/disk-08
+  media-library-09:
+    type: persistentVolumeClaim
+    existingClaim: media-library-09
+    advancedMounts:
+      tdarr-node:
+        app:
+          - path: /media/library/disk-09
+  media-library-10:
+    type: persistentVolumeClaim
+    existingClaim: media-library-10
+    advancedMounts:
+      tdarr-node:
+        app:
+          - path: /media/library/disk-10
   transcode-cache:
     type: emptyDir
     advancedMounts:

--- a/kubernetes/clusters/live/charts/tdarr.yaml
+++ b/kubernetes/clusters/live/charts/tdarr.yaml
@@ -128,8 +128,78 @@ persistence:
     advancedMounts:
       tdarr:
         app:
-          - path: /media/library
+          - path: /media/library/disk-00
             readOnly: false
+  media-library-01:
+    type: persistentVolumeClaim
+    existingClaim: media-library-01
+    advancedMounts:
+      tdarr:
+        app:
+          - path: /media/library/disk-01
+  media-library-02:
+    type: persistentVolumeClaim
+    existingClaim: media-library-02
+    advancedMounts:
+      tdarr:
+        app:
+          - path: /media/library/disk-02
+  media-library-03:
+    type: persistentVolumeClaim
+    existingClaim: media-library-03
+    advancedMounts:
+      tdarr:
+        app:
+          - path: /media/library/disk-03
+  media-library-04:
+    type: persistentVolumeClaim
+    existingClaim: media-library-04
+    advancedMounts:
+      tdarr:
+        app:
+          - path: /media/library/disk-04
+  media-library-05:
+    type: persistentVolumeClaim
+    existingClaim: media-library-05
+    advancedMounts:
+      tdarr:
+        app:
+          - path: /media/library/disk-05
+  media-library-06:
+    type: persistentVolumeClaim
+    existingClaim: media-library-06
+    advancedMounts:
+      tdarr:
+        app:
+          - path: /media/library/disk-06
+  media-library-07:
+    type: persistentVolumeClaim
+    existingClaim: media-library-07
+    advancedMounts:
+      tdarr:
+        app:
+          - path: /media/library/disk-07
+  media-library-08:
+    type: persistentVolumeClaim
+    existingClaim: media-library-08
+    advancedMounts:
+      tdarr:
+        app:
+          - path: /media/library/disk-08
+  media-library-09:
+    type: persistentVolumeClaim
+    existingClaim: media-library-09
+    advancedMounts:
+      tdarr:
+        app:
+          - path: /media/library/disk-09
+  media-library-10:
+    type: persistentVolumeClaim
+    existingClaim: media-library-10
+    advancedMounts:
+      tdarr:
+        app:
+          - path: /media/library/disk-10
   transcode-cache:
     type: emptyDir
     advancedMounts:


### PR DESCRIPTION
## Summary

Updates 8 app charts to mount all 11 media library disks:
- **sonarr, sonarr4k, radarr, radarr4k, bazarr, tdarr, tdarr-node** — renamed `media-library` mount from `/media/library` → `/media/library/disk-00`; added `media-library-01..10` at `/media/library/disk-01..10`
- **jellyfin** — same mount changes; added `ParallelLibraryScanLimit: "3"` env var to mitigate upstream issue #15728 (NFS parallel-scan crash with many library roots)

Existing content on `disk-00` remains accessible read-write. All 8 pods do a rolling restart on deploy; existing media unaffected.

## PR sequence

**This is PR 4/5.** Merge after PR-2 (PVCs must exist before pods can mount them).

1. PR-1 — platform prep ✓
2. PR-2 — 10×10TiB PVCs ✓
3. PR-3 — reconciler CronJob (dry-run) ✓
4. **PR-4 (this)** — app chart persistence updates
5. PR-5 — reconciler enforce mode

## Test plan

- [ ] `task k8s:validate` passes
- [ ] After merge: all 8 consumer pods `Ready`
- [ ] `kubectl exec -n media deploy/sonarr -- df -h | grep disk-` returns 11 lines
- [ ] `curl sonarr/api/v3/rootfolder` returns 11 entries (after reconciler runs)
- [ ] Jellyfin library scan completes without crash
- [ ] Existing media still visible in Jellyfin from disk-00