### PR TITLE
feat(platform): scale cert-manager-istio-csr to 2 replicas

### DIFF
--- a/kubernetes/platform/charts/istio-csr.yaml
+++ b/kubernetes/platform/charts/istio-csr.yaml
@@ -5,7 +5,7 @@
 # Replaces Istio's built-in CA with cert-manager for unified PKI management.
 # Enables workload identity certificates to be issued by the istio-mesh-ca ClusterIssuer.
 
-replicaCount: 1
+replicaCount: 2
 
 image:
   repository: quay.io/jetstack/cert-manager-istio-csr


### PR DESCRIPTION
## Summary

- Scales `cert-manager-istio-csr` from 1 to 2 replicas in `kubernetes/platform/charts/istio-csr.yaml`
- Addresses thundering-herd readiness probe degradation: all mesh workloads have 1h cert duration, causing synchronized renewal bursts every 30 minutes that saturate the gRPC goroutine pool and starve the `/readyz` handler
- Both replicas serve the gRPC `CreateCertificate` path (active-active); only one holds the `istio-system/istio-csr` leader lease for config/root cert distribution

## Context

Diagnosed via cluster investigation: `cert-manager-istio-csr` pod had 39 readiness probe failures over 7 hours (probe: `GET :6060/readyz`, 1s timeout). Root cause is API client-side throttling (1.0–2.4s delays) during cert renewal bursts causing gRPC p99 latency to spike to 2.5–10s, starving the health handler goroutine. mTLS itself is not degraded — all CertificateRequests succeed — but a sustained burst could cause 3 consecutive probe failures and briefly remove the pod from the endpoint slice.

## Test plan

- [ ] Verify `cert-manager-istio-csr` Deployment shows 2/2 Ready replicas after merge
- [ ] Confirm no increase in `IstiodSDSCertificateErrors` or `IstioCSRDown` alerts
- [ ] Monitor readiness probe failure rate over next renewal window (~30 min after rollout)