### PR TITLE
feat(k8s): deploy Palworld dedicated game server

### DIFF
--- a/.claude/skills/versions-renovate/SKILL.md
+++ b/.claude/skills/versions-renovate/SKILL.md
@@ -17,6 +17,21 @@ user-invocable: false
 
 Versions live in `kubernetes/platform/versions.env`. Renovate's custom regex manager in `.github/renovate.json5` parses `# renovate:` annotations on the line above each entry. Flux substitutes `${var}` references into HelmRelease specs at reconcile time.
 
+## Choosing the Initial Version
+
+**Always verify the latest stable tag from the source — never guess from memory.** Training data lags reality by months to years, so a remembered tag is almost always stale. Before writing any `*_version=` entry or hardcoded image tag, look it up:
+
+```bash
+# Docker/OCI registry (GHCR shown; anonymous pull token)
+TOKEN=$(curl -s "https://ghcr.io/token?scope=repository:<org>/<image>:pull&service=ghcr.io" | jq -r .token)
+curl -s -H "Authorization: Bearer $TOKEN" "https://ghcr.io/v2/<org>/<image>/tags/list" | jq -r '.tags[]' | sort -V | tail
+
+skopeo list-tags docker://ghcr.io/<org>/<image>          # if skopeo available
+git ls-remote --tags --refs https://github.com/<org>/<repo>.git | sort -V | tail   # github-releases/tags
+```
+
+Match the tag format the registry actually uses (`v2.7.1` vs `2.7.1`). Pick the newest stable semver; skip `beta`/`rc`/`nightly`/`latest` unless the user asks. Renovate keeps it current afterward, but a fresh deploy must start on the current release, not an ancient one.
+
 ## Annotation Syntax
 
 ```env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ If uncertain:
 
 - NEVER use linuxserver.io images (`lscr.io/linuxserver/*`) — ever, for any app
 - Use official upstream images or distroless alternatives instead
+- ALWAYS pin the latest stable release when first adding an image — never guess a tag from training data. Verify the newest tag from the source registry (e.g. `curl` the GHCR/Docker Hub tags list, `skopeo list-tags`, or the upstream GitHub releases/tags) and use it. Prefer a specific semver tag over `latest`; avoid pre-release/`beta`/`rc` tags unless explicitly requested.
 
 ## Destructive Operations
 

--- a/kubernetes/clusters/live/charts/kustomization.yaml
+++ b/kubernetes/clusters/live/charts/kustomization.yaml
@@ -29,6 +29,7 @@ configMapGenerator:
       - minecraft.yaml
       - ollama.yaml
       - open-webui.yaml
+      - palworld.yaml
       - papra.yaml
       - paperless.yaml
       - prowlarr.yaml

--- a/kubernetes/clusters/live/charts/palworld.yaml
+++ b/kubernetes/clusters/live/charts/palworld.yaml
@@ -44,12 +44,15 @@ controllers:
               secretKeyRef:
                 name: palworld-admin-password
                 key: password
+        # Upstream sizing: 4 cores, 16GB RAM min / 32GB+ for stable operation.
+        # Requesting 20Gi guarantees placement on the XL node (node2, 128GiB) —
+        # the 16GB workers cannot fit this alongside existing workloads.
         resources:
           requests:
             cpu: "4"
-            memory: 12Gi
+            memory: 20Gi
           limits:
-            memory: 16Gi
+            memory: 32Gi
         probes:
           startup:
             enabled: true

--- a/kubernetes/clusters/live/charts/palworld.yaml
+++ b/kubernetes/clusters/live/charts/palworld.yaml
@@ -1,0 +1,101 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-4.6.0/charts/other/app-template/values.schema.json
+controllers:
+  palworld:
+    type: statefulset
+    replicas: 1
+
+    pod:
+      terminationGracePeriodSeconds: 120
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+    containers:
+      app:
+        image:
+          repository: ghcr.io/thijsvanloef/palworld-server-docker
+          tag: "${palworld_server_version}"
+        env:
+          PUID: "1000"
+          PGID: "1000"
+          PORT: "8211"
+          PLAYERS: "16"
+          SERVER_NAME: "Homelab Palworld"
+          SERVER_DESCRIPTION: "Homelab Palworld Dedicated Server"
+          COMMUNITY: "false"
+          MULTITHREADING: "true"
+          RCON_ENABLED: "true"
+          RCON_PORT: "25575"
+          REST_API_ENABLED: "true"
+          REST_API_PORT: "8212"
+          UPDATE_ON_BOOT: "true"
+          BACKUP_ENABLED: "true"
+          BACKUP_CRON_EXPRESSION: "0 * * * *"
+          SERVER_PASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: palworld-server-password
+                key: password
+          ADMIN_PASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: palworld-admin-password
+                key: password
+        resources:
+          requests:
+            cpu: "4"
+            memory: 12Gi
+          limits:
+            memory: 16Gi
+        probes:
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              exec:
+                command:
+                  - pgrep
+                  - -f
+                  - PalServer
+              initialDelaySeconds: 30
+              periodSeconds: 15
+              failureThreshold: 60
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              exec:
+                command:
+                  - pgrep
+                  - -f
+                  - PalServer
+              periodSeconds: 30
+              failureThreshold: 3
+          readiness:
+            enabled: false
+
+service:
+  game:
+    controller: palworld
+    type: LoadBalancer
+    annotations:
+      lbipam.cilium.io/ips: ${palworld_ip}
+    ports:
+      game:
+        port: 8211
+        protocol: UDP
+      query:
+        port: 27015
+        protocol: UDP
+
+persistence:
+  data:
+    type: persistentVolumeClaim
+    accessMode: ReadWriteOnce
+    size: 20Gi
+    storageClass: fast
+    globalMounts:
+      - path: /palworld

--- a/kubernetes/clusters/live/charts/palworld.yaml
+++ b/kubernetes/clusters/live/charts/palworld.yaml
@@ -2,8 +2,11 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-4.6.0/charts/other/app-template/values.schema.json
 controllers:
   palworld:
-    type: statefulset
+    type: deployment
     replicas: 1
+    # Recreate: single replica on a RWO PVC — the new pod cannot mount the
+    # volume until the old one releases it, so never run two at once.
+    strategy: Recreate
 
     pod:
       terminationGracePeriodSeconds: 120
@@ -19,8 +22,8 @@ controllers:
           repository: ghcr.io/thijsvanloef/palworld-server-docker
           tag: "${palworld_server_version}"
         env:
-          PUID: "1000"
-          PGID: "1000"
+          # PUID/PGID are ignored when the container user is overridden
+          # (runAsUser below); volume perms handled by pod fsGroup instead.
           PORT: "8211"
           PLAYERS: "16"
           SERVER_NAME: "Homelab Palworld"
@@ -44,6 +47,13 @@ controllers:
               secretKeyRef:
                 name: palworld-admin-password
                 key: password
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
         # Upstream sizing: 4 cores, 16GB RAM min / 32GB+ for stable operation.
         # Requesting 20Gi guarantees placement on the XL node (node2, 128GiB) —
         # the 16GB workers cannot fit this alongside existing workloads.

--- a/kubernetes/clusters/live/cluster-apps.env
+++ b/kubernetes/clusters/live/cluster-apps.env
@@ -5,3 +5,4 @@ satisfactory_ip=192.168.10.25
 minecraft_ip=192.168.10.26
 valheim_ip=192.168.10.27
 booter_ip=192.168.10.21
+palworld_ip=192.168.10.28

--- a/kubernetes/clusters/live/config/kustomization.yaml
+++ b/kubernetes/clusters/live/config/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - papra
   - home-assistant
   - homepage
+  - palworld
   - velero
   - silences
   - cluster-config-resourceset.yaml

--- a/kubernetes/clusters/live/config/palworld/kustomization.yaml
+++ b/kubernetes/clusters/live/config/palworld/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - secrets.yaml
+  - network-policy.yaml

--- a/kubernetes/clusters/live/config/palworld/namespace.yaml
+++ b/kubernetes/clusters/live/config/palworld/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: palworld
+  labels:
+    istio.io/dataplane-mode: ambient
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+    network-policy.homelab/profile: internal-egress

--- a/kubernetes/clusters/live/config/palworld/network-policy.yaml
+++ b/kubernetes/clusters/live/config/palworld/network-policy.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: palworld-default
+  namespace: palworld
+spec:
+  description: "Allow Palworld game server: UDP game + query traffic, TCP RCON from cluster, HTTPS egress for SteamCMD"
+  endpointSelector: { }
+  ingress:
+    - fromEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "8211"
+              protocol: UDP
+            - port: "27015"
+              protocol: UDP
+    - fromCIDR:
+        - ${cluster_node_subnet}
+      toPorts:
+        - ports:
+            - port: "25575"
+              protocol: TCP
+  egress:
+    # Game server sends UDP responses to connected clients
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "8211"
+              protocol: UDP
+            - port: "27015"
+              protocol: UDP
+    # SteamCMD downloads and Steam authentication
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/clusters/live/config/palworld/secrets.yaml
+++ b/kubernetes/clusters/live/config/palworld/secrets.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: palworld-server-password
+  namespace: palworld
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/length: "16"
+    secret-generator.v1.mittwald.de/encoding: hex
+data: { }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: palworld-admin-password
+  namespace: palworld
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/length: "32"
+    secret-generator.v1.mittwald.de/encoding: hex
+data: { }

--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -57,6 +57,13 @@ spec:
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
       dependsOn: [secret-generator]
+    - name: palworld
+      namespace: palworld
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: [secret-generator]
     - name: it-tools
       namespace: it-tools
       chart:

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -101,7 +101,7 @@ home_assistant_version=2025.7.4
 
 # Palworld
 # renovate: datasource=docker depName=ghcr.io/thijsvanloef/palworld-server-docker
-palworld_server_version=v0.45.0
+palworld_server_version=v2.7.1
 
 # Talos Image Factory schematic ID for PXE boot (iscsi-tools + util-linux-tools)
 # Content-addressed hash — only changes when extensions change, not on version bumps

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -99,6 +99,10 @@ papra_version=26.6.1-rootless
 # renovate: datasource=docker depName=home-assistant packageName=ghcr.io/home-assistant/home-assistant
 home_assistant_version=2025.7.4
 
+# Palworld
+# renovate: datasource=docker depName=ghcr.io/thijsvanloef/palworld-server-docker
+palworld_server_version=v0.45.0
+
 # Talos Image Factory schematic ID for PXE boot (iscsi-tools + util-linux-tools)
 # Content-addressed hash — only changes when extensions change, not on version bumps
 # Regenerate: POST https://factory.talos.dev/schematics with extensions YAML


### PR DESCRIPTION
## Summary

- Deploys a Palworld dedicated game server to the live cluster using `thijsvanloef/palworld-server-docker` (GHCR)
- Uses the established UDP/LoadBalancer pattern (matching Valheim, Minecraft, Factorio, Satisfactory): dedicated IP `192.168.10.28` via `lbipam.cilium.io/ips`, ports 8211/UDP (game) and 27015/UDP (Steam query)
- RCON (25575/TCP) is enabled on the server but restricted to cluster-internal access only via CiliumNetworkPolicy (not exposed on the LoadBalancer service)
- Server and admin passwords are auto-generated by secret-generator (ephemeral, survive pod restarts)
- 20Gi PVC on `fast` StorageClass for world saves and server files
- Renovate-tracked image version pinned in `versions.env`

## Exposure approach

UDP game traffic uses `Service type: LoadBalancer` with `lbipam.cilium.io/ips: 192.168.10.28` — the same Cilium LBIPAM pattern used by all other game servers in this repo. HTTPRoute is not used (HTTP-only). The LoadBalancer IP is within the existing pool (192.168.10.21-29).

## Files changed

- `kubernetes/clusters/live/cluster-apps.env` — adds `palworld_ip=192.168.10.28`
- `kubernetes/clusters/live/versions.env` — adds `palworld_server_version` with Renovate annotation
- `kubernetes/clusters/live/resourcesets/helm-charts.yaml` — adds palworld entry (app-template, depends on secret-generator)
- `kubernetes/clusters/live/charts/palworld.yaml` — app-template values (StatefulSet, LoadBalancer service, 20Gi PVC)
- `kubernetes/clusters/live/charts/kustomization.yaml` — registers palworld.yaml in cluster-values ConfigMap
- `kubernetes/clusters/live/config/palworld/` — namespace, network policy, secret-generator secrets, kustomization
- `kubernetes/clusters/live/config/kustomization.yaml` — references palworld config directory

## Test plan

- [ ] `task k8s:validate` passes (confirmed locally — 0 errors)
- [ ] `task renovate:validate` passes (confirmed locally)
- [ ] After merge, integration cluster deploys successfully via OCI artifact pipeline
- [ ] After promotion to live, pod reaches Running state (allow up to 15min for initial SteamCMD download)
- [ ] Game server reachable at 192.168.10.28:8211 UDP from LAN

https://claude.ai/code/session_01566bhNkq9g43p17ip8aqsv