### PR TITLE
fix(papra): use client_secret_post for Authelia token endpoint auth

### DIFF
--- a/.claude/skills/deploy-app/SKILL.md
+++ b/.claude/skills/deploy-app/SKILL.md
@@ -124,6 +124,8 @@ Add to `kubernetes/platform/namespaces.yaml` inputs array:
 
 For PostgreSQL provisioning, see the [cnpg-database skill](../cnpg-database/SKILL.md).
 
+For Garage S3 storage, see **Section 3.8** below — the `access.network-policy.homelab/garage-s3` label alone is not sufficient.
+
 ### 3.3 Add to helm-charts.yaml
 
 Add to `kubernetes/platform/helm-charts.yaml` inputs array:
@@ -177,6 +179,84 @@ Renovate tracks versions.env entries automatically via inline `# renovate:` anno
 Create `kubernetes/platform/config/<app-name>/` for extra resources. See [references/file-templates.md](references/file-templates.md) for HTTPRoute, secret, and ExternalSecret templates. See [references/monitoring-patterns.md](references/monitoring-patterns.md) for Canary, PrometheusRule, and Grafana dashboard examples.
 
 For gateway routing and TLS, see the [gateway-routing skill](../gateway-routing/SKILL.md).
+
+### 3.8 Garage S3 Object Storage
+
+Garage S3 requires **three resources** across two locations. Missing any one causes an admission webhook denial.
+
+**Step 1: GarageBucket** — in the cluster config, app namespace, under `garage` namespace:
+```yaml
+# kubernetes/clusters/live/config/<app>/garage-bucket.yaml
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: <app>
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage
+```
+
+**Step 2: GarageKey** — in the cluster config, app namespace:
+```yaml
+# kubernetes/clusters/live/config/<app>/garage-key.yaml
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: <app>
+  namespace: <app>
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  neverExpires: true
+  bucketPermissions:
+    - bucketRef:
+        name: <app>
+        namespace: garage
+      read: true
+      write: true
+  secretTemplate:
+    name: <app>-s3-credentials
+```
+
+**Step 3: GarageReferenceGrant** — PLATFORM-level, must go in `kubernetes/platform/config/garage/`:
+```yaml
+# kubernetes/platform/config/garage/reference-grant-<app>.yaml
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: allow-<app>
+spec:
+  from:
+    - kind: GarageKey
+      namespace: <app>
+```
+
+Also register it in `kubernetes/platform/config/garage/kustomization.yaml`. Without this, the Garage admission webhook (`vgaragekey.kb.io`) will deny the GarageKey with `cross-namespace reference not permitted`.
+
+**Namespace label** (also required for network access):
+```yaml
+access.network-policy.homelab/garage-s3: "true"
+```
+
+**S3 env vars in the app** (GarageKey generates the `<app>-s3-credentials` secret automatically):
+```yaml
+S3_ACCESS_KEY_ID:
+  valueFrom:
+    secretKeyRef:
+      name: <app>-s3-credentials
+      key: access-key-id
+S3_SECRET_ACCESS_KEY:
+  valueFrom:
+    secretKeyRef:
+      name: <app>-s3-credentials
+      key: secret-access-key
+S3_BUCKET: <app>
+S3_REGION: garage
+S3_ENDPOINT: "http://${garage_s3_endpoint}"
+S3_FORCE_PATH_STYLE: "true"
+```
 
 ---
 

--- a/.claude/skills/deploy-app/references/file-templates.md
+++ b/.claude/skills/deploy-app/references/file-templates.md
@@ -297,3 +297,63 @@ resources:
 | Secrets | `secretName`, `existingSecret`, `auth.existingSecret` |
 
 Always check the specific chart's values.yaml or use `helm show values <chart>` for exact keys.
