### PR TITLE
feat(paperless): enable AI suggestions via local Ollama

### DIFF
--- a/kubernetes/clusters/dev/apps/paperless/values.yaml
+++ b/kubernetes/clusters/dev/apps/paperless/values.yaml
@@ -86,6 +86,11 @@ controllers:
           PAPERLESS_CONSUMER_ENABLE_BARCODES: "true"
           PAPERLESS_CONSUMER_ENABLE_ASN_BARCODE: "true"
           PAPERLESS_CONSUMER_BARCODE_SCANNER: "ZXING"
+          # AI — LLM suggestions via local Ollama
+          PAPERLESS_AI_ENABLED: "true"
+          PAPERLESS_AI_LLM_BACKEND: "ollama"
+          PAPERLESS_AI_LLM_MODEL: "qwen2.5:7b-instruct-q8_0"
+          PAPERLESS_AI_LLM_URL: "http://ollama.ai.svc.cluster.local:11434"
           PAPERLESS_DATA_DIR: "/data"
           PAPERLESS_MEDIA_ROOT: "/media"
         securityContext:

--- a/kubernetes/clusters/live/charts/paperless.yaml
+++ b/kubernetes/clusters/live/charts/paperless.yaml
@@ -105,6 +105,11 @@ controllers:
           PAPERLESS_CONSUMER_ENABLE_BARCODES: "true"
           PAPERLESS_CONSUMER_ENABLE_ASN_BARCODE: "true"
           PAPERLESS_CONSUMER_BARCODE_SCANNER: "ZXING"
+          # AI — LLM suggestions via local Ollama
+          PAPERLESS_AI_ENABLED: "true"
+          PAPERLESS_AI_LLM_BACKEND: "ollama"
+          PAPERLESS_AI_LLM_MODEL: "qwen2.5:7b-instruct-q8_0"
+          PAPERLESS_AI_LLM_URL: "http://ollama.ai.svc.cluster.local:11434"
           # Storage paths
           PAPERLESS_DATA_DIR: "/data"
           PAPERLESS_MEDIA_ROOT: "/media"

--- a/kubernetes/clusters/live/config/ai-prereqs/network-policy.yaml
+++ b/kubernetes/clusters/live/config/ai-prereqs/network-policy.yaml
@@ -60,3 +60,23 @@ spec:
         - ports:
             - port: "11434"
               protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: ai-ollama-from-paperless
+  namespace: ai
+spec:
+  description: "Ollama ingress from paperless-ngx for AI document suggestions"
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: ollama
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: paperless
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP

--- a/kubernetes/clusters/live/config/paperless/kustomization.yaml
+++ b/kubernetes/clusters/live/config/paperless/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - paperless-secret.yaml
   - canary.yaml
   - imap-egress.yaml
+  - ollama-egress.yaml

--- a/kubernetes/clusters/live/config/paperless/ollama-egress.yaml
+++ b/kubernetes/clusters/live/config/paperless/ollama-egress.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: paperless-ollama-egress
+  namespace: paperless
+spec:
+  description: "Allow paperless-ngx egress to Ollama API for AI document suggestions"
+  endpointSelector: { }
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP


### PR DESCRIPTION
## Summary

- Enable `PAPERLESS_AI_ENABLED` with `ollama` backend on both dev and live clusters
- Point at `ollama.ai.svc.cluster.local:11434` using `qwen2.5:7b-instruct-q8_0` (same model loaded for Sure — no new pull required)
- Add `paperless-ollama-egress` CiliumNetworkPolicy in `paperless` namespace for cross-namespace egress
- Add `ai-ollama-from-paperless` CiliumNetworkPolicy in `ai` namespace for ollama ingress from paperless, following the existing Sure pattern

Implements the AI suggestion feature from [paperless-ngx#10319](https://github.com/paperless-ngx/paperless-ngx/pull/10319) introduced in v3: tag, correspondent, document type, and title suggestions powered by LLM on document open.

## Test plan

- [ ] Confirm Flux deploys updated paperless pod on dev
- [ ] Open a document in paperless UI — verify "Suggest" button appears in the editor
- [ ] Click Suggest — confirm AI returns tag/correspondent/document type/title suggestions
- [ ] Verify Cilium allows paperless→ollama traffic (no policy-denied drops in Hubble)
- [ ] Promote to live after dev validation

https://claude.ai/code/session_019ghWComM9XTB4SmKM8D8rG