### PR TITLE
feat(sure): set LLM_JSON_MODE=none for standard model inference

### DIFF
--- a/kubernetes/clusters/live/charts/sure.yaml
+++ b/kubernetes/clusters/live/charts/sure.yaml
@@ -76,6 +76,7 @@ controllers:
           LLM_CONTEXT_WINDOW: "8192"
           LLM_MAX_RESPONSE_TOKENS: "4096"
           OPENAI_REQUEST_TIMEOUT: "300"
+          LLM_JSON_MODE: "none"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
@@ -168,6 +169,7 @@ controllers:
           LLM_CONTEXT_WINDOW: "8192"
           LLM_MAX_RESPONSE_TOKENS: "4096"
           OPENAI_REQUEST_TIMEOUT: "300"
+          LLM_JSON_MODE: "none"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false


### PR DESCRIPTION
## Summary

- Add `LLM_JSON_MODE: "none"` to both `web` and `worker` containers

## Why

`auto` mode (the default) attempts strict JSON schema first, then falls back to `none` when >50% of responses return null. In practice, qwen2.5:7b-instruct-q8_0 was consistently hitting the strict-mode failure threshold on every batch:

```
Auto mode: 60% failed (6 nulls, 0 missing) in strict mode, retrying with none mode
Auto mode: 70% failed (7 nulls, 0 missing) in strict mode, retrying with none mode
```

This doubled every LLM call — one wasted strict attempt + one successful none attempt. Setting `none` directly skips the strict attempt for this standard instruction model.

Per Sure discord: `none` is correct for standard models (llama, mistral, qwen); `strict` is for thinking models (qwen-thinking, deepseek-reasoner).

Ref: https://docs.sure.am/evals