### PR TITLE
fix(renovate): pin cloudnative-pg postgresql to v18 major track

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -244,6 +244,12 @@
       "allowedVersions": "< 0.11.0"
     },
     {
+      // Pin PostgreSQL to v18 major — CNPG major-version upgrades require
+      // deliberate cluster rebuild or pg_upgrade, not an automatic bump.
+      "matchDepNames": ["cloudnative-pg-postgresql"],
+      "allowedVersions": "^18"
+    },
+    {
       // pluto aqua datasource diverges from GitHub releases - force github-releases
       // to prevent phantom versions that 404 on install
       "matchManagers": ["mise"],


### PR DESCRIPTION
## Summary

- Renovate opened PR #1183 offering a bump to `19beta1` for the `cloudnative-pg-postgresql` image
- CNPG major-version PostgreSQL upgrades require a deliberate cluster rebuild or `pg_upgrade` — they cannot be applied via an automatic image tag bump
- Adds a `packageRule` in the **Version holds** section of `.github/renovate.json5` pinning `cloudnative-pg-postgresql` to `^18` until PG19 reaches stable and a controlled upgrade path is planned

## Details

The image is tracked via a `versions.env` annotation:
```
# renovate: datasource=docker depName=cloudnative-pg-postgresql packageName=ghcr.io/cloudnative-pg/postgresql versioning=loose
postgresql_image_version=18.4
```

Without an `allowedVersions` guard, Renovate correctly detected `19beta1` as a newer tag and opened a PR. That bump would have silently migrated the CNPG cluster to an incompatible major version, which CNPG does not support without explicit operator intervention.

## Test plan

- [ ] `renovate-validate` CI check passes on this PR
- [ ] Confirm PR #1183 (PostgreSQL 19beta1 bump) closes or is superseded after merge