### PR TITLE
fix(cnpg): route webhook PKI through cert-manager to fix caBundle rotation bug

### DIFF
--- a/kubernetes/platform/charts/cloudnative-pg.yaml
+++ b/kubernetes/platform/charts/cloudnative-pg.yaml
@@ -4,6 +4,14 @@ priorityClassName: platform
 crds:
   create: true
 replicaCount: 2
+# Disable operator-managed caBundle injection — cert-manager CA injector owns this.
+# The operator has a bug (upstream PR #9819, unmerged) where it injects the leaf cert
+# instead of the CA cert into caBundle, breaking webhook TLS after the first 90-day rotation.
+commonAnnotations:
+  cert-manager.io/inject-ca-from: cnpg-system/cnpg-webhook-cert
+additionalEnv:
+  - name: MANAGE_WEBHOOK_CONFIGURATIONS
+    value: "false"
 monitoring:
   podMonitorEnabled: true
   grafanaDashboard:

--- a/kubernetes/platform/config.yaml
+++ b/kubernetes/platform/config.yaml
@@ -46,10 +46,14 @@ spec:
       namespace: monitoring
       path: kubernetes/platform/config/monitoring
       dependsOn: [kube-prometheus-stack, canary-checker, external-secrets-stores]
+    - name: cnpg-pki
+      namespace: cnpg-system
+      path: kubernetes/platform/config/cnpg-pki
+      dependsOn: [cloudnative-pg, cert-manager, issuers]
     - name: database-config
       namespace: database
       path: ${cluster_path}/config/database
-      dependsOn: [cloudnative-pg, garage-config, canary-checker]
+      dependsOn: [cloudnative-pg, cnpg-pki, garage-config, canary-checker]
     - name: dragonfly-config
       namespace: cache
       path: kubernetes/platform/config/dragonfly

--- a/kubernetes/platform/config/cnpg-pki/issuer.yaml
+++ b/kubernetes/platform/config/cnpg-pki/issuer.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cert-manager.io/issuer_v1.json
+# Bootstrap issuer: creates the CNPG webhook CA via self-sign, then hands off to cnpg-ca-issuer.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: cnpg-selfsigned-issuer
+  namespace: cnpg-system
+spec:
+  selfSigned: { }
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cert-manager.io/certificate_v1.json
+# CA certificate for signing CNPG webhook TLS certs.
+# Long-lived (10y) since rotation requires re-injection into caBundle — cert-manager handles that automatically.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cnpg-webhook-ca
+  namespace: cnpg-system
+spec:
+  isCA: true
+  commonName: cnpg-webhook-ca
+  secretName: cnpg-webhook-ca-secret
+  duration: 87600h
+  renewBefore: 720h
+  issuerRef:
+    name: cnpg-selfsigned-issuer
+    kind: Issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cert-manager.io/issuer_v1.json
+# Issues webhook leaf certs signed by the CNPG webhook CA above.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: cnpg-ca-issuer
+  namespace: cnpg-system
+spec:
+  ca:
+    secretName: cnpg-webhook-ca-secret

--- a/kubernetes/platform/config/cnpg-pki/kustomization.yaml
+++ b/kubernetes/platform/config/cnpg-pki/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - issuer.yaml
+  - webhook-cert.yaml

--- a/kubernetes/platform/config/cnpg-pki/webhook-cert.yaml
+++ b/kubernetes/platform/config/cnpg-pki/webhook-cert.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cert-manager.io/certificate_v1.json
+# Webhook TLS certificate for the CNPG operator.
+# secretName matches the secret the operator mounts (cnpg-webhook-cert).
+# cert-manager populates ca.crt in the secret; the CA injector reads it via
+# the cert-manager.io/inject-ca-from annotation on the webhook configurations.
+# renewBefore (30d) keeps the cert fresh well before CNPG's 7-day expiry threshold,
+# preventing the operator from attempting its own (broken) renewal.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cnpg-webhook-cert
+  namespace: cnpg-system
+spec:
+  secretName: cnpg-webhook-cert
+  duration: 2160h
+  renewBefore: 720h
+  issuerRef:
+    name: cnpg-ca-issuer
+    kind: Issuer
+  dnsNames:
+    - cnpg-webhook-service.cnpg-system.svc
+    - cnpg-webhook-service.cnpg-system.svc.cluster.local
+  privateKey:
+    algorithm: ECDSA
+    size: 256


### PR DESCRIPTION
## Problem

CNPG operator v1.30.0 has a bug ([upstream PR #9819](https://github.com/cloudnative-pg/cloudnative-pg/pull/9819), filed Jan 2026, **still unmerged** after 5+ months) where the 90-day webhook cert rotation writes the server leaf cert into `caBundle` instead of the CA cert.

The relevant code in `pkg/certs/k8s.go`:
```go
// setupWebhooksCertificate passes webhookSecret (leaf cert) to inject functions
// but caBundle requires the CA cert — wrong variable
pki.injectPublicKeyIntoMutatingWebhook(ctx, kubeClient, webhookSecret) // BUG: should be caSecret

// Inside the inject function:
config.Webhooks[idx].ClientConfig.CABundle = tlsSecret.Data["tls.crt"] // injects leaf, not CA
```

This caused Flux `cluster-config` and `database-config` kustomizations to fail on live today at 02:51 UTC — the first cert rotation since cluster creation (~90 days ago). Backups have also been failing since 03:03 UTC.

## Solution

Route CNPG webhook PKI through cert-manager's CA injector, which correctly maintains `caBundle`:

1. **`config/cnpg-pki/`** — new Kustomization with:
   - Self-signed `Issuer` (bootstrap) → CA `Certificate` (`cnpg-webhook-ca`) → CA-backed `Issuer`
   - Webhook leaf `Certificate` targeting `secretName: cnpg-webhook-cert` (what the operator mounts), with `renewBefore: 720h` to always refresh 30 days before expiry — well ahead of CNPG's own 7-day renewal threshold, preventing the operator from attempting its broken renewal logic
2. **`charts/cloudnative-pg.yaml`** — two additions:
   - `MANAGE_WEBHOOK_CONFIGURATIONS=false` env var: disables the broken caBundle injection code path in the operator
   - `cert-manager.io/inject-ca-from: cnpg-system/cnpg-webhook-cert` annotation via `commonAnnotations`: cert-manager CA injector reads `ca.crt` from the cert secret and injects it into both webhook configurations correctly
3. **`config.yaml`** — adds `cnpg-pki` Kustomization (depends on `cloudnative-pg`, `cert-manager`, `issuers`) and adds it as a dependency of `database-config`

## Convergence path

On merge → Flux reconcile:
1. `cnpg-pki` reconciles: cert-manager creates CA + webhook cert in `cnpg-system`
2. `cloudnative-pg` HelmRelease updates: operator restarts with `MANAGE_WEBHOOK_CONFIGURATIONS=false` + `inject-ca-from` annotation on webhook configurations
3. cert-manager CA injector injects correct `ca.crt` into `caBundle` on both webhook configurations
4. `cluster-config` and `database-config` Flux kustomizations resume normal reconciliation
5. Scheduled backups resume

## References
- Upstream bug: cloudnative-pg/cloudnative-pg#9817
- Upstream fix PR (unmerged): cloudnative-pg/cloudnative-pg#9819