### PR TITLE
feat(sure): tune LLM settings for local Ollama

### DIFF
--- a/kubernetes/clusters/live/charts/sure.yaml
+++ b/kubernetes/clusters/live/charts/sure.yaml
@@ -72,9 +72,9 @@ controllers:
           # LLM — local Ollama (OpenAI-compatible API)
           OPENAI_ACCESS_TOKEN: "ollama-local"
           OPENAI_URI_BASE: "http://ollama.ai.svc.cluster.local:11434/v1"
-          OPENAI_MODEL: "qwen2.5:7b"
-          LLM_CONTEXT_WINDOW: "8192"
-          LLM_MAX_RESPONSE_TOKENS: "1024"
+          OPENAI_MODEL: "qwen2.5:7b-instruct-q8_0"
+          LLM_CONTEXT_WINDOW: "32768"
+          LLM_MAX_RESPONSE_TOKENS: "4096"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
@@ -163,9 +163,9 @@ controllers:
           # LLM — local Ollama (OpenAI-compatible API)
           OPENAI_ACCESS_TOKEN: "ollama-local"
           OPENAI_URI_BASE: "http://ollama.ai.svc.cluster.local:11434/v1"
-          OPENAI_MODEL: "qwen2.5:7b"
-          LLM_CONTEXT_WINDOW: "8192"
-          LLM_MAX_RESPONSE_TOKENS: "1024"
+          OPENAI_MODEL: "qwen2.5:7b-instruct-q8_0"
+          LLM_CONTEXT_WINDOW: "32768"
+          LLM_MAX_RESPONSE_TOKENS: "4096"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false


### PR DESCRIPTION
## Summary

- Switch `OPENAI_MODEL` to `qwen2.5:7b-instruct-q8_0` (q8 quantization = higher precision weights, better JSON adherence)
- Increase `LLM_CONTEXT_WINDOW` from `8192` → `32768` (model's native max, enables larger categorization batches)
- Increase `LLM_MAX_RESPONSE_TOKENS` from `1024` → `4096` (prevents mid-JSON truncation on verbose batches)

## Notes

Requires `qwen2.5:7b-instruct-q8_0` to be pulled on the Ollama instance before rollout (`ollama pull qwen2.5:7b-instruct-q8_0`). The model is ~7.7 GB and fits within the P4000's 8 GB VRAM.