### PR TITLE
feat(longhorn): add snapshot-frequent weekly RecurringJob

### DIFF
--- a/kubernetes/platform/config/longhorn/kustomization.yaml
+++ b/kubernetes/platform/config/longhorn/kustomization.yaml
@@ -6,6 +6,7 @@ kind: Kustomization
 resources:
   - prometheus-rules.yaml
   - recurring-jobs/filesystem-trim-daily.yaml
+  - recurring-jobs/snapshot-frequent.yaml
   - routes/
   - storage-classes/fast-ephemeral.yaml
   - storage-classes/fast.yaml

--- a/kubernetes/platform/config/longhorn/recurring-jobs/snapshot-frequent.yaml
+++ b/kubernetes/platform/config/longhorn/recurring-jobs/snapshot-frequent.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/longhorn.io/recurringjob_v1beta2.json
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: &name snapshot-frequent
+spec:
+  name: *name
+  cron: "0 20 * * 5"
+  task: snapshot
+  concurrency: 1
+  retain: 2
+  groups:
+    - *name
+  labels:
+    jobname: *name


### PR DESCRIPTION
## Why

The `snapshot-frequent` recurring-job group is referenced by both `slow` and `fast` StorageClasses (`recurringJobSelector`) and all volumes provisioned from them carry `recurring-job-group.longhorn.io/snapshot-frequent: enabled`. However, the backing RecurringJob CR was never created (or was previously removed), so no snapshots are actually taken.

Without a recent snapshot checkpoint, a Longhorn replica rebuild must scan the entire volume head from the beginning. For the 10 TiB `media/media-library` HDD volume this measured ~13 hours. A weekly snapshot bounds that scan to the delta since the last snapshot — measured churn ~0.57 GiB/week → rebuild time drops to ~1-2 minutes.

## What

Add `kubernetes/platform/config/longhorn/recurring-jobs/snapshot-frequent.yaml`:

- `spec.task: snapshot`
- `spec.groups: ["snapshot-frequent"]` — binds to existing volume labels
- `spec.cron: "0 20 * * 5"` — Friday 20:00 (lands before Saturday 02:00 maintenance-window reboots)
- `spec.retain: 2`
- `spec.concurrency: 1`

Register the new file in `kubernetes/platform/config/longhorn/kustomization.yaml`. No StorageClass changes (immutable; selectors already correct).

## Why weekly/retain-2 (vs the removed daily job)

Commit b15dfc41 (2026-05-16) deliberately removed a daily/retain-7 snapshot job because it consumed ~3.6 TB across SSDs with no backup value (CNPG WAL PITR + Velero already cover backups). This job is weekly/retain-2 — approximately 1/28th the churn-cost — and its sole purpose is rebuild-checkpointing, not backup.

Note on `autoCleanupSystemGeneratedSnapshot: true` (set in `charts/longhorn.yaml`): Longhorn auto-generates a "system" snapshot at rebuild sync-point, but with auto-cleanup enabled these are deleted immediately after use — they do not persist as checkpoints. A user-created recurring snapshot (this job) is therefore required to bound rebuild scan cost.

## Blast radius — volumes that will be snapshotted

The `snapshot-frequent` group label is present on **both** the `slow` (HDD) and `fast` (SSD) StorageClass selectors, so this job snapshots ALL volumes carrying the label. The table below lists every affected PVC as of 2026-07-18.

### HDD-backed volumes (slow StorageClass)

| PVC | Namespace | Size |
|-----|-----------|------|
| `media-library` | `media` | 10240 Gi (10 TiB) |
| `paperless-media` | `paperless` | 50 Gi |
| `immich-library` | `immich` | 500 Gi |

### SSD-backed volumes (fast StorageClass)

> **SSD-tier implication vs b15dfc41**: The prior daily/retain-7 job was removed specifically because of SSD snapshot accumulation with no backup value. This job is weekly/retain-2. The snapshot overhead on SSDs is bounded to 2 snapshots per volume at any time; at typical config-volume churn rates this is negligible (<100 MiB/volume). Reviewer should accept or ask to narrow scope (e.g. a slow-only version of the group).

| PVC | Namespace | Size |
|-----|-----------|------|
| `ollama` | `ai` | 100 Gi |
| `open-webui` | `ai` | 5 Gi |
| `df-dragonfly-0/1/2` | `cache` | 2 Gi each |
| `immich-database-1/2/3` | `database` | 10 Gi each |
| `platform-1/2/3` | `database` | 20 Gi each |
| `factorio` | `factorio` | 10 Gi |
| `data-garage-0/1/2` | `garage` | 100 Gi each |
| `metadata-garage-0/1/2` | `garage` | 10 Gi each |
| `immich-machine-learning` | `immich` | 10 Gi |
| `bazarr` | `media` | 2 Gi |
| `houndarr` | `media` | 1 Gi |
| `jellyfin-cache` | `media` | 20 Gi |
| `jellyfin-config` | `media` | 20 Gi |
| `jellyseerr` | `media` | 5 Gi |
| `jfa-go` | `media` | 1 Gi |
| `prowlarr` | `media` | 2 Gi |
| `qbittorrent` | `media` | 5 Gi |
| `radarr` | `media` | 5 Gi |
| `radarr4k` | `media` | 5 Gi |
| `recyclarr` | `media` | 1 Gi |
| `sabnzbd` | `media` | 2 Gi |
| `sonarr` | `media` | 5 Gi |
| `sonarr4k` | `media` | 5 Gi |
| `tdarr-config` | `media` | 5 Gi |
| `tdarr-server` | `media` | 1 Gi |
| `minecraft-backups` | `minecraft` | 10 Gi |
| `minecraft-data` | `minecraft` | 20 Gi |
| `prometheus-kube-prometheus-stack-db-...` | `monitoring` | 50 Gi |
| `storage-grafana-loki-single-binary-0` | `monitoring` | 50 Gi |
| `storage-loki-0` | `monitoring` | 50 Gi |
| `paperless-data` | `paperless` | 10 Gi |
| `satisfactory-data` | `satisfactory` | 30 Gi |
| `valheim` | `valheim` | 10 Gi |
| `vaultwarden` | `vaultwarden` | 1 Gi |

## Validation

`task k8s:validate` passed (YAML lint, ResourceSet expansion, Helm templating, API deprecation check — no errors).

## Test plan

- [ ] Merge to main; pipeline builds and promotes artifact to integration
- [ ] Verify `kubectl --context integration get recurringjobs.longhorn.io -n longhorn-system snapshot-frequent` exists and `Ready`
- [ ] After promotion to live: verify same on live cluster
- [ ] After next Friday 20:00: verify snapshot appears on `media/media-library` volume in Longhorn UI

https://claude.ai/code/session_017AayjJQPH1WYnZqx9vbUTN