### PR TITLE
feat(sure): add SnapTrade OAuth client ID via ExternalSecret

### DIFF
--- a/kubernetes/clusters/live/charts/sure.yaml
+++ b/kubernetes/clusters/live/charts/sure.yaml
@@ -77,6 +77,12 @@ controllers:
           LLM_MAX_RESPONSE_TOKENS: "4096"
           OPENAI_REQUEST_TIMEOUT: "300"
           LLM_JSON_MODE: "none"
+          # SnapTrade — brokerage account connections
+          SNAPTRADE_OAUTH_CLIENT_ID:
+            valueFrom:
+              secretKeyRef:
+                name: sure-snaptrade-credentials
+                key: oauth-client-id
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false
@@ -170,6 +176,12 @@ controllers:
           LLM_MAX_RESPONSE_TOKENS: "4096"
           OPENAI_REQUEST_TIMEOUT: "300"
           LLM_JSON_MODE: "none"
+          # SnapTrade — brokerage account connections
+          SNAPTRADE_OAUTH_CLIENT_ID:
+            valueFrom:
+              secretKeyRef:
+                name: sure-snaptrade-credentials
+                key: oauth-client-id
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false

--- a/kubernetes/clusters/live/config/sure/kustomization.yaml
+++ b/kubernetes/clusters/live/config/sure/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - network-policy.yaml
   - garage-bucket.yaml
   - garage-key.yaml
+  - snaptrade-credentials.yaml

--- a/kubernetes/clusters/live/config/sure/snaptrade-credentials.yaml
+++ b/kubernetes/clusters/live/config/sure/snaptrade-credentials.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: sure-snaptrade-credentials
+  namespace: sure
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: sure-snaptrade-credentials
+  data:
+    - secretKey: oauth-client-id
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/sure/snaptrade-oauth-client-id


### PR DESCRIPTION
## Summary

- Add `ExternalSecret` manifest sourcing `SNAPTRADE_OAUTH_CLIENT_ID` from AWS SSM
- Wire secret into both `web` and `worker` containers
- Register in `kustomization.yaml`

## SSM parameter path

```
/homelab/kubernetes/<cluster_name>/sure/snaptrade-oauth-client-id
```

Populate before merging (see PR description for CLI command).

## After merge

1. Populate the SSM parameter (see below)
2. Flux reconciles → ExternalSecret creates `sure-snaptrade-credentials` → pods restart with env var
3. Go to **Settings → Providers → SnapTrade** in Sure UI → enter Client ID + Consumer Key
4. **Settings → Accounts → Connect Brokerage** → select Fidelity