### PR TITLE
fix(sure): add missing OIDC env vars and fix redirect URI

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -409,7 +409,7 @@ configMap:
           require_pkce: false
           consent_mode: implicit
           redirect_uris:
-            - https://sure.${internal_domain}/auth/authelia/callback
+            - https://sure.${internal_domain}/auth/openid_connect/callback
           scopes:
             - openid
             - profile

--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -400,6 +400,25 @@ configMap:
           grant_types:
             - authorization_code
           token_endpoint_auth_method: client_secret_basic
+        - client_id: sure
+          client_name: Sure
+          client_secret:
+            path: /secrets/sure-oidc-client-secret/client-secret
+          public: false
+          authorization_policy: two_factor
+          require_pkce: false
+          consent_mode: implicit
+          redirect_uris:
+            - https://sure.${internal_domain}/auth/authelia/callback
+          scopes:
+            - openid
+            - profile
+            - email
+          response_types:
+            - code
+          grant_types:
+            - authorization_code
+          token_endpoint_auth_method: client_secret_basic
 
   regulation:
     max_retries: 3
@@ -427,4 +446,5 @@ secret:
     tandoor-oidc-client-secret: { }
     jellyseerr-oidc-client-secret: { }
     papra-oidc-client-secret: { }
+    sure-oidc-client-secret: { }
     authelia-smtp-credentials: { }

--- a/kubernetes/clusters/live/charts/sure.yaml
+++ b/kubernetes/clusters/live/charts/sure.yaml
@@ -52,6 +52,9 @@ controllers:
               secretKeyRef:
                 name: sure-oidc-client-secret
                 key: client-secret
+          OIDC_REDIRECT_URI: "https://sure.${internal_domain}/auth/openid_connect/callback"
+          OIDC_BUTTON_LABEL: "Sign in with Authelia"
+          OIDC_BUTTON_ICON: "shield"
           APP_DOMAIN: "sure.${internal_domain}"
           # Garage S3 — Active Storage backend
           ACTIVE_STORAGE_SERVICE: generic_s3


### PR DESCRIPTION
## Summary

- Adds `OIDC_BUTTON_LABEL` and `OIDC_REDIRECT_URI` env vars to Sure — both required for `ProviderLoader` to register the `openid_connect` OmniAuth strategy (empty label causes silent skip)
- Corrects Authelia `sure` client redirect URI from `/auth/authelia/callback` → `/auth/openid_connect/callback` to match OmniAuth's strategy name

## Root cause

`config/auth.yml` inside the Sure container requires `OIDC_BUTTON_LABEL` (non-empty) and `OIDC_REDIRECT_URI` to consider the provider valid. Without them, Sure logs `Skipping OIDC provider 'openid_connect' - missing required configuration` and registers zero OmniAuth strategies — no login button, no `/auth/openid_connect` route.

## Test plan

- [ ] Sure pods restart and logs show provider loaded (no "Skipping OIDC provider" warning)  
- [ ] "Sign in with Authelia" button appears on `/sessions/new`
- [ ] `/auth/openid_connect` route exists (no 404)
- [ ] OAuth flow completes — Authelia redirects back to `/auth/openid_connect/callback` successfully

https://claude.ai/code/session_015N7o6eYxsctYgX2Tz41Yhc