### PR TITLE
fix(sure): Garage S3 storage + fix dragonfly replication

### DIFF
--- a/kubernetes/clusters/live/charts/sure.yaml
+++ b/kubernetes/clusters/live/charts/sure.yaml
@@ -53,6 +53,22 @@ controllers:
                 name: sure-oidc-client-secret
                 key: client-secret
           APP_DOMAIN: "sure.${internal_domain}"
+          # Garage S3 — Active Storage backend
+          ACTIVE_STORAGE_SERVICE: generic_s3
+          GENERIC_S3_ACCESS_KEY_ID:
+            valueFrom:
+              secretKeyRef:
+                name: sure-s3-credentials
+                key: access-key-id
+          GENERIC_S3_SECRET_ACCESS_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: sure-s3-credentials
+                key: secret-access-key
+          GENERIC_S3_BUCKET: sure
+          GENERIC_S3_REGION: garage
+          GENERIC_S3_ENDPOINT: "http://${garage_s3_endpoint}"
+          GENERIC_S3_FORCE_PATH_STYLE: "true"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
@@ -122,6 +138,22 @@ controllers:
               secretKeyRef:
                 name: sure-secret
                 key: secret-key-base
+          # Garage S3 — Active Storage backend
+          ACTIVE_STORAGE_SERVICE: generic_s3
+          GENERIC_S3_ACCESS_KEY_ID:
+            valueFrom:
+              secretKeyRef:
+                name: sure-s3-credentials
+                key: access-key-id
+          GENERIC_S3_SECRET_ACCESS_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: sure-s3-credentials
+                key: secret-access-key
+          GENERIC_S3_BUCKET: sure
+          GENERIC_S3_REGION: garage
+          GENERIC_S3_ENDPOINT: "http://${garage_s3_endpoint}"
+          GENERIC_S3_FORCE_PATH_STYLE: "true"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
@@ -160,11 +192,4 @@ route:
           - identifier: app
             port: 3000
 
-persistence:
-  storage:
-    type: persistentVolumeClaim
-    storageClass: fast
-    accessMode: ReadWriteOnce
-    size: 5Gi
-    globalMounts:
-      - path: /rails/storage
+persistence: { }

--- a/kubernetes/clusters/live/charts/sure.yaml
+++ b/kubernetes/clusters/live/charts/sure.yaml
@@ -4,8 +4,8 @@
 controllers:
   sure:
     type: deployment
-    replicas: 1
-    strategy: Recreate
+    replicas: 2
+    strategy: RollingUpdate
     annotations:
       reloader.stakater.com/auto: "true"
 

--- a/kubernetes/clusters/live/config/sure/garage-bucket.yaml
+++ b/kubernetes/clusters/live/config/sure/garage-bucket.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: sure
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage

--- a/kubernetes/clusters/live/config/sure/garage-key.yaml
+++ b/kubernetes/clusters/live/config/sure/garage-key.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: sure
+  namespace: sure
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  neverExpires: true
+  bucketPermissions:
+    - bucketRef:
+        name: sure
+        namespace: garage
+      read: true
+      write: true
+  secretTemplate:
+    name: sure-s3-credentials

--- a/kubernetes/clusters/live/config/sure/kustomization.yaml
+++ b/kubernetes/clusters/live/config/sure/kustomization.yaml
@@ -9,3 +9,5 @@ resources:
   - sure-secret.yaml
   - sure-oidc-client-secret-replica.yaml
   - network-policy.yaml
+  - garage-bucket.yaml
+  - garage-key.yaml

--- a/kubernetes/clusters/live/config/sure/namespace.yaml
+++ b/kubernetes/clusters/live/config/sure/namespace.yaml
@@ -11,3 +11,4 @@ metadata:
     network-policy.homelab/profile: internal
     access.network-policy.homelab/postgres: "true"
     access.network-policy.homelab/dragonfly: "true"
+    access.network-policy.homelab/garage-s3: "true"

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -93,7 +93,7 @@ minecraft_backup_version=2026.7.1
 minecraft_game_version=1.21.4
 
 # renovate: datasource=docker depName=sure packageName=ghcr.io/we-promise/sure
-sure_version=v0.7.2
+sure_version=0.7.2
 
 # Talos Image Factory schematic ID for PXE boot (iscsi-tools + util-linux-tools)
 # Content-addressed hash — only changes when extensions change, not on version bumps

--- a/kubernetes/platform/config/dragonfly/password-secret.yaml
+++ b/kubernetes/platform/config/dragonfly/password-secret.yaml
@@ -8,6 +8,6 @@ metadata:
     secret-generator.v1.mittwald.de/length: "32"
     secret-generator.v1.mittwald.de/encoding: hex
     replicator.v1.mittwald.de/replication-allowed: "true"
-    replicator.v1.mittwald.de/replication-allowed-namespaces: "ai,immich,authelia,paperless"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "ai,immich,authelia,paperless,sure"
 type: Opaque
 data: { }


### PR DESCRIPTION
## Summary

- **Fix `CreateContainerConfigError`**: `dragonfly-auth` secret not replicating to `sure` namespace — adds `sure` to `replication-allowed-namespaces` in platform dragonfly password-secret
- **Garage S3**: Switches Active Storage backend from local PVC to Garage (`generic_s3`) — app is now stateless
- **Drop PVC**: Removes the 5Gi RWO PersistentVolumeClaim — no longer needed
- **Namespace label**: Adds `access.network-policy.homelab/garage-s3: "true"` for Cilium egress to Garage on port 3900
- **GarageBucket + GarageKey**: Declarative bucket and credentials provisioning via garage-operator

## Test plan

- [ ] `dragonfly-auth` secret in `sure` namespace populated after merge
- [ ] Pod reaches `Running` state
- [ ] Active Storage uploads go to Garage bucket `sure`