### PR TITLE
fix(home-assistant): stop injecting prometheus LLAT into pod, unblocking startup

### DIFF
--- a/kubernetes/clusters/live/charts/home-assistant.yaml
+++ b/kubernetes/clusters/live/charts/home-assistant.yaml
@@ -29,11 +29,6 @@ controllers:
               secretKeyRef:
                 name: hass-db-credentials
                 key: uri
-          HASS_PROMETHEUS_TOKEN:
-            valueFrom:
-              secretKeyRef:
-                name: hass-prometheus-token
-                key: token
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false


### PR DESCRIPTION
## Summary

- **Root cause**: The HA pod spec had `HASS_PROMETHEUS_TOKEN` sourced via `secretKeyRef` from `hass-prometheus-token`. That secret is populated by an ExternalSecret that reads the Home Assistant Long-Lived Access Token from AWS SSM — but the LLAT can only be created in the HA UI **after** HA is running. This is a chicken-and-egg deadlock: the pod can't start without the secret, and the secret can't exist until the pod starts.
- **Why it is wrong by design**: Home Assistant Core does not consume any Prometheus token as an environment variable. The `prometheus:` integration serves `/api/prometheus` and requires the **caller** (Prometheus/ServiceMonitor) to present the LLAT as a bearer token. The token belongs only to the `serviceMonitor.app.endpoints[].bearerTokenSecret` reference, never to the HA container itself.
- **Fix**: Remove the `HASS_PROMETHEUS_TOKEN` env entry (5 lines) from the HA container spec. The `env:` map is not left empty — `HASS_RECORDER_DB_URL` from `hass-db-credentials` remains. The ServiceMonitor `bearerTokenSecret` reference is untouched and correct.
- **ExternalSecret and ServiceMonitor**: Left in place. The `hass-prometheus-token` ExternalSecret will remain in `SecretSyncedError` until the LLAT is manually created post-deploy — this is an acceptable documented deviation that only degrades scraping, not HA startup.

## Test plan

- [ ] Validate: `task k8s:validate` — passed green (36 charts templated, no deprecated APIs)
- [ ] Verify on live cluster: HA pod transitions from `CreateContainerConfigError` to `Running`
- [ ] Confirm only `hass-db-credentials` is a hard startup dependency (already syncs via kubernetes-replicator)
- [ ] Confirm ServiceMonitor `bearerTokenSecret` still references `hass-prometheus-token` (scraping degrades until LLAT is created, not a blocker)

https://claude.ai/code/session_01SLajhrZwVC3ERfnd8W5gAT