### PR TITLE
fix(renovate): group tdarr server+node into single lockstep PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -207,6 +207,17 @@
         "after 2am and before 6am on Monday"
       ]
     },
+    {
+      // tdarr server + node MUST run identical versions — a mismatch causes
+      // the node process to hard-exit (incident: node crashlooped 310× for 2d4h
+      // after server bumped independently via a separate Renovate PR).
+      // Grouping forces both into one atomic PR so they can never diverge.
+      "matchDepNames": [
+        "tdarr",
+        "tdarr-node"
+      ],
+      "groupName": "tdarr"
+    },
     // ============================================================
     // Version holds — upstream regressions (see .github/version-holds.yaml)
     // ============================================================


### PR DESCRIPTION
## Why

`tdarr-node` hard-refuses to start when its version does not match the tdarr server (process exits with status 1). Renovate was tracking the two images as independent packages, which let them drift: server bumped to 2.82.02 via #1300 while the node PR (#1301) was still open, causing a 310x crashloop over 2d4h on the live cluster.

## What changed

A single `packageRules` entry in `.github/renovate.json5` assigns `groupName: "tdarr"` to both `depName` values (`tdarr` and `tdarr-node`). Renovate will now batch all updates for these two packages into one branch and one PR, making version skew structurally impossible.

### Approach: grouping vs single-source-of-truth

A single renovate annotation driving both variables was considered but is not viable here: the two variables track genuinely different Docker images (`ghcr.io/haveagitgat/tdarr` vs `ghcr.io/haveagitgat/tdarr_node`) and must be updated as separate env vars because the chart values reference them independently. Grouping via `packageRules` is the idiomatic Renovate fix for this exact pattern and is already used throughout this repo (grafana stack, prometheus stack, authelia stack, etc.).

### Automerge posture

Unchanged. The grouped PR inherits the existing `minimumReleaseAge` rules from `.renovate/automerge.json5` (patch → 1 day, minor → 3 days). Grouping fully eliminates the desync vector so no additional restriction is needed.

### Related risk (out of scope)

The live cluster had zero required status checks at merge time, which allowed PR #1300 to merge while CI was broken. A separate agent is addressing the `validate-base` CI break. Restoring required status checks would provide an additional safety layer, but that is a branch-protection concern separate from this PR's scope.

## Test plan

- [x] `task renovate:validate` passes (`Config validated successfully`)
- [ ] After merge, verify Renovate closes the open tdarr-node PR (#1301) and re-opens as a single grouped PR containing both `tdarr_version` and `tdarr_node_version`
- [ ] Confirm the grouped PR title references both images