### PR TITLE
feat(home-assistant): add OIDC SSO via Authelia (hass-oidc-auth v1.1.1)

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -428,6 +428,29 @@ configMap:
           grant_types:
             - authorization_code
           token_endpoint_auth_method: client_secret_basic
+        - client_id: home-assistant
+          client_name: Home Assistant
+          client_secret:
+            path: /secrets/home-assistant-oidc-client-secret/client-secret
+          public: false
+          authorization_policy: two_factor
+          consent_mode: implicit
+          require_pkce: true
+          pkce_challenge_method: S256
+          redirect_uris:
+            - https://hass.${internal_domain}/auth/oidc/callback
+          scopes:
+            - openid
+            - profile
+            - groups
+            - email
+          response_types:
+            - code
+          grant_types:
+            - authorization_code
+          access_token_signed_response_alg: none
+          userinfo_signed_response_alg: none
+          token_endpoint_auth_method: client_secret_post
 
   regulation:
     max_retries: 3
@@ -456,4 +479,5 @@ secret:
     jellyseerr-oidc-client-secret: { }
     papra-oidc-client-secret: { }
     sure-oidc-client-secret: { }
+    home-assistant-oidc-client-secret: { }
     authelia-smtp-credentials: { }

--- a/kubernetes/clusters/live/charts/home-assistant.yaml
+++ b/kubernetes/clusters/live/charts/home-assistant.yaml
@@ -18,6 +18,42 @@ controllers:
         seccompProfile:
           type: RuntimeDefault
 
+    initContainers:
+      install-oidc-component:
+        image:
+          repository: alpine
+          # renovate: datasource=docker depName=alpine
+          tag: "3.22.0"
+        command:
+          - sh
+          - -c
+          - |
+            set -eu
+            TARGET=/config/custom_components/auth_oidc
+            if [ -f "${TARGET}/.version" ] && [ "$(cat ${TARGET}/.version)" = "${hass_oidc_auth_version}" ]; then
+              echo "auth_oidc ${hass_oidc_auth_version} already installed, skipping"
+              exit 0
+            fi
+            echo "Installing hass-oidc-auth ${hass_oidc_auth_version}..."
+            rm -rf "${TARGET}"
+            wget -qO /tmp/oidc.tar.gz "https://github.com/christiaangoossens/hass-oidc-auth/archive/refs/tags/${hass_oidc_auth_version}.tar.gz"
+            mkdir -p /config/custom_components
+            tar -xzf /tmp/oidc.tar.gz -C /tmp
+            cp -r /tmp/hass-oidc-auth-*/custom_components/auth_oidc "${TARGET}"
+            echo "${hass_oidc_auth_version}" > "${TARGET}/.version"
+            echo "auth_oidc ${hass_oidc_auth_version} installed"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+
     containers:
       app:
         image:
@@ -29,6 +65,11 @@ controllers:
               secretKeyRef:
                 name: hass-db-credentials
                 key: uri
+          HASS_OIDC_CLIENT_SECRET:
+            valueFrom:
+              secretKeyRef:
+                name: home-assistant-oidc-client-secret
+                key: client-secret
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false

--- a/kubernetes/clusters/live/config/authelia-prereqs/home-assistant-oidc-client-secret.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/home-assistant-oidc-client-secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: home-assistant-oidc-client-secret
+  namespace: authelia
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: client-secret
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "64"
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "home-assistant"
+data: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - sure-oidc-client-secret.yaml
   - jellyseerr-oidc-client-secret.yaml
   - papra-oidc-client-secret.yaml
+  - home-assistant-oidc-client-secret.yaml
   - authelia-secrets.yaml
   - authelia-smtp-credentials.yaml
   - authelia-smtp-egress.yaml

--- a/kubernetes/clusters/live/config/home-assistant/hass-config-configmap.yaml
+++ b/kubernetes/clusters/live/config/home-assistant/hass-config-configmap.yaml
@@ -39,6 +39,21 @@ data:
     logger:
       default: warning
 
+    # OpenID Connect SSO via hass-oidc-auth custom component.
+    # The component registers itself alongside the built-in homeassistant auth provider;
+    # local login remains available as a break-glass fallback via ?skip_oidc_redirect=true.
+    # Mobile app uses the device-code flow (one-time; see component docs).
+    # client_secret is injected from the replicated OIDC secret — never committed.
+    auth_oidc:
+      client_id: home-assistant
+      client_secret: !env_var HASS_OIDC_CLIENT_SECRET
+      discovery_url: "https://auth.${external_domain}/.well-known/openid-configuration"
+      display_name: "Authelia (SSO)"
+      roles:
+        admin: "lldap_admins"
+      features:
+        default_redirect: true
+
     # Core integrations (explicit list — discovery components intentionally omitted)
     config:
     frontend:

