### PR TITLE
fix(live/redlib): use internal-egress network policy profile

### DIFF
--- a/kubernetes/clusters/live/config/redlib/namespace.yaml
+++ b/kubernetes/clusters/live/config/redlib/namespace.yaml
@@ -8,4 +8,4 @@ metadata:
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/warn: restricted
-    network-policy.homelab/profile: internal
+    network-policy.homelab/profile: internal-egress


### PR DESCRIPTION
## Summary

- Fixes crash loop introduced by #1320
- Redlib fetches all content from Reddit's external servers (OAuth handshake + API calls)
- `internal` network profile blocks all external egress — pod crashes with TLS/connection errors to Reddit OAuth endpoint
- `internal-egress` matches the profile used by other externally-fetching apps (homepage, minecraft, valheim)

## Test plan

- [ ] Pod reaches `Ready 1/1` without restarts
- [ ] `redlib.<internal_domain>` loads Reddit front-end content