### PR TITLE
fix(istio-csr): enable client cert authenticator to prevent mesh outage on JWT expiry

### DIFF
--- a/kubernetes/platform/charts/istio-csr.yaml
+++ b/kubernetes/platform/charts/istio-csr.yaml
@@ -34,6 +34,11 @@ app:
   server:
     # Ambient mode: allow ztunnel to request certificates on behalf of workloads
     caTrustedNodeAccounts: istio-system/ztunnel
+    authenticators:
+      # Allow proxies to renew certs using their existing cert as auth, breaking
+      # the hard dependency on the in-memory istio-token JWT (12h TTL). Without
+      # this, JWT expiry causes a full mesh outage with no renewal fallback.
+      enableClientCert: true
     # Address for Istio components to connect
     serving:
       address: 0.0.0.0


### PR DESCRIPTION
## Why

Today's mesh outage was caused by a missing fallback in the istio-csr authentication chain.

Envoy sidecars authenticate to istio-csr using a projected `istio-token` JWT. This JWT has a 12-hour TTL and is cached in memory at pod startup. When the JWT expires, the proxy has **no fallback mechanism** — it cannot use its existing (valid) workload certificate to renew. The result is a full mesh outage: every proxy loses the ability to rotate its certificate, TLS connections fail, and the mesh stops functioning.

The root setting responsible is `--enable-client-cert-authenticator=false` (the default). With this off, there is literally no path to cert renewal once the in-memory JWT expires.

## Fix

Enable `app.server.authenticators.enableClientCert: true` in the istio-csr Helm values.

This activates a second authentication path: proxies may present their existing (still-valid) workload certificate as proof of identity when requesting a renewal. This breaks the hard dependency on the JWT being resident in memory, providing resilience against the failure mode that caused today's outage.

## Validation

- `task k8s:validate` passes (Helm schema, YAML lint, ResourceSet expansion, API deprecation check)
- Verified against upstream chart values for istio-csr v0.16.0 — the correct field path is `app.server.authenticators.enableClientCert`

## Test Plan

- [ ] Verify istio-csr HelmRelease reconciles successfully after merge (watch integration cluster)
- [ ] Confirm `--enable-client-cert-authenticator=true` appears in the istio-csr pod args post-rollout
- [ ] Optionally: validate that a proxy whose JWT has expired can still renew its cert using the cert-auth path