--- a/kubernetes/clusters/live/config/home-assistant/hass-oidc-client-secret-replica.yaml
+++ b/kubernetes/clusters/live/config/home-assistant/hass-oidc-client-secret-replica.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: home-assistant-oidc-client-secret
+  namespace: home-assistant
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: authelia/home-assistant-oidc-client-secret
+data: { }

--- a/kubernetes/clusters/live/config/home-assistant/kustomization.yaml
+++ b/kubernetes/clusters/live/config/home-assistant/kustomization.yaml
@@ -11,4 +11,5 @@ resources:
   - hass-database-cluster.yaml
   - hass-database-backup.yaml
   - hass-cnpg-garage-key.yaml
+  - hass-oidc-client-secret-replica.yaml
   - canary.yaml

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -98,6 +98,8 @@ papra_version=26.6.1-rootless
 # Home Assistant
 # renovate: datasource=docker depName=home-assistant packageName=ghcr.io/home-assistant/home-assistant
 home_assistant_version=2025.7.4
+# renovate: datasource=github-releases depName=hass-oidc-auth packageName=christiaangoossens/hass-oidc-auth
+hass_oidc_auth_version=v1.1.1
 
 # Palworld
 # renovate: datasource=docker depName=ghcr.io/thijsvanloef/palworld-server-docker


### PR DESCRIPTION
## Summary

- Registers a new `home-assistant` OIDC client in Authelia with redirect URI `https://hass.internal.tomnowak.work/auth/oidc/callback`, PKCE (S256), implicit consent, scopes `openid profile groups email`, and `client_secret_post` auth method — matching the pattern used by other internal apps (paperless, sure, etc.)
- Delivers the `hass-oidc-auth` custom component (v1.1.1) via an idempotent initContainer that downloads the pinned GitHub release tarball and extracts `custom_components/auth_oidc/` into the `/config` PVC on each pod start; a `.version` sentinel skips reinstall when already up-to-date
- Wires `auth_oidc:` into `configuration.yaml` (ConfigMap) using `!env_var HASS_OIDC_CLIENT_SECRET`; the `lldap_admins` group maps to HA admin, `default_redirect: true` sends browser logins directly to Authelia
- The built-in `homeassistant` auth provider is **retained automatically** — the component inserts itself first in the provider chain without removing existing providers; local login remains available at `?skip_oidc_redirect=true` as a break-glass fallback
- Secret flow mirrors the existing pattern: `secret-generator` auto-generates a 64-byte hex secret in the `authelia` namespace, `kubernetes-replicator` copies it to the `home-assistant` namespace, and the pod consumes the plaintext via env var while Authelia reads the same value via its file-based secret path

## OIDC Pattern Verified (mirrored from paperless)

| Component | Location |
|-----------|----------|
| Source secret (generator + replicator annotations) | `authelia-prereqs/home-assistant-oidc-client-secret.yaml` |
| Consumer secret (replica) | `config/home-assistant/hass-oidc-client-secret-replica.yaml` |
| Authelia client registration | `charts/authelia.yaml` → `identity_providers.oidc.clients` |
| Authelia secret mount | `charts/authelia.yaml` → `secret.additionalSecrets` |
| App consumes secret | `charts/home-assistant.yaml` → `HASS_OIDC_CLIENT_SECRET` env var |
| App configuration | `hass-config-configmap.yaml` → `auth_oidc:` block |

## Component Details

- **Version pinned**: `v1.1.1` (released 2026-06-08), tracked in `versions.env` with `datasource=github-releases` Renovate annotation
- **Install method**: initContainer (`alpine:3.22.0`) downloads tarball, extracts to `/config/custom_components/auth_oidc/`, writes version sentinel — idempotent on restarts
- **Config schema used** (from live source): `client_id`, `client_secret`, `discovery_url`, `display_name`, `roles.admin`, `features.default_redirect`
- **Callback URL registered**: `https://hass.internal.tomnowak.work/auth/oidc/callback` (verified from `endpoints/callback.py`: `PATH = "/auth/oidc/callback"`)

## Known Caveat

Mobile app OIDC login uses a one-time device-code flow; after first setup, subsequent logins proceed without re-authorization. The built-in local auth provider remains available for emergency/break-glass access.

## Test Plan

- [ ] Validate `task k8s:validate` passes (confirmed: 0 Invalid, 0 Errors)
- [ ] Validate `task renovate:validate` passes (confirmed: Config validated successfully)
- [ ] After merge and live promotion: confirm `home-assistant-oidc-client-secret` is generated in `authelia` ns and replicated to `home-assistant` ns
- [ ] Confirm initContainer completes and `auth_oidc` dir appears at `/config/custom_components/auth_oidc/`
- [ ] Confirm browser login redirects to Authelia SSO
- [ ] Confirm local login accessible via `?skip_oidc_redirect=true`
- [ ] Confirm `lldap_admins` group members receive HA admin role

Claude-Session: https://claude.ai/code/session_01SLajhrZwVC3ERfnd8W5gAT