### PR TITLE
feat(sure): set OPENAI_REQUEST_TIMEOUT=300 for local Ollama

### DIFF
--- a/kubernetes/clusters/live/charts/sure.yaml
+++ b/kubernetes/clusters/live/charts/sure.yaml
@@ -75,6 +75,7 @@ controllers:
           OPENAI_MODEL: "qwen2.5:7b-instruct-q8_0"
           LLM_CONTEXT_WINDOW: "32768"
           LLM_MAX_RESPONSE_TOKENS: "4096"
+          OPENAI_REQUEST_TIMEOUT: "300"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
@@ -166,6 +167,7 @@ controllers:
           OPENAI_MODEL: "qwen2.5:7b-instruct-q8_0"
           LLM_CONTEXT_WINDOW: "32768"
           LLM_MAX_RESPONSE_TOKENS: "4096"
+          OPENAI_REQUEST_TIMEOUT: "300"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false


### PR DESCRIPTION
## Summary

- Add `OPENAI_REQUEST_TIMEOUT: "300"` to both `web` and `worker` containers

The default Ruby `Net::HTTP` read timeout of 60s is too short for local LLM inference, particularly under concurrent load from Sidekiq's rule processing. Bumping to 300s lets the model take up to 5 minutes per request before failing.

Ref: Sure discord — confirmed env var name is `OPENAI_REQUEST_TIMEOUT`.