### PR TITLE
feat(paperless): upgrade paperless-ngx v2.20.15 → v3.0.3

### DIFF
--- a/kubernetes/clusters/dev/apps/paperless/values.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/values.yaml
@@ -49,7 +49,7 @@ controllers:
           PAPERLESS_OCR_LANGUAGE: "eng"
           PAPERLESS_TASK_WORKERS: "2"
           PAPERLESS_THREADS_PER_WORKER: "2"
-          PAPERLESS_CONSUMER_POLLING: "0"
+          PAPERLESS_CONSUMER_POLLING_INTERVAL: "0"
           PAPERLESS_SECRET_KEY:
             valueFrom:
               secretKeyRef:
@@ -60,6 +60,7 @@ controllers:
               secretKeyRef:
                 name: paperless-db-credentials
                 key: password
+          PAPERLESS_DBENGINE: postgresql
           PAPERLESS_DBHOST: platform-pooler-rw.database.svc.cluster.local
           PAPERLESS_DBPORT: "5432"
           PAPERLESS_DBNAME: paperless
@@ -72,6 +73,7 @@ controllers:
           PAPERLESS_REDIS:
             dependsOn: DRAGONFLY_PASSWORD
             value: "redis://:$(DRAGONFLY_PASSWORD)@dragonfly.cache.svc.cluster.local:6379"
+          PAPERLESS_ALLAUTH_TRUSTED_PROXY_COUNT: "1"
           # Filename format — organise media into year/correspondent/date-title hierarchy
           # NOTE: changing PAPERLESS_FILENAME_FORMAT on an existing instance causes paperless
           # to re-file every document in the media volume on next startup (high I/O on the
@@ -80,12 +82,10 @@ controllers:
           PAPERLESS_FILENAME_FORMAT_REMOVE_NONE: "true"
           PAPERLESS_CONSUMER_DELETE_DUPLICATES: "true"
           # Barcode / ASN — QR-code labelling of physical documents (ASN#####) read at
-          # consume time; PATCH-T separator pages split batch scans. ZXING backend is
-          # required (default pyzbar misreads small QR codes; needs paperless >= 1.14).
+          # consume time; PATCH-T separator pages split batch scans.
           # Inert until physical ASN labels are applied to scanned documents.
           PAPERLESS_CONSUMER_ENABLE_BARCODES: "true"
           PAPERLESS_CONSUMER_ENABLE_ASN_BARCODE: "true"
-          PAPERLESS_CONSUMER_BARCODE_SCANNER: "ZXING"
           PAPERLESS_DATA_DIR: "/data"
           PAPERLESS_MEDIA_ROOT: "/media"
         securityContext:

--- a/kubernetes/clusters/dev/versions.env
+++ b/kubernetes/clusters/dev/versions.env
@@ -4,4 +4,4 @@
 # - Renovate updates this file (via inline comment annotations)
 
 # renovate: datasource=docker depName=paperless-ngx packageName=ghcr.io/paperless-ngx/paperless-ngx
-paperless_ngx_version=2.20.15
+paperless_ngx_version=3.0.3

--- a/kubernetes/clusters/live/charts/paperless.yaml
+++ b/kubernetes/clusters/live/charts/paperless.yaml
@@ -55,7 +55,7 @@ controllers:
           PAPERLESS_TASK_WORKERS: "2"
           PAPERLESS_THREADS_PER_WORKER: "2"
           # Disable consumer directory — web upload only
-          PAPERLESS_CONSUMER_POLLING: "0"
+          PAPERLESS_CONSUMER_POLLING_INTERVAL: "0"
           # Secret key for session cookies and CSRF tokens
           PAPERLESS_SECRET_KEY:
             valueFrom:
@@ -68,6 +68,7 @@ controllers:
               secretKeyRef:
                 name: paperless-db-credentials
                 key: password
+          PAPERLESS_DBENGINE: postgresql
           PAPERLESS_DBHOST: platform-pooler-rw.database.svc.cluster.local
           PAPERLESS_DBPORT: "5432"
           PAPERLESS_DBNAME: paperless
@@ -81,6 +82,7 @@ controllers:
           PAPERLESS_REDIS:
             dependsOn: DRAGONFLY_PASSWORD
             value: "redis://:$(DRAGONFLY_PASSWORD)@dragonfly.cache.svc.cluster.local:6379"
