### PR TITLE
feat(paperless): add Tika + Gotenberg for office document ingestion

### DIFF
--- a/kubernetes/clusters/dev/apps/kustomization.yaml
+++ b/kubernetes/clusters/dev/apps/kustomization.yaml
@@ -11,4 +11,6 @@ configMapGenerator:
     namespace: flux-system
     behavior: create
     files:
+      - gotenberg.yaml=paperless/gotenberg.yaml
       - paperless.yaml=paperless/values.yaml
+      - tika.yaml=paperless/tika.yaml

--- a/kubernetes/clusters/dev/apps/paperless/gotenberg.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/gotenberg.yaml
@@ -1,0 +1,62 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+# https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+controllers:
+  gotenberg:
+    type: deployment
+    replicas: 1
+
+    pod:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+
+    containers:
+      app:
+        image:
+          repository: gotenberg/gotenberg
+          # renovate: datasource=docker depName=gotenberg packageName=gotenberg/gotenberg
+          tag: "${gotenberg_version}"
+        args:
+          - gotenberg
+          - --chromium-disable-javascript=true
+          - --chromium-allow-list=file:///tmp/.*
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 256Mi
+          limits:
+            memory: 1Gi
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /health
+                port: 3000
+              periodSeconds: 30
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /health
+                port: 3000
+              periodSeconds: 10
+
+service:
+  app:
+    controller: gotenberg
+    ports:
+      http:
+        port: 3000

--- a/kubernetes/clusters/dev/apps/paperless/tika.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/tika.yaml
@@ -1,0 +1,57 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+# https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+controllers:
+  tika:
+    type: deployment
+    replicas: 1
+
+    pod:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 35002
+        runAsGroup: 35002
+        seccompProfile:
+          type: RuntimeDefault
+
+    containers:
+      app:
+        image:
+          repository: apache/tika
+          # renovate: datasource=docker depName=apache-tika packageName=apache/tika
+          tag: "${tika_version}"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 512Mi
+          limits:
+            memory: 2Gi
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /tika
+                port: 9998
+              periodSeconds: 30
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /tika
+                port: 9998
+              periodSeconds: 10
+
+service:
+  app:
+    controller: tika
+    ports:
+      http:
+        port: 9998

--- a/kubernetes/clusters/dev/apps/paperless/values.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/values.yaml
@@ -72,6 +72,10 @@ controllers:
           PAPERLESS_REDIS:
             dependsOn: DRAGONFLY_PASSWORD
             value: "redis://:$(DRAGONFLY_PASSWORD)@dragonfly.cache.svc.cluster.local:6379"
+          # Tika + Gotenberg — office document ingestion (.docx/.xlsx/.odt/.pptx)
+          PAPERLESS_TIKA_ENABLED: "true"
+          PAPERLESS_TIKA_ENDPOINT: "http://tika.paperless.svc.cluster.local:9998"
+          PAPERLESS_TIKA_GOTENBERG_ENDPOINT: "http://gotenberg.paperless.svc.cluster.local:3000"
           PAPERLESS_DATA_DIR: "/data"
           PAPERLESS_MEDIA_ROOT: "/media"
         securityContext:

--- a/kubernetes/clusters/dev/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/dev/resourcesets/helm-charts.yaml
@@ -22,6 +22,20 @@ spec:
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
       dependsOn: [cloudnative-pg, secret-generator]
+    - name: gotenberg
+      namespace: paperless
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: []
+    - name: tika
+      namespace: paperless
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: []
   resourcesTemplate: |
     ---
     apiVersion: source.toolkit.fluxcd.io/v1

--- a/kubernetes/clusters/dev/versions.env
+++ b/kubernetes/clusters/dev/versions.env
@@ -5,3 +5,7 @@
 
 # renovate: datasource=docker depName=paperless-ngx packageName=ghcr.io/paperless-ngx/paperless-ngx
 paperless_ngx_version=2.20.15
+# renovate: datasource=docker depName=gotenberg packageName=gotenberg/gotenberg
+gotenberg_version=8.34.0
+# renovate: datasource=docker depName=apache-tika packageName=apache/tika
+tika_version=3.3.1.0

