### PR TITLE
feat(gateway): proxy UniFi Network and Protect via internal gateway

### DIFF
--- a/kubernetes/platform/config.yaml
+++ b/kubernetes/platform/config.yaml
@@ -38,6 +38,10 @@ spec:
       namespace: istio-gateway
       path: kubernetes/platform/config/gateway
       dependsOn: [istiod]
+    - name: unifi-config
+      namespace: istio-gateway
+      path: kubernetes/platform/config/unifi
+      dependsOn: [istiod, canary-checker]
     - name: oauth2-proxy-config
       namespace: oauth2-proxy
       path: kubernetes/platform/config/oauth2-proxy

--- a/kubernetes/platform/config/unifi/canary.yaml
+++ b/kubernetes/platform/config/unifi/canary.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/canaries.flanksource.com/canary_v1.json
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: http-check-unifi-network
+spec:
+  schedule: "@every 1m"
+  http:
+    - name: unifi-network-gateway-health
+      url: https://network.${internal_domain}
+      # UniFi serves an SPA at root and may redirect to the login/manage path.
+      responseCodes: [200, 302, 307]
+      maxSSLExpiry: 7
+      thresholdMillis: 5000
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/canaries.flanksource.com/canary_v1.json
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: http-check-unifi-protect
+spec:
+  schedule: "@every 1m"
+  http:
+    - name: unifi-protect-gateway-health
+      url: https://protect.${internal_domain}
+      responseCodes: [200, 302, 307]
+      maxSSLExpiry: 7
+      thresholdMillis: 5000

--- a/kubernetes/platform/config/unifi/destinationrule.yaml
+++ b/kubernetes/platform/config/unifi/destinationrule.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/networking.istio.io/destinationrule_v1.json
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: unifi-network
+spec:
+  host: unifi-network.egress.local
+  trafficPolicy:
+    tls:
+      # Originate TLS toward the self-signed UniFi backend. The gateway already
+      # terminated the client's TLS with the internal wildcard cert; here we
+      # re-encrypt hop-by-hop. insecureSkipVerify accepts the self-signed cert.
+      mode: SIMPLE
+      insecureSkipVerify: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/networking.istio.io/destinationrule_v1.json
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: unifi-protect
+spec:
+  host: unifi-protect.egress.local
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      insecureSkipVerify: true

--- a/kubernetes/platform/config/unifi/httproute.yaml
+++ b/kubernetes/platform/config/unifi/httproute.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: unifi-network
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "UniFi Network"
+    gethomepage.dev/group: "Network"
+    gethomepage.dev/icon: "unifi.svg"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: istio-gateway
+  hostnames:
+    - "network.${internal_domain}"
+  rules:
+    - backendRefs:
+        # Route to the mesh-external UniFi Network host defined by the
+        # ServiceEntry of the same name. DestinationRule originates TLS.
+        - group: networking.istio.io
+          kind: Hostname
+          name: unifi-network.egress.local
+          port: 443
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: unifi-protect
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "UniFi Protect"
+    gethomepage.dev/group: "Network"
+    gethomepage.dev/icon: "unifi.svg"
+spec:
+  parentRefs:
+    - name: internal
+      namespace: istio-gateway
+  hostnames:
+    - "protect.${internal_domain}"
+  rules:
+    - backendRefs:
+        - group: networking.istio.io
+          kind: Hostname
+          name: unifi-protect.egress.local
+          port: 443

--- a/kubernetes/platform/config/unifi/kustomization.yaml
+++ b/kubernetes/platform/config/unifi/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - serviceentry.yaml
+  - destinationrule.yaml
+  - httproute.yaml
+  - canary.yaml

--- a/kubernetes/platform/config/unifi/serviceentry.yaml
+++ b/kubernetes/platform/config/unifi/serviceentry.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/networking.istio.io/serviceentry_v1.json
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: unifi-network
+spec:
+  # Synthetic mesh-external host referenced by the HTTPRoute backendRef.
+  # Not resolved via DNS: resolution=STATIC routes straight to the endpoint IP.
+  hosts:
+    - unifi-network.egress.local
+  location: MESH_EXTERNAL
+  resolution: STATIC
+  ports:
+    - number: 443
+      name: https
+      protocol: HTTPS
+  endpoints:
+    # UniFi Network controller (UDM) on the LAN, self-signed HTTPS.
+    - address: 192.168.1.1
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/networking.istio.io/serviceentry_v1.json
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: unifi-protect
+spec:
+  hosts:
+    - unifi-protect.egress.local
+  location: MESH_EXTERNAL
+  resolution: STATIC
+  ports:
+    - number: 443
+      name: https
+      protocol: HTTPS
+  endpoints:
+    # UniFi Protect NVR on the LAN, self-signed HTTPS.
+    - address: 192.168.1.40


### PR DESCRIPTION
## What

Proxy the UniFi **Network** controller (`192.168.1.1`) and **Protect** NVR (`192.168.1.40`) through the Istio **internal** gateway:

| Service | New URL | Backend |
|---------|---------|---------|
| UniFi Network | `network.${internal_domain}` | `https://192.168.1.1` |
| UniFi Protect | `protect.${internal_domain}` | `https://192.168.1.40` |

Gives valid HTTPS (internal wildcard cert) + clean DNS in place of the raw self-signed LAN IPs.

## How

New `kubernetes/platform/config/unifi/` subsystem, wired into `config.yaml` (`unifi-config`, `dependsOn: [istiod, canary-checker]`, ns `istio-gateway`). Per backend:

- **ServiceEntry** — `MESH_EXTERNAL`, `resolution: STATIC` → LAN IP, port 443/HTTPS.
- **DestinationRule** — TLS origination (`mode: SIMPLE`, `insecureSkipVerify: true`) so the gateway re-encrypts to the self-signed UniFi endpoint after terminating the client's TLS with the internal wildcard cert.
- **HTTPRoute** — attaches to the `internal` gateway, routes via `kind: Hostname` backendRef (Istio 1.30 external-host routing).
- **Canary** — 1m gateway health check (lenient `200/302/307`, since UniFi redirects to login).

## Why no other changes

- **Network policy**: `istio-gateway` egress already allows `world:443` — covers both LAN backends. No change.
- **TLS cert**: covered by the `*.${internal_domain}` internal wildcard. No change.
- **DNS**: covered by wildcard `*.${internal_domain}` → internal ingress IP. No change.

## Validation

`task k8s:validate` → exit 0 (ResourceSet expansion, kustomize build, schema, deprecation scan all pass).

https://claude.ai/code/session_018C25Mtov5H7gjGoC647wgY