+          PAPERLESS_ALLAUTH_TRUSTED_PROXY_COUNT: "1"
           # OIDC/SSO via Authelia
           PAPERLESS_APPS: "allauth.socialaccount.providers.openid_connect"
           PAPERLESS_OIDC_CLIENT_SECRET:
@@ -99,12 +101,10 @@ controllers:
           PAPERLESS_FILENAME_FORMAT_REMOVE_NONE: "true"
           PAPERLESS_CONSUMER_DELETE_DUPLICATES: "true"
           # Barcode / ASN — QR-code labelling of physical documents (ASN#####) read at
-          # consume time; PATCH-T separator pages split batch scans. ZXING backend is
-          # required (default pyzbar misreads small QR codes; needs paperless >= 1.14).
+          # consume time; PATCH-T separator pages split batch scans.
           # Inert until physical ASN labels are applied to scanned documents.
           PAPERLESS_CONSUMER_ENABLE_BARCODES: "true"
           PAPERLESS_CONSUMER_ENABLE_ASN_BARCODE: "true"
-          PAPERLESS_CONSUMER_BARCODE_SCANNER: "ZXING"
           # Storage paths
           PAPERLESS_DATA_DIR: "/data"
           PAPERLESS_MEDIA_ROOT: "/media"

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -55,7 +55,7 @@ bazarr_version=1.6.0
 # renovate: datasource=docker depName=yq packageName=mikefarah/yq
 yq_version=4.53.3
 # renovate: datasource=docker depName=paperless-ngx packageName=ghcr.io/paperless-ngx/paperless-ngx
-paperless_ngx_version=2.20.15
+paperless_ngx_version=3.0.3
 # renovate: datasource=docker depName=vaultwarden packageName=vaultwarden/server
 vaultwarden_version=1.36.0-alpine
 # renovate: datasource=docker depName=homepage packageName=ghcr.io/gethomepage/homepage


### PR DESCRIPTION
## Summary

- Bump `paperless_ngx_version` from `2.20.15` to `3.0.3` (dev + live)
- Apply all breaking-change env var mitigations required by the [official v3 migration guide](https://github.com/paperless-ngx/paperless-ngx/blob/main/docs/migration-v3.md)

## Breaking changes addressed

| Change | Action taken |
|--------|-------------|
| `PAPERLESS_CONSUMER_POLLING` renamed | → `PAPERLESS_CONSUMER_POLLING_INTERVAL` |
| `PAPERLESS_DBENGINE` now required for PostgreSQL | Added `postgresql` explicitly |
| `PAPERLESS_CONSUMER_BARCODE_SCANNER` removed (zxing-cpp only) | Removed env var |
| Login rate-limiting behind reverse proxy | Added `PAPERLESS_ALLAUTH_TRUSTED_PROXY_COUNT: "1"` for Istio |

## Automatic on first startup (no manual action needed)

- **Search index rebuilt**: Whoosh → Tantivy (incompatible format; paperless auto-rebuilds from DB — first startup slower)
- **DB migrations run**: OCR/archive settings migrated, mail rule clamping, task history cleared
- **Saved views migrated**: `note:` / `custom_field:` filter prefixes rewritten to `notes.note:` / `custom_fields.value:`

## Prerequisites met

- We are on `v2.20.15` — the exact required pre-upgrade version per the migration guide
- `PAPERLESS_SECRET_KEY` already set via ESO secret — satisfies new "required" enforcement
- `PAPERLESS_CONSUMER_DELETE_DUPLICATES: "true"` already explicit — maintains duplicate rejection (v3 default changed to allow)
- No consume scripts in use — positional arg removal is a no-op for us
- No document/thumbnail encryption in use — removal is a no-op

## Test plan

- [ ] Merge flows to dev; confirm Flux deploys v3.0.3 pod successfully
- [ ] Confirm startup logs show DB migrations completed and Tantivy index rebuilt
- [ ] Log in via Authelia OIDC — confirm no 403 errors
- [ ] Upload a test document and confirm it processes correctly
- [ ] Verify filename format still organises into `year/correspondent/date-title` hierarchy
- [ ] Check barcode/ASN scanning still functions (zxing-cpp backend active by default)
- [ ] Promote through integration → live after dev validation passes

https://claude.ai/code/session_01RME9kRBgeiaV4pVn2xhUQ8