### PR TITLE
fix(papra): add GarageReferenceGrant + document S3 storage pattern

### DIFF
--- a/.claude/skills/deploy-app/SKILL.md
+++ b/.claude/skills/deploy-app/SKILL.md
@@ -124,6 +124,8 @@ Add to `kubernetes/platform/namespaces.yaml` inputs array:
 
 For PostgreSQL provisioning, see the [cnpg-database skill](../cnpg-database/SKILL.md).
 
+For Garage S3 storage, see **Section 3.8** below — the `access.network-policy.homelab/garage-s3` label alone is not sufficient.
+
 ### 3.3 Add to helm-charts.yaml
 
 Add to `kubernetes/platform/helm-charts.yaml` inputs array:
@@ -177,6 +179,84 @@ Renovate tracks versions.env entries automatically via inline `# renovate:` anno
 Create `kubernetes/platform/config/<app-name>/` for extra resources. See [references/file-templates.md](references/file-templates.md) for HTTPRoute, secret, and ExternalSecret templates. See [references/monitoring-patterns.md](references/monitoring-patterns.md) for Canary, PrometheusRule, and Grafana dashboard examples.
 
 For gateway routing and TLS, see the [gateway-routing skill](../gateway-routing/SKILL.md).
+
+### 3.8 Garage S3 Object Storage
+
+Garage S3 requires **three resources** across two locations. Missing any one causes an admission webhook denial.
+
+**Step 1: GarageBucket** — in the cluster config, app namespace, under `garage` namespace:
+```yaml
+# kubernetes/clusters/live/config/<app>/garage-bucket.yaml
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: <app>
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage
+```
+
+**Step 2: GarageKey** — in the cluster config, app namespace:
+```yaml
+# kubernetes/clusters/live/config/<app>/garage-key.yaml
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: <app>
+  namespace: <app>
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  neverExpires: true
+  bucketPermissions:
+    - bucketRef:
+        name: <app>
+        namespace: garage
+      read: true
+      write: true
+  secretTemplate:
+    name: <app>-s3-credentials
+```
+
+**Step 3: GarageReferenceGrant** — PLATFORM-level, must go in `kubernetes/platform/config/garage/`:
+```yaml
+# kubernetes/platform/config/garage/reference-grant-<app>.yaml
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: allow-<app>
+spec:
+  from:
+    - kind: GarageKey
+      namespace: <app>
+```
+
+Also register it in `kubernetes/platform/config/garage/kustomization.yaml`. Without this, the Garage admission webhook (`vgaragekey.kb.io`) will deny the GarageKey with `cross-namespace reference not permitted`.
+
+**Namespace label** (also required for network access):
+```yaml
+access.network-policy.homelab/garage-s3: "true"
+```
+
+**S3 env vars in the app** (GarageKey generates the `<app>-s3-credentials` secret automatically):
+```yaml
+S3_ACCESS_KEY_ID:
+  valueFrom:
+    secretKeyRef:
+      name: <app>-s3-credentials
+      key: access-key-id
+S3_SECRET_ACCESS_KEY:
+  valueFrom:
+    secretKeyRef:
+      name: <app>-s3-credentials
+      key: secret-access-key
+S3_BUCKET: <app>
+S3_REGION: garage
+S3_ENDPOINT: "http://${garage_s3_endpoint}"
+S3_FORCE_PATH_STYLE: "true"
+```
 
 ---
 

--- a/.claude/skills/deploy-app/references/file-templates.md
+++ b/.claude/skills/deploy-app/references/file-templates.md
@@ -297,3 +297,63 @@ resources:
 | Secrets | `secretName`, `existingSecret`, `auth.existingSecret` |
 
 Always check the specific chart's values.yaml or use `helm show values <chart>` for exact keys.
