### PR TITLE
feat(paperless): allow egress to Gmail IMAP for mail ingestion

### DIFF
--- a/kubernetes/clusters/live/config/paperless/imap-egress.yaml
+++ b/kubernetes/clusters/live/config/paperless/imap-egress.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+# Allows paperless-ngx to reach Gmail IMAP for mail-based document ingestion.
+# The internal profile only permits egress on port 443; IMAPS uses port 993.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: paperless-imap-egress
+  namespace: paperless
+spec:
+  description: "Allow paperless-ngx IMAP egress to Gmail (port 993)"
+  endpointSelector: { }
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "993"
+              protocol: TCP

--- a/kubernetes/clusters/live/config/paperless/kustomization.yaml
+++ b/kubernetes/clusters/live/config/paperless/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - paperless-oidc-client-secret-replica.yaml
   - paperless-secret.yaml
   - canary.yaml
+  - imap-egress.yaml


### PR DESCRIPTION
## Summary

- Adds `CiliumNetworkPolicy/paperless-imap-egress` in the `paperless` namespace permitting egress on **TCP/993** (IMAPS) to the `world` entity
- Registers the policy in the paperless cluster config `kustomization.yaml` so Flux deploys it automatically after merge

## Why

Paperless-ngx supports fetching documents from an email inbox (Gmail IMAP) as an ingestion source. The `paperless` namespace uses the `internal` network profile which allows only DNS egress; TCP/993 (IMAP over SSL) is blocked by Cilium, preventing the Gmail IMAP connection from being established.

## Two-part policy design

**Egress rule (TCP/993):** The CNP adds a `toEntities: world` + `toPorts: 993/TCP` rule. This is identical to the pattern used by `authelia-smtp-egress` for port 465 — a dedicated supplemental CNP layered on top of the namespace profile.

**DNS:** No additional DNS rule is required. The cluster-wide `baseline-dns-egress` CCNP already permits all pods to reach CoreDNS on UDP/53 with `matchPattern: "*"`, which covers resolution of `imap.gmail.com` and its Google IP pool. The `toFQDNs` approach is not used in this repo; the `world` entity correctly covers all rotating Google IPs without hardcoding addresses.

**Scope:** IMAP (993) only. SMTP (465/587) is intentionally excluded — outbound mail delivery is handled by a scanner on a separate network, not by the cluster.

## Test plan

- [ ] `task k8s:validate` passes (Valid: 505, Invalid: 0, Errors: 0) — confirmed before commit
- [ ] After merge → Flux promotion pipeline converges on live cluster
- [ ] Hubble confirms TCP/993 egress from `paperless` namespace to `world` is FORWARDED
- [ ] Paperless mail inbox polling connects successfully to `imap.gmail.com:993`

https://claude.ai/code/session_01TYMMyMgp1v4K2GgXbPkDsn