### PR TITLE
fix(live/redlib): use sha-a4d36e9 image tag

### DIFF
--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -74,8 +74,7 @@ flaresolverr_version=v3.5.0
 sabnzbd_version=5.0.4
 # renovate: datasource=docker depName=it-tools packageName=ghcr.io/corentinth/it-tools versioning=loose
 it_tools_version=2024.10.22-7ca5933
-# renovate: datasource=docker depName=redlib packageName=quay.io/redlib/redlib
-redlib_version=v0.36.0
+redlib_version=sha-a4d36e9
 # renovate: datasource=docker depName=firefly-iii packageName=fireflyiii/core versioning=regex:^version-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
 firefly_version=version-6.6.6
 


### PR DESCRIPTION
## Summary

- Fixes `ImagePullBackOff` introduced by #1320
- `quay.io/redlib/redlib` only publishes `sha-*` and `latest` tags — no semver tags
- `v0.36.0` exists as a GitHub source release but was never pushed as a container image tag
- Pins to `sha-a4d36e9` (latest published image, April 24 2026)
- Removes broken Renovate annotation (sha-based tags can't be auto-updated by Renovate)

## Test plan

- [ ] Pod reaches `Running` state (no `ImagePullBackOff`)
- [ ] `/settings` health probe passes