### PR TITLE
feat(sure): configure Ollama as local LLM provider

### DIFF
--- a/kubernetes/clusters/live/charts/sure.yaml
+++ b/kubernetes/clusters/live/charts/sure.yaml
@@ -53,6 +53,12 @@ controllers:
                 name: sure-oidc-client-secret
                 key: client-secret
           APP_DOMAIN: "sure.${internal_domain}"
+          # LLM — local Ollama (OpenAI-compatible API)
+          OPENAI_ACCESS_TOKEN: "ollama-local"
+          OPENAI_URI_BASE: "http://ollama.ai.svc.cluster.local:11434/v1"
+          OPENAI_MODEL: "qwen2.5:7b"
+          LLM_CONTEXT_WINDOW: "8192"
+          LLM_MAX_RESPONSE_TOKENS: "1024"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
@@ -122,6 +128,12 @@ controllers:
               secretKeyRef:
                 name: sure-secret
                 key: secret-key-base
+          # LLM — local Ollama (OpenAI-compatible API)
+          OPENAI_ACCESS_TOKEN: "ollama-local"
+          OPENAI_URI_BASE: "http://ollama.ai.svc.cluster.local:11434/v1"
+          OPENAI_MODEL: "qwen2.5:7b"
+          LLM_CONTEXT_WINDOW: "8192"
+          LLM_MAX_RESPONSE_TOKENS: "1024"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false

--- a/kubernetes/clusters/live/config/ai-prereqs/network-policy.yaml
+++ b/kubernetes/clusters/live/config/ai-prereqs/network-policy.yaml
@@ -40,3 +40,23 @@ spec:
         - ports:
             - port: "11434"
               protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: ai-ollama-from-sure
+  namespace: ai
+spec:
+  description: "Ollama ingress from Sure for LLM chat and auto-categorization"
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: ollama
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: sure
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP

--- a/kubernetes/clusters/live/config/sure/network-policy.yaml
+++ b/kubernetes/clusters/live/config/sure/network-policy.yaml
@@ -17,3 +17,22 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: sure-to-ollama
+  namespace: sure
+spec:
+  description: "Allow Sure egress to Ollama LLM API for chat assistant and auto-categorization"
+  endpointSelector: { }
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP


### PR DESCRIPTION
## Summary

- Adds `OPENAI_ACCESS_TOKEN`, `OPENAI_URI_BASE`, `OPENAI_MODEL`, `LLM_CONTEXT_WINDOW`, and `LLM_MAX_RESPONSE_TOKENS` to both the `web` and `worker` containers in `sure.yaml`, pointing at the cluster-internal Ollama instance (`qwen2.5:7b`)
- Adds `sure-to-ollama` CiliumNetworkPolicy in the `sure` namespace allowing egress to Ollama port 11434
- Adds `ai-ollama-from-sure` CiliumNetworkPolicy in the `ai` namespace allowing Ollama ingress from the `sure` namespace

Both containers need the LLM env vars: `web` serves the interactive chat assistant, `worker` (Sidekiq) runs background auto-categorization jobs.

The `internal` network policy profile on the `sure` namespace provides DNS-only egress by default — the new CNPs explicitly open the cross-namespace path to Ollama without changing the profile or broadening any other egress.

## Test plan

- [ ] Verify Flux reconciles `sure` and `ai-prereqs` config kustomizations without errors
- [ ] Check `hubble observe --verdict DROPPED --namespace sure` for any drops after rollout
- [ ] Open Sure → Settings → AI and confirm provider shows as configured
- [ ] Send a chat message and confirm response comes from Ollama (check Ollama pod logs)
- [ ] Import a transaction and confirm auto-categorization fires (check worker logs for `auto_categorize`)