### PR TITLE
feat(live): deploy redlib

### DIFF
--- a/kubernetes/clusters/live/charts/kustomization.yaml
+++ b/kubernetes/clusters/live/charts/kustomization.yaml
@@ -33,6 +33,7 @@ configMapGenerator:
       - prowlarr.yaml
       - qbittorrent.yaml
       - radarr.yaml
+      - redlib.yaml
       - radarr4k.yaml
       - recyclarr.yaml
       - sabnzbd.yaml

--- a/kubernetes/clusters/live/charts/redlib.yaml
+++ b/kubernetes/clusters/live/charts/redlib.yaml
@@ -1,0 +1,85 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-4.6.0/charts/other/app-template/values.schema.json
+# https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+controllers:
+  redlib:
+    type: deployment
+    replicas: 1
+
+    pod:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+
+    containers:
+      app:
+        image:
+          repository: quay.io/redlib/redlib
+          tag: "${redlib_version}"
+        env:
+          TZ: UTC
+          REDLIB_PORT: "8080"
+          REDLIB_DEFAULT_SHOW_NSFW: "false"
+          REDLIB_DEFAULT_HIDE_HLS_NOTIFICATION: "true"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop: [ALL]
+          seccompProfile:
+            type: RuntimeDefault
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            memory: 512Mi
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /settings
+                port: 8080
+              initialDelaySeconds: 5
+              periodSeconds: 30
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /settings
+                port: 8080
+              initialDelaySeconds: 5
+              periodSeconds: 10
+
+service:
+  app:
+    controller: redlib
+    ports:
+      http:
+        port: 8080
+
+route:
+  internal:
+    enabled: true
+    annotations:
+      gethomepage.dev/enabled: "true"
+      gethomepage.dev/name: "Redlib"
+      gethomepage.dev/group: "Apps"
+      gethomepage.dev/icon: "reddit.svg"
+      gethomepage.dev/pod-selector: "app.kubernetes.io/name=redlib"
+    parentRefs:
+      - name: internal
+        namespace: istio-gateway
+    hostnames:
+      - "redlib.${internal_domain}"
+    rules:
+      - backendRefs:
+          - identifier: app
+            port: 8080

--- a/kubernetes/clusters/live/config/kustomization.yaml
+++ b/kubernetes/clusters/live/config/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - booter
   - external-dns
   - it-tools
+  - redlib
   - zipline
   - vaultwarden
   - immich

--- a/kubernetes/clusters/live/config/redlib/kustomization.yaml
+++ b/kubernetes/clusters/live/config/redlib/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/kubernetes/clusters/live/config/redlib/namespace.yaml
+++ b/kubernetes/clusters/live/config/redlib/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: redlib
+  labels:
+    istio.io/dataplane-mode: ambient
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+    network-policy.homelab/profile: internal

--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -64,6 +64,13 @@ spec:
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
       dependsOn: []
+    - name: redlib
+      namespace: redlib
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: []
     - name: factorio
       namespace: factorio
       chart:

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -74,6 +74,8 @@ flaresolverr_version=v3.5.0
 sabnzbd_version=5.0.4
 # renovate: datasource=docker depName=it-tools packageName=ghcr.io/corentinth/it-tools versioning=loose
 it_tools_version=2024.10.22-7ca5933
+# renovate: datasource=docker depName=redlib packageName=quay.io/redlib/redlib
+redlib_version=v0.36.0
 # renovate: datasource=docker depName=firefly-iii packageName=fireflyiii/core versioning=regex:^version-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
 firefly_version=version-6.6.6
 


### PR DESCRIPTION
## Summary

- Deploys [Redlib](https://github.com/redlib-org/redlib) (private Reddit front-end) to the live cluster
- Image: `quay.io/redlib/redlib:v0.36.0` (official upstream, Renovate-managed)
- Chart: `app-template` via OCI, ambient mesh + baseline PSS namespace
- Route: `redlib.${internal_domain}` on internal gateway with homepage integration
- No persistent storage required — stateless app

## Test plan

- [ ] Flux reconciles `HelmRelease/redlib` in `redlib` namespace
- [ ] Pod reaches `Running` state
- [ ] `https://redlib.<internal_domain>` loads Reddit front-end
- [ ] `/settings` health probe passes (liveness + readiness)
- [ ] Homepage shows Redlib in "Apps" group