### PR TITLE
feat(ollama): tune context, flash attention, KV cache for local inference

### DIFF
--- a/kubernetes/clusters/live/charts/ollama.yaml
+++ b/kubernetes/clusters/live/charts/ollama.yaml
@@ -20,6 +20,9 @@ controllers:
           OLLAMA_NUM_PARALLEL: "2"
           OLLAMA_MAX_LOADED_MODELS: "1"
           OLLAMA_KEEP_ALIVE: "10m"
+          OLLAMA_CONTEXT_LENGTH: "8192"
+          OLLAMA_FLASH_ATTN: "1"
+          OLLAMA_KV_CACHE_TYPE: "q8_0"
           NVIDIA_VISIBLE_DEVICES: all
         resources:
           requests:

--- a/kubernetes/clusters/live/charts/ollama.yaml
+++ b/kubernetes/clusters/live/charts/ollama.yaml
@@ -21,7 +21,7 @@ controllers:
           OLLAMA_MAX_LOADED_MODELS: "1"
           OLLAMA_KEEP_ALIVE: "10m"
           OLLAMA_CONTEXT_LENGTH: "8192"
-          OLLAMA_FLASH_ATTN: "1"
+          OLLAMA_FLASH_ATTENTION: "1"
           OLLAMA_KV_CACHE_TYPE: "q8_0"
           NVIDIA_VISIBLE_DEVICES: all
         resources:

--- a/kubernetes/clusters/live/charts/sure.yaml
+++ b/kubernetes/clusters/live/charts/sure.yaml
@@ -73,7 +73,7 @@ controllers:
           OPENAI_ACCESS_TOKEN: "ollama-local"
           OPENAI_URI_BASE: "http://ollama.ai.svc.cluster.local:11434/v1"
           OPENAI_MODEL: "qwen2.5:7b-instruct-q8_0"
-          LLM_CONTEXT_WINDOW: "32768"
+          LLM_CONTEXT_WINDOW: "8192"
           LLM_MAX_RESPONSE_TOKENS: "4096"
           OPENAI_REQUEST_TIMEOUT: "300"
         securityContext:
@@ -165,7 +165,7 @@ controllers:
           OPENAI_ACCESS_TOKEN: "ollama-local"
           OPENAI_URI_BASE: "http://ollama.ai.svc.cluster.local:11434/v1"
           OPENAI_MODEL: "qwen2.5:7b-instruct-q8_0"
-          LLM_CONTEXT_WINDOW: "32768"
+          LLM_CONTEXT_WINDOW: "8192"
           LLM_MAX_RESPONSE_TOKENS: "4096"
           OPENAI_REQUEST_TIMEOUT: "300"
         securityContext:


### PR DESCRIPTION
## Summary

- `OLLAMA_CONTEXT_LENGTH=8192` — explicit per-slot context, aligned with Sure's `LLM_CONTEXT_WINDOW`; previously defaulted to 4096 making the 32768 setting in Sure a no-op
- `OLLAMA_FLASH_ATTN=1` — enables flash attention on the P4000 (Pascal/GP104, CUDA-supported); reduces VRAM pressure and speeds up attention for longer prompts
- `OLLAMA_KV_CACHE_TYPE=q8_0` — quantizes KV cache from fp16 to q8_0, halving cache VRAM usage; 2 parallel slots × 8192 context ≈ 870 MiB vs ~1.7 GB fp16
- `LLM_CONTEXT_WINDOW=8192` in `sure.yaml` — aligns with what Ollama can actually serve; 32768 was aspirational but exceeded VRAM limits with `NUM_PARALLEL=2`

## VRAM budget at rest

| Component | VRAM |
|---|---|
| qwen2.5:7b-instruct-q8_0 weights | ~7.7 GB |
| KV cache (2 slots × 8192 ctx, q8_0) | ~870 MiB |
| Total | ~8.5 GB (fits with flash attn overhead reduction) |