### PR TITLE
fix(sure): strip v prefix from image tag

### DIFF
--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -93,7 +93,7 @@ minecraft_backup_version=2026.7.1
 minecraft_game_version=1.21.4
 
 # renovate: datasource=docker depName=sure packageName=ghcr.io/we-promise/sure
-sure_version=v0.7.2
+sure_version=0.7.2
 
 # Talos Image Factory schematic ID for PXE boot (iscsi-tools + util-linux-tools)
 # Content-addressed hash — only changes when extensions change, not on version bumps


### PR DESCRIPTION
## Summary

- `ghcr.io/we-promise/sure:v0.7.2` does not exist — pod was in `ImagePullBackOff`
- `docker/metadata-action` semver pattern strips the `v` prefix from git tags, so the published image is `0.7.2` not `v0.7.2`
- Fixes `sure_version` in `versions.env`

## Test plan

- [ ] Confirm pod starts after merge and Flux reconciles