### PR TITLE
fix(tuppr): correct Garage health check CEL expression

### DIFF
--- a/kubernetes/platform/config/tuppr/kubernetes-upgrade.yaml
+++ b/kubernetes/platform/config/tuppr/kubernetes-upgrade.yaml
@@ -37,14 +37,14 @@ spec:
         status.phase == 'Cluster in healthy state' &&
           status.readyInstances == object.spec.instances
       timeout: 15m
-    - apiVersion: garage.rajsingh.info/v1alpha1
+    - apiVersion: garage.rajsingh.info/v1beta2
       kind: GarageCluster
       name: garage
       namespace: garage
       description: Garage cluster must be running with all replicas ready
       expr: |
         status.phase == 'Running' &&
-          status.readyReplicas == object.spec.replicas
+          status.readyReplicas == status.replicas
       timeout: 10m
     - apiVersion: dragonflydb.io/v1alpha1
       kind: Dragonfly

--- a/kubernetes/platform/config/tuppr/talos-upgrade.yaml
+++ b/kubernetes/platform/config/tuppr/talos-upgrade.yaml
@@ -40,14 +40,14 @@ spec:
         status.phase == 'Cluster in healthy state' &&
           status.readyInstances == object.spec.instances
       timeout: 15m
-    - apiVersion: garage.rajsingh.info/v1alpha1
+    - apiVersion: garage.rajsingh.info/v1beta2
       kind: GarageCluster
       name: garage
       namespace: garage
       description: Garage cluster must be running with all replicas ready
       expr: |
         status.phase == 'Running' &&
-          status.readyReplicas == object.spec.replicas
+          status.readyReplicas == status.replicas
       timeout: 10m
     - apiVersion: dragonflydb.io/v1alpha1
       kind: Dragonfly


### PR DESCRIPTION
## Summary

- `GarageCluster` v1beta2 has no `spec.replicas` field — the CEL expression `status.readyReplicas == object.spec.replicas` was throwing a runtime evaluation error (not returning false) on every evaluation
- This caused `KubernetesUpgrade` to loop on 30-minute health check timeouts indefinitely, never making progress or transitioning back to wait for the next maintenance window
- `TalosUpgrade` has an implicit dependency on `KubernetesUpgrade` completing first, so it has also been blocked — Talos upgrades have been silently skipping every Sunday window since May 20

**Fixes:**
- Change `object.spec.replicas` → `status.replicas` (the field that actually exists on GarageCluster status)
- Bump `apiVersion` from `garage.rajsingh.info/v1alpha1` → `v1beta2` to match the installed CRD version

## Test plan

- [ ] After merge, confirm `KubernetesUpgrade` controller stops logging CEL evaluation errors
- [ ] Confirm health checks pass and `KubernetesUpgrade` progresses to upgrade on next Sunday window (July 12)
- [ ] Confirm `TalosUpgrade` also proceeds after `KubernetesUpgrade` completes