### PR TITLE
feat(sure): allow egress to api.snaptrade.com for brokerage OAuth

### DIFF
--- a/kubernetes/clusters/live/config/sure/network-policy.yaml
+++ b/kubernetes/clusters/live/config/sure/network-policy.yaml
@@ -19,6 +19,24 @@ spec:
               protocol: TCP
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+# Permits Sure to reach the SnapTrade API for brokerage account OAuth and data sync.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: sure-snaptrade-egress
+  namespace: sure
+spec:
+  description: "Allow Sure egress to SnapTrade API (api.snaptrade.com:443)"
+  endpointSelector: { }
+  egress:
+    - toFQDNs:
+        - matchName: api.snaptrade.com
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:


### PR DESCRIPTION
## Summary

- Adds `sure-snaptrade-egress` CiliumNetworkPolicy allowing Sure pods to reach `api.snaptrade.com:443`
- Follows the same FQDN egress pattern as `sure-simplefin-egress`
- Fixes `Faraday::SSLError (peeraddr=(null))` on `start_oauth_connect` — Cilium was dropping the outbound TLS connection before handshake

## Root Cause

The `sure` namespace uses the `internal` network policy profile which blocks all external egress except DNS. Sure's SnapTrade integration POSTs to `api.snaptrade.com` during OAuth, which was silently dropped at the Cilium layer.

## Test plan

- [ ] Merge → Flux reconciles → CNP applied in `sure` namespace
- [ ] Click Add Account > SnapTrade in Sure UI — OAuth dialog should open instead of closing immediately
- [ ] Complete Fidelity account connection flow