### PR TITLE
feat(media): enable media-reconciler enforce mode

### DIFF
--- a/kubernetes/clusters/live/charts/media-reconciler.yaml
+++ b/kubernetes/clusters/live/charts/media-reconciler.yaml
@@ -1,0 +1,75 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+# https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+controllers:
+  media-reconciler:
+    type: cronjob
+    cronjob:
+      schedule: "0 2 * * *"
+      successfulJobsHistory: 3
+      failedJobsHistory: 3
+    pod:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+    containers:
+      app:
+        image:
+          repository: docker.io/python
+          tag: "3.12-alpine"
+        command: ["python", "/scripts/reconciler.py"]
+        env:
+          SONARR_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: sonarr-api-key
+                key: api-key
+          SONARR4K_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: sonarr4k-api-key
+                key: api-key
+          RADARR_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: radarr-api-key
+                key: api-key
+          RADARR4K_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: radarr4k-api-key
+                key: api-key
+          JELLYSEERR_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: jellyseerr-api-key
+                key: api-key
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            memory: 256Mi
+
+persistence:
+  scripts:
+    type: configMap
+    name: media-reconciler-config
+    advancedMounts:
+      media-reconciler:
+        app:
+          - path: /scripts
+  tmp:
+    type: emptyDir
+    advancedMounts:
+      media-reconciler:
+        app:
+          - path: /tmp


### PR DESCRIPTION
## Summary

Removes `--dry-run` from the `media-reconciler` CronJob command. After this merge:
- New Jellyseerr requests land on disk-01..10 (steered by reconciler's `activeDirectory` update)
- *arr root folders and Tdarr libraries are actively synced daily

## ⚠️ Prerequisites — merge only after:

1. PR-3 merged and reconciler running in dry-run for **~1 week**
2. Dry-run logs verified: correct disk selection, no errors, emptiest-disk logic working
3. PR-4 merged: all 8 consumer pods showing 11 NFS mounts

## PR sequence

**This is PR 5/5 — final step.**

1. PR-1 — platform prep ✓
2. PR-2 — 10×10TiB PVCs ✓
3. PR-3 — reconciler CronJob (dry-run) ✓
4. PR-4 — app chart persistence updates ✓
5. **PR-5 (this)** — reconciler enforce mode

## Test plan

- [ ] Dry-run logs clean for ≥1 week
- [ ] After merge: request a low-bandwidth title in Jellyseerr → verify file lands under `/media/library/disk-NN` matching reconciler's chosen disk
- [ ] `curl jellyseerr/api/v1/settings/sonarr/1` returns `activeDirectory` ∈ `disk-01..10` (never `disk-00`)
- [ ] Prometheus 24h: `LonghornShareManagerMemoryHigh` not firing; no `LonghornVolumeSchedulingFailed`