+
+---
+
+## Garage S3 Storage
+
+Three files required. See SKILL.md Section 3.8 for the full workflow.
+
+### GarageBucket (cluster config, garage namespace)
+
+```yaml
+# kubernetes/clusters/live/config/<app>/garage-bucket.yaml
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: <app>
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage
+```
+
+### GarageKey (cluster config, app namespace)
+
+```yaml
+# kubernetes/clusters/live/config/<app>/garage-key.yaml
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: <app>
+  namespace: <app>
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  neverExpires: true
+  bucketPermissions:
+    - bucketRef:
+        name: <app>
+        namespace: garage
+      read: true
+      write: true
+  secretTemplate:
+    name: <app>-s3-credentials
+```
+
+### GarageReferenceGrant (PLATFORM-level — kubernetes/platform/config/garage/)
+
+```yaml
+# kubernetes/platform/config/garage/reference-grant-<app>.yaml
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: allow-<app>
+spec:
+  from:
+    - kind: GarageKey
+      namespace: <app>
+```
+
+Register in `kubernetes/platform/config/garage/kustomization.yaml` resources list. Without this, the admission webhook denies the GarageKey.

--- a/kubernetes/platform/config/garage/CLAUDE.md
+++ b/kubernetes/platform/config/garage/CLAUDE.md
@@ -1,0 +1,42 @@
+# Garage Config - Claude Reference
+
+Platform-level Garage S3 object storage configuration.
+
+## Adding S3 Storage for a New App
+
+Three resources are required across two locations. Missing the `GarageReferenceGrant` causes an admission webhook denial:
+
+```
+GarageKey dry-run failed (Forbidden): admission webhook "vgaragekey.kb.io" denied the request:
+cross-namespace reference from GarageKey "<app>"/"<name>" to GarageCluster "garage"/"garage"
+is not permitted: create a GarageReferenceGrant in namespace "garage"
+```
+
+### Checklist
+
+| Resource | Location | Purpose |
+|----------|----------|---------|
+| `GarageBucket` | `clusters/live/config/<app>/garage-bucket.yaml` (namespace: `garage`) | Creates the bucket |
+| `GarageKey` | `clusters/live/config/<app>/garage-key.yaml` (namespace: `<app>`) | Generates S3 credentials secret |
+| `GarageReferenceGrant` | **this directory** `reference-grant-<app>.yaml` | Permits cross-namespace reference |
+
+### GarageReferenceGrant Template
+
+```yaml
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: allow-<app>
+spec:
+  from:
+    - kind: GarageKey
+      namespace: <app>
+```
+
+Add to `kustomization.yaml` resources list after creating the file.
+
+### Namespace Label (also required)
+
+```yaml
+access.network-policy.homelab/garage-s3: "true"
+```

--- a/kubernetes/platform/config/garage/kustomization.yaml
+++ b/kubernetes/platform/config/garage/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - reference-grant-tandoor.yaml
   - reference-grant-zipline.yaml
   - reference-grant-sure.yaml
+  - reference-grant-papra.yaml

--- a/kubernetes/platform/config/garage/reference-grant-papra.yaml
+++ b/kubernetes/platform/config/garage/reference-grant-papra.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: allow-papra
+spec:
+  from:
+    - kind: GarageKey
+      namespace: papra


### PR DESCRIPTION
## Summary

- Fixes `cluster-config` kustomization blocked by Garage admission webhook
- Documents the missing `GarageReferenceGrant` pattern so future app deployments don't hit the same issue

## Root Cause

`GarageKey` in the `papra` namespace references `GarageCluster` in the `garage` namespace. The Garage admission webhook (`vgaragekey.kb.io`) enforces cross-namespace access control via `GarageReferenceGrant`. This was missing from the initial implementation and from all skill/template documentation.

## Changes

**Fix:**
- `kubernetes/platform/config/garage/reference-grant-papra.yaml` — grants `papra` ns permission to reference the garage cluster
- `kubernetes/platform/config/garage/kustomization.yaml` — registers the grant

**Docs (prevent recurrence):**
- `deploy-app/SKILL.md` — new Section 3.8 covering the 3-resource Garage S3 pattern with explicit callout that `GarageReferenceGrant` is platform-level
- `deploy-app/references/file-templates.md` — copy-paste templates for all 3 resources
- `kubernetes/platform/config/garage/CLAUDE.md` — in-context checklist visible when working in that directory

## Test Plan

- [ ] `cluster-config` kustomization reconciles successfully (no more admission webhook error)
- [ ] `papra-s3-credentials` secret created in `papra` namespace by GarageKey controller
- [ ] Papra HelmRelease deploys and pod reaches Running state