### PR TITLE
fix(jellyfin-exporter): add timeoutSeconds to liveness and readiness probes

### DIFF
--- a/kubernetes/clusters/live/charts/jellyfin-exporter.yaml
+++ b/kubernetes/clusters/live/charts/jellyfin-exporter.yaml
@@ -58,6 +58,7 @@ controllers:
                 path: /metrics
                 port: 9594
               periodSeconds: 30
+              timeoutSeconds: 30
           readiness:
             enabled: true
             custom: true
@@ -66,6 +67,7 @@ controllers:
                 path: /metrics
                 port: 9594
               periodSeconds: 10
+              timeoutSeconds: 30
 
 service:
   app:


### PR DESCRIPTION
## Summary

- Liveness and readiness probes on `/metrics` had no `timeoutSeconds` (defaulted to 1s)
- `/metrics` requires an upstream Jellyfin API call — response time exceeds 1s
- Kubelet drops the connection after timeout → broken-pipe errors → crashloop

Sets `timeoutSeconds: 30` on both probes, matching the existing startup probe.

## Test plan

- [ ] Confirm pod stops crashlooping after rollout on live
- [ ] Verify `/metrics` endpoint returns 200 via liveness/readiness checks
- [ ] Confirm Prometheus scrapes resume without broken-pipe errors in logs