### PR TITLE
fix(cnpg): use annotation not label for cert-manager direct injection

### DIFF
--- a/kubernetes/platform/config/cnpg-pki/cnpg-ca-secret-label.yaml
+++ b/kubernetes/platform/config/cnpg-pki/cnpg-ca-secret-label.yaml
@@ -1,12 +1,13 @@
 ---
-# Label cnpg-ca-secret to allow cert-manager CA injector to read it.
-# The inject-ca-from-secret annotation (on both webhook configurations) requires this label.
-# prune: false on the cnpg-pki Kustomization ensures this label persists and the secret
-# is never deleted by Flux even if the Kustomization is removed.
+# Annotate cnpg-ca-secret to allow cert-manager CA injector to read it directly.
+# cert-manager v1.21+ checks secret.Annotations (not labels) for allow-direct-injection.
+# The inject-ca-from-secret annotation on both webhook configurations requires this.
+# prune: false on the cnpg-pki Kustomization ensures this annotation persists and the
+# secret is never deleted by Flux even if the Kustomization is removed.
 apiVersion: v1
 kind: Secret
 metadata:
   name: cnpg-ca-secret
   namespace: cnpg-system
-  labels:
+  annotations:
     cert-manager.io/allow-direct-injection: "true"


### PR DESCRIPTION
## Root cause

cert-manager v1.21+ checks `secret.Annotations` for `cert-manager.io/allow-direct-injection`, not `secret.Labels`. PR #1371 applied it as a label, so the CA injector refused every time with "Secret resource does not allow direct injection". The cert-manager-webhook-ca secret uses an annotation — confirmed by inspecting the live cluster.

## Fix

Change `cnpg-ca-secret-label.yaml` to apply `cert-manager.io/allow-direct-injection: "true"` as an annotation instead of a label. SSA field ownership transfers automatically on next Flux reconcile.

## Manual unblock

To restore webhooks immediately without waiting for GitOps:
1. Annotate (not label) `cnpg-ca-secret` in `cnpg-system` with `cert-manager.io/allow-direct-injection=true`
2. Re-trigger CA injector by removing and re-adding `cert-manager.io/inject-ca-from-secret` on both webhook configurations
