### PR TITLE
ci: enforce Talos/Kubernetes version compatibility

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -112,16 +112,10 @@
     {
       "matchDepNames": [
         "talos",
-        "!siderolabs/talos"
-      ],
-      "groupName": "talos",
-      "automerge": true
-    },
-    {
-      "matchDepNames": [
+        "!siderolabs/talos",
         "kubernetes"
       ],
-      "groupName": "kubernetes",
+      "groupName": "talos-platform",
       "automerge": true
     },
     {

--- a/.github/workflows/kubernetes-validate.yaml
+++ b/.github/workflows/kubernetes-validate.yaml
@@ -23,6 +23,22 @@ jobs:
       - name: Setup tools
         uses: jdx/mise-action@v4
 
+      - name: Check Talos/Kubernetes version compatibility
+        run: |
+          TALOS=$(grep '^talos_version=' kubernetes/platform/versions.env | cut -d= -f2)
+          K8S=$(grep '^kubernetes_version=' kubernetes/platform/versions.env | cut -d= -f2)
+
+          EXPECTED=$(curl -sf "https://api.github.com/repos/siderolabs/talos/releases/tags/${TALOS}" \
+            | jq -r '.body' \
+            | grep -oP 'Kubernetes: \K[\d.]+')
+
+          echo "Talos ${TALOS} expects Kubernetes ${EXPECTED}, configured ${K8S}"
+
+          if [[ "$K8S" != "$EXPECTED" ]]; then
+            echo "ERROR: Talos ${TALOS} requires Kubernetes ${EXPECTED} but versions.env has ${K8S}" >&2
+            exit 1
+          fi
+
       - name: Validate (cluster-independent)
         run: task k8s:validate
 

--- a/.github/workflows/kubernetes-validate.yaml
+++ b/.github/workflows/kubernetes-validate.yaml
@@ -34,8 +34,8 @@ jobs:
           TALOS_MINOR=$(echo "${TALOS}" | grep -oP 'v\K\d+\.\d+' | tr -d '.')
           COMPAT_PATH="pkg/machinery/compatibility/talos${TALOS_MINOR}/talos${TALOS_MINOR}.go"
 
-          COMPAT=$(gh api "/repos/siderolabs/talos/contents/${COMPAT_PATH}" \
-            -f ref="${TALOS}" --jq '.content' | base64 -d)
+          COMPAT=$(gh api "/repos/siderolabs/talos/contents/${COMPAT_PATH}?ref=${TALOS}" \
+            --jq '.content' | base64 -d)
 
           K8S_MIN=$(echo "${COMPAT}" | grep -oP 'MinimumKubernetesVersion\s*=\s*semver\.MustParse\("\K[\d.]+')
           K8S_MAX=$(echo "${COMPAT}" | grep -oP 'MaximumKubernetesVersion\s*=\s*semver\.MustParse\("\K[\d.]+')

--- a/.github/workflows/kubernetes-validate.yaml
+++ b/.github/workflows/kubernetes-validate.yaml
@@ -24,18 +24,27 @@ jobs:
         uses: jdx/mise-action@v4
 
       - name: Check Talos/Kubernetes version compatibility
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           TALOS=$(grep '^talos_version=' kubernetes/platform/versions.env | cut -d= -f2)
           K8S=$(grep '^kubernetes_version=' kubernetes/platform/versions.env | cut -d= -f2)
 
-          EXPECTED=$(curl -sf "https://api.github.com/repos/siderolabs/talos/releases/tags/${TALOS}" \
-            | jq -r '.body' \
-            | grep -oP 'Kubernetes: \K[\d.]+')
+          # Derive compat package from Talos minor (e.g. v1.13.5 -> talos113)
+          TALOS_MINOR=$(echo "${TALOS}" | grep -oP 'v\K\d+\.\d+' | tr -d '.')
+          COMPAT_PATH="pkg/machinery/compatibility/talos${TALOS_MINOR}/talos${TALOS_MINOR}.go"
 
-          echo "Talos ${TALOS} expects Kubernetes ${EXPECTED}, configured ${K8S}"
+          COMPAT=$(gh api "/repos/siderolabs/talos/contents/${COMPAT_PATH}" \
+            -f ref="${TALOS}" --jq '.content' | base64 -d)
 
-          if [[ "$K8S" != "$EXPECTED" ]]; then
-            echo "ERROR: Talos ${TALOS} requires Kubernetes ${EXPECTED} but versions.env has ${K8S}" >&2
+          K8S_MIN=$(echo "${COMPAT}" | grep -oP 'MinimumKubernetesVersion\s*=\s*semver\.MustParse\("\K[\d.]+')
+          K8S_MAX=$(echo "${COMPAT}" | grep -oP 'MaximumKubernetesVersion\s*=\s*semver\.MustParse\("\K[\d.]+')
+
+          echo "Talos ${TALOS} supports Kubernetes ${K8S_MIN} - ${K8S_MAX}"
+          echo "Configured: ${K8S}"
+
+          if ! printf '%s\n%s\n%s\n' "${K8S_MIN}" "${K8S}" "${K8S_MAX}" | sort -V -C; then
+            echo "ERROR: kubernetes_version=${K8S} outside supported range [${K8S_MIN}, ${K8S_MAX}] for Talos ${TALOS}" >&2
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- Merges the separate `talos` and `kubernetes` Renovate groups into a single `talos-platform` group so the two versions always update together in the same PR, preventing incompatible drift
- Adds a CI step to `kubernetes-validate.yaml` that fetches the Talos GitHub release for the configured `talos_version`, extracts the expected Kubernetes version from the release body, and fails if `kubernetes_version` in `versions.env` does not match

## Test plan

- [ ] Verify `task renovate:validate` passes (run locally — it does)
- [ ] Verify the new CI step passes on this PR with the current `versions.env` values
- [ ] Confirm that a future Renovate PR for a Talos bump will include the paired Kubernetes update in a single `talos-platform` group PR