### PR TITLE
fix(istio): rolling restart to remediate expired istio-token JWTs

### DIFF
--- a/kubernetes/platform/charts/istio-ztunnel.yaml
+++ b/kubernetes/platform/charts/istio-ztunnel.yaml
@@ -7,3 +7,6 @@ profile: ambient
 # Point to istio-csr for certificate requests (Ambient mode)
 # ztunnel authenticates with its own identity but requests certs for workloads on its node
 caAddress: cert-manager-istio-csr.cert-manager.svc:443
+
+podAnnotations:
+  kubectl.kubernetes.io/restartedAt: "2026-07-12T17:00:00Z"

--- a/kubernetes/platform/config/gateway/gateway-deployment-defaults.yaml
+++ b/kubernetes/platform/config/gateway/gateway-deployment-defaults.yaml
@@ -7,6 +7,10 @@ data:
   deployment: |
     spec:
       replicas: ${default_replica_count}
+      template:
+        metadata:
+          annotations:
+            kubectl.kubernetes.io/restartedAt: "2026-07-12T17:00:00Z"
   podDisruptionBudget: |
     spec:
       maxUnavailable: 1


### PR DESCRIPTION
## Summary

Emergency remediation for a mesh auth outage caused by projected `istio-token` JWTs expiring in 11 Istio pods that have been running since June 24, 2026:

- 6 gateway pods (internal + external Istio gateways in `istio-gateway` namespace)
- 5 ztunnel pods (`istio-system` namespace)

Adds a `kubectl.kubernetes.io/restartedAt: "2026-07-12T17:00:00Z"` annotation to:

1. **Gateway pods** — via `spec.template.metadata.annotations` in the `gateway-deployment-defaults` ConfigMap (used by both internal and external gateways via `infrastructure.parametersRef`). Istio applies this as a strategic merge patch to the generated Deployment, changing the pod template spec and triggering a rolling update.

2. **Ztunnel pods** — via `podAnnotations` in the `istio-ztunnel` Helm values. Flux detects the changed values and triggers a HelmRelease upgrade, which rolls the DaemonSet pods.

When Flux reconciles, kubelet issues fresh projected service account tokens to each new pod, immediately restoring mesh authentication.

## Test plan

- [ ] Confirm PR pipeline passes (build + integration promotion)
- [ ] After merge, verify gateway pods in `istio-gateway` roll (new pods should show creation time of ~today)
- [ ] Verify ztunnel pods in `istio-system` roll similarly
- [ ] Confirm mesh auth is restored — check that RBAC/SPIFFE identity errors no longer appear in Envoy/ztunnel logs
- [ ] Verify `istio-token` projected volume mount in new pods shows a recent expiry (should be ~24h from now, not expired)