--- a/kubernetes/clusters/live/charts/gotenberg.yaml
+++ b/kubernetes/clusters/live/charts/gotenberg.yaml
@@ -1,0 +1,62 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+# https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+controllers:
+  gotenberg:
+    type: deployment
+    replicas: 1
+
+    pod:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+
+    containers:
+      app:
+        image:
+          repository: gotenberg/gotenberg
+          # renovate: datasource=docker depName=gotenberg packageName=gotenberg/gotenberg
+          tag: "${gotenberg_version}"
+        args:
+          - gotenberg
+          - --chromium-disable-javascript=true
+          - --chromium-allow-list=file:///tmp/.*
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 256Mi
+          limits:
+            memory: 1Gi
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /health
+                port: 3000
+              periodSeconds: 30
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /health
+                port: 3000
+              periodSeconds: 10
+
+service:
+  app:
+    controller: gotenberg
+    ports:
+      http:
+        port: 3000

--- a/kubernetes/clusters/live/charts/kustomization.yaml
+++ b/kubernetes/clusters/live/charts/kustomization.yaml
@@ -28,9 +28,11 @@ configMapGenerator:
       - minecraft.yaml
       - ollama.yaml
       - open-webui.yaml
+      - gotenberg.yaml
       - papra.yaml
       - paperless.yaml
       - prowlarr.yaml
+      - tika.yaml
       - qbittorrent.yaml
       - radarr.yaml
       - redlib.yaml

--- a/kubernetes/clusters/live/charts/paperless.yaml
+++ b/kubernetes/clusters/live/charts/paperless.yaml
@@ -91,6 +91,10 @@ controllers:
           PAPERLESS_SOCIALACCOUNT_PROVIDERS:
             dependsOn: PAPERLESS_OIDC_CLIENT_SECRET
             value: '{"openid_connect": {"OAUTH_PKCE_ENABLED": true, "APPS": [{"provider_id": "authelia", "name": "Authelia", "client_id": "paperless", "secret": "$(PAPERLESS_OIDC_CLIENT_SECRET)", "settings": {"server_url": "https://auth.${external_domain}/.well-known/openid-configuration"}}]}}'
+          # Tika + Gotenberg — office document ingestion (.docx/.xlsx/.odt/.pptx)
+          PAPERLESS_TIKA_ENABLED: "true"
+          PAPERLESS_TIKA_ENDPOINT: "http://tika.paperless.svc.cluster.local:9998"
+          PAPERLESS_TIKA_GOTENBERG_ENDPOINT: "http://gotenberg.paperless.svc.cluster.local:3000"
           # Storage paths
           PAPERLESS_DATA_DIR: "/data"
           PAPERLESS_MEDIA_ROOT: "/media"

--- a/kubernetes/clusters/live/charts/tika.yaml
+++ b/kubernetes/clusters/live/charts/tika.yaml
@@ -1,0 +1,57 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+# https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+controllers:
+  tika:
+    type: deployment
+    replicas: 1
+
+    pod:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 35002
+        runAsGroup: 35002
+        seccompProfile:
+          type: RuntimeDefault
+
+    containers:
+      app:
+        image:
+          repository: apache/tika
+          # renovate: datasource=docker depName=apache-tika packageName=apache/tika
+          tag: "${tika_version}"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 512Mi
+          limits:
+            memory: 2Gi
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /tika
+                port: 9998
+              periodSeconds: 30
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /tika
+                port: 9998
+              periodSeconds: 10
+
+service:
+  app:
+    controller: tika
+    ports:
+      http:
+        port: 9998

--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -232,6 +232,20 @@ spec:
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
       dependsOn: [cloudnative-pg, secret-generator]
+    - name: gotenberg
+      namespace: paperless
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: []
+    - name: tika
+      namespace: paperless
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: []
     - name: homepage
       namespace: homepage
       chart:

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -56,6 +56,10 @@ bazarr_version=1.6.0
 yq_version=4.53.3
 # renovate: datasource=docker depName=paperless-ngx packageName=ghcr.io/paperless-ngx/paperless-ngx
 paperless_ngx_version=2.20.15