+
+---
+
+## Garage S3 Storage
+
+Three files required. See SKILL.md Section 3.8 for the full workflow.
+
+### GarageBucket (cluster config, garage namespace)
+
+```yaml
+# kubernetes/clusters/live/config/<app>/garage-bucket.yaml
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: <app>
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage
+```
+
+### GarageKey (cluster config, app namespace)
+
+```yaml
+# kubernetes/clusters/live/config/<app>/garage-key.yaml
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: <app>
+  namespace: <app>
+spec:
+  clusterRef:
+    name: garage
+    namespace: garage
+  neverExpires: true
+  bucketPermissions:
+    - bucketRef:
+        name: <app>
+        namespace: garage
+      read: true
+      write: true
+  secretTemplate:
+    name: <app>-s3-credentials
+```
+
+### GarageReferenceGrant (PLATFORM-level — kubernetes/platform/config/garage/)
+
+```yaml
+# kubernetes/platform/config/garage/reference-grant-<app>.yaml
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: allow-<app>
+spec:
+  from:
+    - kind: GarageKey
+      namespace: <app>
+```
+
+Register in `kubernetes/platform/config/garage/kustomization.yaml` resources list. Without this, the admission webhook denies the GarageKey.

--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -399,7 +399,7 @@ configMap:
             - code
           grant_types:
             - authorization_code
-          token_endpoint_auth_method: client_secret_basic
+          token_endpoint_auth_method: client_secret_post
 
   regulation:
     max_retries: 3

--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -390,7 +390,7 @@ configMap:
           require_pkce: true
           pkce_challenge_method: S256
           redirect_uris:
-            - https://papra.${internal_domain}/api/auth/callback/authelia
+            - https://papra.${internal_domain}/api/auth/oauth2/callback/authelia
           scopes:
             - openid
             - profile

--- a/kubernetes/clusters/live/charts/papra.yaml
+++ b/kubernetes/clusters/live/charts/papra.yaml
@@ -53,7 +53,7 @@ controllers:
                 key: client-secret
           AUTH_PROVIDERS_CUSTOMS:
             dependsOn: PAPRA_OIDC_CLIENT_SECRET
-            value: '[{"providerId":"authelia","providerName":"Authelia","type":"oidc","clientId":"papra","clientSecret":"$(PAPRA_OIDC_CLIENT_SECRET)","discoveryUrl":"https://auth.${external_domain}/.well-known/openid-configuration","scopes":["openid","profile","email"]}]'
+            value: '[{"providerId":"authelia","providerName":"Authelia","type":"oidc","clientId":"papra","clientSecret":"$(PAPRA_OIDC_CLIENT_SECRET)","discoveryUrl":"https://auth.${external_domain}/.well-known/openid-configuration","scopes":["openid","profile","email"],"pkce":true}]'
 
           # S3 document storage via Garage
           DOCUMENT_STORAGE_DRIVER: s3

--- a/kubernetes/clusters/live/charts/papra.yaml
+++ b/kubernetes/clusters/live/charts/papra.yaml
@@ -70,7 +70,8 @@ controllers:
           DOCUMENT_STORAGE_S3_BUCKET_NAME: papra
           DOCUMENT_STORAGE_S3_REGION: garage
           DOCUMENT_STORAGE_S3_ENDPOINT: "http://${garage_s3_endpoint}"
-          DOCUMENT_STORAGE_S3_FORCE_PATH_STYLE: "true"
+          # forcePathStyle must be a native boolean — set via papra.config.yaml ConfigMap
+          # because Papra 0.9.x schema rejects the string "true" from env vars
 
           # Email via SMTP — same relay credentials as Authelia
           EMAILS_DRIVER: smtp
@@ -169,6 +170,13 @@ persistence:
     existingClaim: papra-data
     globalMounts:
       - path: /app/app-data
+  config:
+    type: configMap
+    name: papra-config
+    globalMounts:
+      - path: /app/app-data/papra.config.yaml
+        subPath: papra.config.yaml
+        readOnly: true
   tmp:
     type: emptyDir
     globalMounts:

