### PR TITLE
fix(longhorn): suspend RecurringJobs mutating media rebuild source chain

### DIFF
--- a/kubernetes/platform/config/longhorn/kustomization.yaml
+++ b/kubernetes/platform/config/longhorn/kustomization.yaml
@@ -5,8 +5,20 @@ kind: Kustomization
 
 resources:
   - prometheus-rules.yaml
-  - recurring-jobs/filesystem-trim-daily.yaml
-  - recurring-jobs/snapshot-frequent.yaml
+  # TEMPORARILY SUSPENDED 2026-07-22 (incident): filesystem-trim's daily coalesce
+  # mutates the source snapshot chain of the media-library volume
+  # (pvc-cd6ba345-906b-4a8a-be87-bbc8328b3219) mid-rebuild, tearing down and
+  # restarting the Longhorn replica rebuild from scratch every day at ~09:48 UTC.
+  # The rebuild needs ~50-60h uninterrupted on HDD. Restore this line once the
+  # volume is back to robustness=healthy (both replicas RW).
+  # - recurring-jobs/filesystem-trim-daily.yaml
+  # HELD OUT OF LIVE 2026-07-22 (incident): #1398 added this job but it never
+  # promoted (cluster is under lockdown, live frozen at rev 0.1.1073). The media
+  # volume still carries the `snapshot-frequent` group label, so promoting this
+  # job now would start taking snapshots on that volume mid-rebuild and add a
+  # second source-chain mutator, risking another rebuild reset. Re-introduce only
+  # after the media rebuild completes AND the job is re-scoped off the HDD tier.
+  # - recurring-jobs/snapshot-frequent.yaml
   - routes/
   - storage-classes/fast-ephemeral.yaml
   - storage-classes/fast.yaml


### PR DESCRIPTION
## Problem

The media-library volume (`pvc-cd6ba345-906b-4a8a-be87-bbc8328b3219`) is rebuilding a degraded replica on node43 (~8.94 TiB, HDD-sourced, ~50 MB/s → ~50–60h). A troubleshooter root-caused a **daily rebuild-reset loop**:

**5 Whys**
1. Rebuild progress reset (40%→8%): target replica `r-bb99cdf8` torn down mid-sync (`failed to handle data server … error=EOF` → `Closing replica` → `Deleting instance`), restarted from scratch.
2. Torn down because the engine detected the **source snapshot chain changed** mid-rebuild.
3. Chain changed because a daily job coalesced/pruned a snapshot on the source (`Replacing volume-snap-…eb1b8502.img with …fc369f56.img`).
4. A chain change aborts the rebuild because Longhorn's sync-agent is **not incremental across chain changes** — it discards the partial replica and restarts (no checkpoint).
5. **Root:** `filesystem-trim-daily` (cron `0 4 * * *`); its async coalesce lands ~09:48 UTC. Rebuild needs ~50–60h → can never outrun a daily reset. Confirmed loop: resets `2026-07-21T09:48:42Z` **and** `2026-07-22T09:49:32Z`.

## Change

Comment both RecurringJobs out of the longhorn config kustomization (`prune: true` → Flux removes `filesystem-trim-daily` from live):

- **`filesystem-trim-daily`** — temporary suspend; restore once media volume is `robustness=healthy`.
- **`snapshot-frequent`** (#1398) — held out of live. It never promoted (lockdown, live frozen at rev `0.1.1073`); promoting it now would start snapshots on the same volume via its dangling group label = a **second** chain mutator. Re-add after rebuild + re-scoped off HDD tier.

Build verified: `kubectl kustomize` now emits **zero** RecurringJobs.

## ⚠️ Promotion caveat

The OCI pipeline promotes **main HEAD**, so merging + lifting lockdown ships the whole current main→live delta, not just this diff. Confirm what else is queued (e.g. #1398, canary-label change) is OK to ship before promoting.

https://claude.ai/code/session_01XUnN6zRrh7fyAVdBgv3NDc