### PR TITLE
feat(paperless): add filename format and duplicate-deletion env vars

### DIFF
--- a/kubernetes/clusters/dev/apps/paperless/values.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/values.yaml
@@ -72,6 +72,13 @@ controllers:
           PAPERLESS_REDIS:
             dependsOn: DRAGONFLY_PASSWORD
             value: "redis://:$(DRAGONFLY_PASSWORD)@dragonfly.cache.svc.cluster.local:6379"
+          # Filename format — organise media into year/correspondent/date-title hierarchy
+          # NOTE: changing PAPERLESS_FILENAME_FORMAT on an existing instance causes paperless
+          # to re-file every document in the media volume on next startup (high I/O on the
+          # 'slow' storage-class PVC). Plan maintenance accordingly.
+          PAPERLESS_FILENAME_FORMAT: "{created_year}/{correspondent}/{created_year}-{created_month}-{created_day} {title}"
+          PAPERLESS_FILENAME_FORMAT_REMOVE_NONE: "true"
+          PAPERLESS_CONSUMER_DELETE_DUPLICATES: "true"
           PAPERLESS_DATA_DIR: "/data"
           PAPERLESS_MEDIA_ROOT: "/media"
         securityContext:

--- a/kubernetes/clusters/dev/apps/paperless/values.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/values.yaml
@@ -79,6 +79,13 @@ controllers:
           PAPERLESS_FILENAME_FORMAT: "{created_year}/{correspondent}/{created_year}-{created_month}-{created_day} {title}"
           PAPERLESS_FILENAME_FORMAT_REMOVE_NONE: "true"
           PAPERLESS_CONSUMER_DELETE_DUPLICATES: "true"
+          # Barcode / ASN — QR-code labelling of physical documents (ASN#####) read at
+          # consume time; PATCH-T separator pages split batch scans. ZXING backend is
+          # required (default pyzbar misreads small QR codes; needs paperless >= 1.14).
+          # Inert until physical ASN labels are applied to scanned documents.
+          PAPERLESS_CONSUMER_ENABLE_BARCODES: "true"
+          PAPERLESS_CONSUMER_ENABLE_ASN_BARCODE: "true"
+          PAPERLESS_CONSUMER_BARCODE_SCANNER: "ZXING"
           PAPERLESS_DATA_DIR: "/data"
           PAPERLESS_MEDIA_ROOT: "/media"
         securityContext:

--- a/kubernetes/clusters/live/charts/paperless.yaml
+++ b/kubernetes/clusters/live/charts/paperless.yaml
@@ -98,6 +98,13 @@ controllers:
           PAPERLESS_FILENAME_FORMAT: "{created_year}/{correspondent}/{created_year}-{created_month}-{created_day} {title}"
           PAPERLESS_FILENAME_FORMAT_REMOVE_NONE: "true"
           PAPERLESS_CONSUMER_DELETE_DUPLICATES: "true"
+          # Barcode / ASN — QR-code labelling of physical documents (ASN#####) read at
+          # consume time; PATCH-T separator pages split batch scans. ZXING backend is
+          # required (default pyzbar misreads small QR codes; needs paperless >= 1.14).
+          # Inert until physical ASN labels are applied to scanned documents.
+          PAPERLESS_CONSUMER_ENABLE_BARCODES: "true"
+          PAPERLESS_CONSUMER_ENABLE_ASN_BARCODE: "true"
+          PAPERLESS_CONSUMER_BARCODE_SCANNER: "ZXING"
           # Storage paths
           PAPERLESS_DATA_DIR: "/data"
           PAPERLESS_MEDIA_ROOT: "/media"

--- a/kubernetes/clusters/live/charts/paperless.yaml
+++ b/kubernetes/clusters/live/charts/paperless.yaml
@@ -91,6 +91,13 @@ controllers:
           PAPERLESS_SOCIALACCOUNT_PROVIDERS:
             dependsOn: PAPERLESS_OIDC_CLIENT_SECRET
             value: '{"openid_connect": {"OAUTH_PKCE_ENABLED": true, "APPS": [{"provider_id": "authelia", "name": "Authelia", "client_id": "paperless", "secret": "$(PAPERLESS_OIDC_CLIENT_SECRET)", "settings": {"server_url": "https://auth.${external_domain}/.well-known/openid-configuration"}}]}}'
+          # Filename format — organise media into year/correspondent/date-title hierarchy
+          # NOTE: changing PAPERLESS_FILENAME_FORMAT on an existing instance causes paperless
+          # to re-file every document in the media volume on next startup (high I/O on the
+          # 'slow' storage-class PVC). Plan maintenance accordingly.
+          PAPERLESS_FILENAME_FORMAT: "{created_year}/{correspondent}/{created_year}-{created_month}-{created_day} {title}"
+          PAPERLESS_FILENAME_FORMAT_REMOVE_NONE: "true"
+          PAPERLESS_CONSUMER_DELETE_DUPLICATES: "true"
           # Storage paths
           PAPERLESS_DATA_DIR: "/data"
           PAPERLESS_MEDIA_ROOT: "/media"


### PR DESCRIPTION
## Summary

Adds three quality-of-life environment variables to paperless-ngx:

- `PAPERLESS_FILENAME_FORMAT: "{created_year}/{correspondent}/{created_year}-{created_month}-{created_day} {title}"` — organises the media volume into a `year/correspondent/date title` hierarchy instead of flat storage
- `PAPERLESS_FILENAME_FORMAT_REMOVE_NONE: "true"` — suppresses `None` path segments when correspondent or other fields are unset
- `PAPERLESS_CONSUMER_DELETE_DUPLICATES: "true"` — automatically discard re-ingested files that match an existing document fingerprint

Applied to both `live` and `dev` clusters. Independent of PR #1407 (Tika/Gotenberg).

## Operational caveat — I/O churn on first startup after merge

**Setting `PAPERLESS_FILENAME_FORMAT` on an instance with existing documents triggers paperless to re-file the entire media volume on its next startup.** Every stored document will be moved from its current path to the new `year/correspondent/date title` layout. On the `slow` storage-class PVC this will produce sustained I/O until complete (proportional to media volume size). The pod will start and serve requests during this process, but expect elevated disk activity. No data is lost — this is a rename/move operation only.

Plan maintenance accordingly: consider scheduling the merge during a low-traffic window or monitoring Longhorn I/O metrics (`longhorn_volume_actual_size_bytes`, `longhorn_volume_read_iops`, `longhorn_volume_write_iops`) during convergence.

## Test plan

- [ ] `task k8s:validate` passes (verified: no errors, no deprecated APIs)
- [ ] `task k8s:validate-live` passes (verified: 0 errors)
- [ ] After merge: `kubectl -n paperless describe pod` shows the three new env vars present
- [ ] Observe paperless logs on first pod restart for file-move activity
- [ ] After re-filing completes, confirm media volume still accessible and documents browsable in UI

https://claude.ai/code/session_01TYMMyMgp1v4K2GgXbPkDsn

---

## Update: ASN barcode detection added
Also enables ASN (Archive Serial Number) barcode/QR labelling of physical documents:
- `PAPERLESS_CONSUMER_ENABLE_BARCODES`, `PAPERLESS_CONSUMER_ENABLE_ASN_BARCODE`, `PAPERLESS_CONSUMER_BARCODE_SCANNER: ZXING`
- ZXING backend required (default pyzbar misreads small QR codes; paperless >= 1.14)
- Inert until physical ASN labels are applied to scanned documents
