### PR TITLE
fix(jellyfin): opt out of ambient mesh to dodge connect_originate leak

### DIFF
--- a/kubernetes/clusters/live/charts/jellyfin.yaml
+++ b/kubernetes/clusters/live/charts/jellyfin.yaml
@@ -6,6 +6,18 @@ controllers:
     type: deployment
 
     pod:
+      # TEMPORARY WORKAROUND for istio/istio#60074 (+ #60767): the external
+      # gateway's ambient connect_originate HTTP/2 pool leaks HBONE streams to
+      # Jellyfin and never closes them, wedging playback after client-aborted
+      # Range requests (Infuse seeking/buffering). No config-level fix exists
+      # upstream and only a gateway restart clears it. Opting Jellyfin out of
+      # ambient makes the gateway route directly to the pod (plain cluster, no
+      # HBONE), sidestepping the leak. Cost: no ambient mTLS on the
+      # gateway->Jellyfin hop. Jellyfin is public, gateway-TLS-terminated, and
+      # self-authenticating, and no AuthorizationPolicy targets its workload.
+      # REMOVE this label once #60074 is fixed and the fix is deployed.
+      labels:
+        istio.io/dataplane-mode: none
       runtimeClassName: nvidia
       nodeSelector:
         nvidia.com/gpu.present: "true"


### PR DESCRIPTION
## Summary

Removes **only Jellyfin** from the Istio ambient mesh (pod label `istio.io/dataplane-mode: none`) to work around the recurring gateway outage where the external gateway's ambient `connect_originate` HTTP/2 pool **leaks HBONE streams to Jellyfin and never closes them** (upstream istio/istio#60074, #60767). No config-level fix exists upstream and only a gateway restart clears it.

Each occurrence has correlated with video streaming via Infuse — the client-aborted HTTP **Range** requests are the exact trigger in #60074.

## Live evidence

Captured during an active recurrence: gateway replica `external-istio-…-fg256` held **29 frozen `rq_active`** streams to the Jellyfin HBONE endpoint `172.18.0.55:15008`, with `rq_total` frozen and `rq_error=0 / rq_timeout=0`, across a 12s sample — while node2's ztunnel and the Jellyfin pod were healthy (serving `jellyfin-exporter` east-west normally). Source-side Envoy stream leak, not a backend fault.

## The change

```yaml
controllers:
  jellyfin:
    pod:
      labels:
        istio.io/dataplane-mode: none
```

The `media` namespace stays ambient; only Jellyfin opts out. The gateway then routes directly to `pod-IP:8096` via a plain Envoy cluster instead of originating an HBONE tunnel → the `connect_originate` leak cannot occur for Jellyfin.

## Trade-off

- **Lost:** ambient mTLS on the gateway→Jellyfin hop (in-cluster plaintext unless Cilium transparent encryption is enabled); ztunnel L4 telemetry/identity for the Jellyfin workload.
- **Not lost (verified):** no `AuthorizationPolicy` targets the Jellyfin workload (`media-app-auth` is gateway-scoped and explicitly excludes Jellyfin); Jellyfin's own app auth is unchanged; the gateway still TLS-terminates `watch.${external_domain}`; Cilium network policy still enforces (CNI-level); source-side `istio_requests_total` from the gateway still feeds the new gateway alerts.

Acceptable exchange for a public, gateway-terminated, self-authenticating service — and it fully sidesteps the bug rather than bounding or reacting to it.

## Removal trigger

Temporary. The label and its comment reference #60074; **remove once the upstream fix lands and is deployed.**

## Related

- Detection side: #1399 (gateway data-plane alerts) adds `GatewayZeroResponseCode`, which pages on this failure mode.

## Validation

- `task k8s:validate` passes (36 charts templated, `pod.labels` accepted by the app-template schema, no deprecated APIs).

https://claude.ai/code/session_0167gop2aNfdjn6mMNNARKWC