### PR TITLE
fix(tuppr): separate Talos and Kubernetes upgrade maintenance windows

### DIFF
--- a/kubernetes/platform/config/tuppr/talos-upgrade.yaml
+++ b/kubernetes/platform/config/tuppr/talos-upgrade.yaml
@@ -8,7 +8,7 @@ spec:
     version: ${talos_version}
   maintenance:
     windows:
-      - start: "0 2 * * 0"  # Every Sunday at 2:00 AM
+      - start: "0 2 * * 6"  # Every Saturday at 2:00 AM
         duration: 4h
         timezone: EST
   policy:


### PR DESCRIPTION
## Summary

- **Root cause**: `TalosUpgrade` and `KubernetesUpgrade` both had `0 2 * * 0` (Sunday 02:00 EST). When they fired simultaneously today, the Kubernetes upgrade was rolling `kube-apiservers` exactly when the Talos upgrade controller tried to reach those same nodes as gRPC `--endpoints`. The gRPC connection failures cascaded and took down the Istio mesh.
- **Fix**: Move `TalosUpgrade` to Saturday (`0 2 * * 6`). Talos node upgrades (OS-level reboots) now complete a full 24 hours before `KubernetesUpgrade` starts its API server rollout on Sunday.
- `KubernetesUpgrade` is unchanged — comment already read "Every Sunday at 2:00 AM".

## Post-merge action required

The `TalosUpgrade/talos` resource is currently in terminal `Phase: Failed` from today's failed run. The Tuppr controller skips it every reconcile cycle until the resource is cleared. After this PR merges, run:

```
kubectl delete talosupgrade talos
```

Flux will immediately recreate it from git, clearing the `Failed` status and allowing the Saturday window to be observed correctly.

## Test plan

- [ ] Validate passes (`task k8s:validate` — no errors)
- [ ] Confirm `talos-upgrade.yaml` cron field is `* * 6` (Saturday) and `kubernetes-upgrade.yaml` remains `* * 0` (Sunday)
- [ ] After merge: run `kubectl delete talosupgrade talos` and confirm Flux recreates it with `Phase: Pending`
- [ ] Verify next Saturday the Talos upgrade completes before Sunday's Kubernetes upgrade window opens