+# renovate: datasource=docker depName=gotenberg packageName=gotenberg/gotenberg
+gotenberg_version=8.34.0
+# renovate: datasource=docker depName=apache-tika packageName=apache/tika
+tika_version=3.3.1.0
 # renovate: datasource=docker depName=vaultwarden packageName=vaultwarden/server
 vaultwarden_version=1.36.0-alpine
 # renovate: datasource=docker depName=homepage packageName=ghcr.io/gethomepage/homepage


### PR DESCRIPTION
## Summary

Adds Apache Tika and Gotenberg as separate Deployments in the `paperless` namespace, enabling paperless-ngx to ingest office documents (.docx, .xlsx, .odt, .pptx) that currently fail silently.

- Two new app-template HelmReleases: `gotenberg` and `tika`, both in the `paperless` namespace
- `PAPERLESS_TIKA_ENABLED: "true"`, `PAPERLESS_TIKA_ENDPOINT`, and `PAPERLESS_TIKA_GOTENBERG_ENDPOINT` wired to cluster-local Service DNS names
- Renovate annotations on both image tags (Gotenberg: `8.34.0`, Tika: `3.3.1.0`) for automatic updates
- Applied consistently to both `live` and `dev` clusters

## Deployment pattern

Separate Deployments + Services rather than sidecars — matches the repo's existing pattern for companion services (e.g. `jellyfin-exporter` alongside `jellyfin`, `jfa-go` alongside `jellyfin`). Tika and Gotenberg expose HTTP endpoints with no shared state or filesystem with paperless, so there is no reason to co-locate them in the same pod.

## Images chosen

| Service | Image | Tag | Rationale |
|---------|-------|-----|-----------|
| Gotenberg | `gotenberg/gotenberg` | `8.34.0` | Current stable; official docker-compose.postgres-tika.yml uses `8.34` |
| Tika | `apache/tika` | `3.3.1.0` | Latest stable; 4.0.0 is in beta/snapshot only |

Gotenberg is configured with `--chromium-disable-javascript=true` and `--chromium-allow-list=file:///tmp/.*` per the official paperless-ngx docker compose reference.

## Security context

- Gotenberg: `runAsUser: 1000`, `readOnlyRootFilesystem: true`
- Tika: `runAsUser: 35002` (image default non-root user), `readOnlyRootFilesystem: false` (Tika extracts to temp paths inside the container)
- Both: `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`

## kubesearch / reference sources

- [phybros/k3s-cluster — helm-release-tika.yaml](https://github.com/phybros/k3s-cluster/blob/main/cluster/apps/default/paperless-ngx/helm-release-tika.yaml) — separate HelmRelease approach (app-template)
- [phybros/k3s-cluster — helm-release-gotenberg.yaml](https://github.com/phybros/k3s-cluster/blob/main/cluster/apps/default/paperless-ngx/helm-release-gotenberg.yaml) — Gotenberg with JS disabled and `/tmp` allowlist
- [paperless-ngx/paperless-ngx — docker-compose.postgres-tika.yml](https://github.com/paperless-ngx/paperless-ngx/blob/dev/docker/compose/docker-compose.postgres-tika.yml) — canonical env var names and Gotenberg flags
- [kubesearch.dev — paperless-ngx app-template](https://kubesearch.dev/hr/bjw-s-labs.github.io-helm-charts-app-template-paperless-ngx) — community deployments index

## Test plan

- [ ] `task k8s:validate` passes (verified: 151 resources, 0 errors, no deprecated APIs)
- [ ] `task k8s:validate-live` passes (verified: 151 resources in resourcesets, 207 manifests, 0 errors)
- [ ] `task renovate:validate` passes (verified: Config validated successfully)
- [ ] After merge: `kubectl -n paperless get deploy` shows `gotenberg`, `tika`, and `paperless` all Running
- [ ] Upload a .docx to paperless-ngx UI and verify it is indexed with full text extraction

https://claude.ai/code/session_01TYMMyMgp1v4K2GgXbPkDsn