--- a/kubernetes/clusters/live/config/papra/kustomization.yaml
+++ b/kubernetes/clusters/live/config/papra/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - papra-smtp-credentials.yaml
   - garage-bucket.yaml
   - garage-key.yaml
+  - papra-config.yaml

--- a/kubernetes/clusters/live/config/papra/papra-config.yaml
+++ b/kubernetes/clusters/live/config/papra/papra-config.yaml
@@ -1,0 +1,16 @@
+---
+# Native YAML boolean for forcePathStyle — avoids string coercion bug in Papra 0.9.x
+# where DOCUMENT_STORAGE_S3_FORCE_PATH_STYLE env var fails validation ("Expected boolean, received string").
+# c12 config loader merges this file with env vars; env vars take precedence for all other settings.
+# Remove once Papra upgrades figue/valibot schema to coerce booleans from env var strings.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: papra-config
+  namespace: papra
+data:
+  papra.config.yaml: |
+    documentsStorage:
+      drivers:
+        s3:
+          forcePathStyle: true

--- a/kubernetes/platform/config/garage/CLAUDE.md
+++ b/kubernetes/platform/config/garage/CLAUDE.md
@@ -1,0 +1,42 @@
+# Garage Config - Claude Reference
+
+Platform-level Garage S3 object storage configuration.
+
+## Adding S3 Storage for a New App
+
+Three resources are required across two locations. Missing the `GarageReferenceGrant` causes an admission webhook denial:
+
+```
+GarageKey dry-run failed (Forbidden): admission webhook "vgaragekey.kb.io" denied the request:
+cross-namespace reference from GarageKey "<app>"/"<name>" to GarageCluster "garage"/"garage"
+is not permitted: create a GarageReferenceGrant in namespace "garage"
+```
+
+### Checklist
+
+| Resource | Location | Purpose |
+|----------|----------|---------|
+| `GarageBucket` | `clusters/live/config/<app>/garage-bucket.yaml` (namespace: `garage`) | Creates the bucket |
+| `GarageKey` | `clusters/live/config/<app>/garage-key.yaml` (namespace: `<app>`) | Generates S3 credentials secret |
+| `GarageReferenceGrant` | **this directory** `reference-grant-<app>.yaml` | Permits cross-namespace reference |
+
+### GarageReferenceGrant Template
+
+```yaml
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: allow-<app>
+spec:
+  from:
+    - kind: GarageKey
+      namespace: <app>
+```
+
+Add to `kustomization.yaml` resources list after creating the file.
+
+### Namespace Label (also required)
+
+```yaml
+access.network-policy.homelab/garage-s3: "true"
+```

--- a/kubernetes/platform/config/garage/kustomization.yaml
+++ b/kubernetes/platform/config/garage/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - reference-grant-tandoor.yaml
   - reference-grant-zipline.yaml
   - reference-grant-sure.yaml
+  - reference-grant-papra.yaml

--- a/kubernetes/platform/config/garage/reference-grant-papra.yaml
+++ b/kubernetes/platform/config/garage/reference-grant-papra.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageReferenceGrant
+metadata:
+  name: allow-papra
+spec:
+  from:
+    - kind: GarageKey
+      namespace: papra


### PR DESCRIPTION
## Problem

SSO flow fails at token exchange after successful PKCE auth code flow:

```
The request was determined to be using 'token_endpoint_auth_method' method 'client_secret_post',
however the OAuth 2.0 client registration does not allow this method. The registered client
with id 'papra' is configured to only support 'token_endpoint_auth_method' method 'client_secret_basic'.
```

better-auth sends client credentials in the POST body (`client_secret_post`) rather than in the `Authorization` header (`client_secret_basic`). Our Authelia client registration had the wrong method.

## Fix

Change `token_endpoint_auth_method: client_secret_basic` → `client_secret_post` for the papra OIDC client in authelia.yaml.