### PR TITLE
fix(llm): revert KV cache quantization and explicit JSON mode

### DIFF
--- a/kubernetes/clusters/live/charts/ollama.yaml
+++ b/kubernetes/clusters/live/charts/ollama.yaml
@@ -22,7 +22,6 @@ controllers:
           OLLAMA_KEEP_ALIVE: "10m"
           OLLAMA_CONTEXT_LENGTH: "8192"
           OLLAMA_FLASH_ATTENTION: "1"
-          OLLAMA_KV_CACHE_TYPE: "q8_0"
           NVIDIA_VISIBLE_DEVICES: all
         resources:
           requests:

--- a/kubernetes/clusters/live/charts/sure.yaml
+++ b/kubernetes/clusters/live/charts/sure.yaml
@@ -76,6 +76,7 @@ controllers:
           LLM_CONTEXT_WINDOW: "8192"
           LLM_MAX_RESPONSE_TOKENS: "4096"
           OPENAI_REQUEST_TIMEOUT: "300"
+          LLM_JSON_MODE: "none"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
@@ -168,6 +169,7 @@ controllers:
           LLM_CONTEXT_WINDOW: "8192"
           LLM_MAX_RESPONSE_TOKENS: "4096"
           OPENAI_REQUEST_TIMEOUT: "300"
+          LLM_JSON_MODE: "none"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false

--- a/kubernetes/clusters/live/charts/sure.yaml
+++ b/kubernetes/clusters/live/charts/sure.yaml
@@ -76,7 +76,6 @@ controllers:
           LLM_CONTEXT_WINDOW: "8192"
           LLM_MAX_RESPONSE_TOKENS: "4096"
           OPENAI_REQUEST_TIMEOUT: "300"
-          LLM_JSON_MODE: "none"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
@@ -169,7 +168,6 @@ controllers:
           LLM_CONTEXT_WINDOW: "8192"
           LLM_MAX_RESPONSE_TOKENS: "4096"
           OPENAI_REQUEST_TIMEOUT: "300"
-          LLM_JSON_MODE: "none"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false


### PR DESCRIPTION
## Summary

- Remove `OLLAMA_KV_CACHE_TYPE: "q8_0"` from Ollama — KV cache quantization reduces attention precision, degrading structured JSON output quality (auto-categorization dropped from 97 to 35 modified)
- Remove `LLM_JSON_MODE: "none"` from both `web` and `worker` containers in Sure — the auto mode's failed strict attempt was implicitly priming the model to understand the expected JSON format before the successful none fallback; removing that step degraded categorization quality

## Test plan

- [ ] Flux reconciles Ollama HelmRelease on live cluster after merge
- [ ] Flux reconciles Sure HelmRelease on live cluster after merge
- [ ] Sure auto-categorization quality returns to ~97 modified