### PR TITLE
feat(sure): register Sure as Authelia OIDC client

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -400,6 +400,25 @@ configMap:
           grant_types:
             - authorization_code
           token_endpoint_auth_method: client_secret_basic
+        - client_id: sure
+          client_name: Sure
+          client_secret:
+            path: /secrets/sure-oidc-client-secret/client-secret
+          public: false
+          authorization_policy: two_factor
+          require_pkce: false
+          consent_mode: implicit
+          redirect_uris:
+            - https://sure.${internal_domain}/auth/authelia/callback
+          scopes:
+            - openid
+            - profile
+            - email
+          response_types:
+            - code
+          grant_types:
+            - authorization_code
+          token_endpoint_auth_method: client_secret_basic
 
   regulation:
     max_retries: 3
@@ -427,4 +446,5 @@ secret:
     tandoor-oidc-client-secret: { }
     jellyseerr-oidc-client-secret: { }
     papra-oidc-client-secret: { }
+    sure-oidc-client-secret: { }
     authelia-smtp-credentials: { }


### PR DESCRIPTION
## Summary

- Adds `sure` to Authelia's `identity_providers.oidc.clients` list
- Mounts `sure-oidc-client-secret` as an `additionalSecret` so Authelia can read the client credential from disk
- Uses `consent_mode: implicit` to skip the consent screen (single-user personal finance app)
- Redirect URI: `https://sure.internal.tomnowak.work/auth/authelia/callback`

## After merge

Once Authelia reconciles, configure the in-app SSO provider in Sure:

1. **Sure → Settings → SSO Providers → Add SSO Provider**
2. Fill in:
   - **Strategy**: OpenID Connect
   - **Name**: `authelia`
   - **Issuer URL**: `https://auth.ionfury.tv`
   - **Client ID**: `sure`
   - **Client Secret**: retrieve via `kubectl get secret -n sure sure-oidc-client-secret -o jsonpath='{.data.client-secret}' | base64 -d`
3. The callback URL will be `https://sure.internal.tomnowak.work/auth/authelia/callback` — matches what's registered in Authelia ✓

> **Note**: If Sure's in-app SSO callback path doesn't match (e.g., uses a different provider name), update the `redirect_uris` in `authelia.yaml` accordingly.

## Test plan

- [ ] Authelia reconciles cleanly (no `secret not found` errors in logs)
- [ ] Sure SSO provider configured via in-app UI with provider name `authelia`
- [ ] Login via Authelia redirects to Sure successfully

https://claude.ai/code/session_015N7o6eYxsctYgX2Tz41Yhc