### PR TITLE
fix(longhorn): raise longGRPCTimeOut to 96h for large HDD volume rebuild

### DIFF
--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -25,6 +25,13 @@ defaultSettings:
   storageMinimalAvailablePercentage: 10
   autoCleanupSystemGeneratedSnapshot: true
   snapshotMaxCount: 3
+  # TEMPORARY 2026-07-23 (incident): raise the long-gRPC deadline from the 86400s
+  # (24h) default to 96h. The media-library volume replica rebuild (~8.9 TiB on
+  # HDD at ~50 MB/s ≈ 57h) exceeds the 24h file-sync RPC deadline, failing with
+  # DeadlineExceeded and restarting from scratch every 24h — it can never finish.
+  # Revert to the default (drop this line) once the rebuild reaches
+  # robustness=healthy. Value is in seconds.
+  longGRPCTimeOut: 345600
 csi:
   attacherReplicaCount: ${default_replica_count}
   provisionerReplicaCount: ${default_replica_count}

--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -25,12 +25,6 @@ defaultSettings:
   storageMinimalAvailablePercentage: 10
   autoCleanupSystemGeneratedSnapshot: true
   snapshotMaxCount: 3
-  # TEMPORARY 2026-07-23 (incident): raise the long-gRPC deadline from the 86400s
-  # (24h) default to 96h. The media-library volume replica rebuild (~8.9 TiB on
-  # HDD at ~50 MB/s ≈ 57h) exceeds the 24h file-sync RPC deadline, failing with
-  # DeadlineExceeded and restarting from scratch every 24h — it can never finish.
-  # Revert to the default (drop this line) once the rebuild reaches
-  # robustness=healthy. Value is in seconds.
   longGRPCTimeOut: 345600
 csi:
   attacherReplicaCount: ${default_replica_count}


### PR DESCRIPTION
## Real root cause (corrects the earlier trim theory in #1404)

The media-library volume (`pvc-cd6ba345-906b-4a8a-be87-bbc8328b3219`) replica rebuild on node43 has reset **three days running** (07-21, 07-22, 07-23), each at ~09:48 UTC. #1404 suspended `filesystem-trim-daily` on the theory that its snapshot coalesce mutated the source chain — but the reset recurred with trim gone (0 RecurringJobs). The failure log gives the actual cause:

```
level=error "Failed to rebuild replica 172.18.3.218"
  rpc error: code = DeadlineExceeded
  desc = failed to sync files [...volume-snap-95ad8dc3.img ActualSize:9251342344192...]
  context deadline exceeded
→ "Removing failed rebuilding replica" → "Start rebuilding ..." (restart from 0)
```

- Rebuild syncs ~8.9 TiB (one 8.41 TiB snapshot) on Seagate HDD at ~45–50 MB/s → **~57h**.
- `long-grpc-timeout` default = **86400s = 24h** → the file-sync gRPC is killed at 24h.
- **57h needed > 24h deadline ⇒ can never finish.** The ~09:48 daily reset drifting +40s/day is the fixed 24h timer restarting later each cycle, not a wall-clock job.

## Change

Add `longGRPCTimeOut: 345600` (96h) to `longhorn.yaml` defaultSettings. Gives the ~57h rebuild ~39h of margin to complete once. Global, temporary ceiling-raise (only allows long ops to run longer before abort; doesn't slow anything).

## Revert plan

Once the media volume is `robustness=healthy`, drop this line (back to 86400 default) **and** restore `filesystem-trim-daily` (#1404). Both are temporary incident measures.

## ⚠️ Promotion caveat

Same as #1404 — promoting ships the current main→live delta, not just this diff. Confirm queued commits are OK before promoting.

https://claude.ai/code/session_01XUnN6zRrh7fyAVdBgv3NDc