### PR TITLE
fix(monitoring): stabilize loki service names via fullnameOverride

### DIFF
--- a/kubernetes/platform/charts/grafana-loki-single-binary.yaml
+++ b/kubernetes/platform/charts/grafana-loki-single-binary.yaml
@@ -1,6 +1,7 @@
 ---
 # https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml
 # yaml-language-server: $schema=https://github.com/grafana/loki/blob/main/production/helm/loki/values.schema.json
+fullnameOverride: loki
 deploymentMode: SingleBinary
 loki:
   auth_enabled: false


### PR DESCRIPTION
## Summary

- Loki v18 (upgraded in a recent Renovate PR) derives service names from the Helm release name (`grafana-loki-single-binary`), producing `grafana-loki-single-binary-headless` instead of the expected `loki-headless`
- This breaks Alloy log shipping (`loki.write.default`) and the Grafana Loki datasource — all 5 Alloy pods have been dropping ~25 entries/sec with `ingester_error` since `2026-07-08 20:19Z`, totalling ~408k dropped entries
- Adding `fullnameOverride: loki` forces stable service names (`loki`, `loki-headless`) regardless of Helm release name

## Impact

This is a **critical fix** resolving three firing `AlloyDroppedEntries` alerts. After merge and Flux reconciliation, Loki services will be recreated with stable names and Alloy will resume shipping logs without any config changes.

> **Note:** Helm service rename causes a brief delete+recreate of Loki services. Loki pod itself is unaffected; there will be a short window (~seconds) where the headless service is unavailable during reconciliation.

## Test plan

- [ ] Flux reconciles `grafana-loki-single-binary` HelmRelease successfully
- [ ] `kubectl get svc -n monitoring loki-headless` returns the service
- [ ] `AlloyDroppedEntries` alerts resolve
- [ ] Grafana Loki datasource returns queries