### PR TITLE
feat(sure): enable MCP endpoint for Claude integration

### DIFF
--- a/kubernetes/clusters/live/charts/sure.yaml
+++ b/kubernetes/clusters/live/charts/sure.yaml
@@ -83,6 +83,13 @@ controllers:
               secretKeyRef:
                 name: sure-snaptrade-credentials
                 key: oauth-client-id
+          # MCP server — enables /mcp for external AI assistants (e.g. Claude)
+          MCP_API_TOKEN:
+            valueFrom:
+              secretKeyRef:
+                name: sure-mcp-credentials
+                key: mcp-api-token
+          MCP_USER_EMAIL: "ionfury@gmail.com"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false

--- a/kubernetes/clusters/live/config/sure/kustomization.yaml
+++ b/kubernetes/clusters/live/config/sure/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - garage-bucket.yaml
   - garage-key.yaml
   - snaptrade-credentials.yaml
+  - sure-mcp-credentials.yaml

--- a/kubernetes/clusters/live/config/sure/sure-mcp-credentials.yaml
+++ b/kubernetes/clusters/live/config/sure/sure-mcp-credentials.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sure-mcp-credentials
+  namespace: sure
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: mcp-api-token
+    secret-generator.v1.mittwald.de/length: "32"
+    secret-generator.v1.mittwald.de/encoding: base64
+data: { }


### PR DESCRIPTION
## Summary

- Creates `sure-mcp-credentials` Secret (secret-generator, 32-byte base64 random token) in the `sure` namespace
- Wires `MCP_API_TOKEN` + `MCP_USER_EMAIL` into the Sure web container, activating the `/mcp` JSON-RPC endpoint
- Enables Claude Code (and other external AI assistants) to query Sure financial data directly

## How it works

Sure's `/mcp` endpoint implements Model Context Protocol (JSON-RPC 2.0). Once these env vars are set, the endpoint accepts `Authorization: Bearer <token>` and exposes tools: `get_transactions`, `get_accounts`, `get_holdings`, `get_balance_sheet`, `get_income_statement`, `import_bank_statement`, `search_family_files`.

## Post-merge setup

After deployment, retrieve the generated token and wire up local Claude Code config:

```bash
TOKEN=$(kubectl --context live get secret sure-mcp-credentials -n sure -o jsonpath='{.data.mcp-api-token}' | base64 -d)
echo "Token: $TOKEN"
```

Then add to `~/.claude/settings.local.json`:

```json
{
  "mcpServers": {
    "sure": {
      "type": "http",
      "url": "https://sure.internal.tomnowak.work/mcp",
      "headers": {
        "Authorization": "Bearer <TOKEN>"
      }
    }
  }
}
```

## Test plan

- [ ] Secret `sure-mcp-credentials` exists in `sure` namespace with `mcp-api-token` key populated
- [ ] Sure pods restart and are healthy
- [ ] `curl -X POST https://sure.internal.tomnowak.work/mcp -H "Authorization: Bearer <token>" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}' | jq .` returns 200 with server info

https://claude.ai/code/session_01XPwcFU9shJSLvKjQGVqDaQ