### PR TITLE
fix(home-assistant): replace shell vars with literal paths in OIDC initContainer

### DIFF
--- a/kubernetes/clusters/live/charts/home-assistant.yaml
+++ b/kubernetes/clusters/live/charts/home-assistant.yaml
@@ -29,18 +29,17 @@ controllers:
           - -c
           - |
             set -eu
-            TARGET=/config/custom_components/auth_oidc
-            if [ -f "${TARGET}/.version" ] && [ "$(cat ${TARGET}/.version)" = "${hass_oidc_auth_version}" ]; then
+            if [ -f /config/custom_components/auth_oidc/.version ] && [ "$(cat /config/custom_components/auth_oidc/.version)" = "${hass_oidc_auth_version}" ]; then
               echo "auth_oidc ${hass_oidc_auth_version} already installed, skipping"
               exit 0
             fi
             echo "Installing hass-oidc-auth ${hass_oidc_auth_version}..."
-            rm -rf "${TARGET}"
+            rm -rf /config/custom_components/auth_oidc
             wget -qO /tmp/oidc.tar.gz "https://github.com/christiaangoossens/hass-oidc-auth/archive/refs/tags/${hass_oidc_auth_version}.tar.gz"
             mkdir -p /config/custom_components
             tar -xzf /tmp/oidc.tar.gz -C /tmp
-            cp -r /tmp/hass-oidc-auth-*/custom_components/auth_oidc "${TARGET}"
-            echo "${hass_oidc_auth_version}" > "${TARGET}/.version"
+            cp -r /tmp/hass-oidc-auth-*/custom_components/auth_oidc /config/custom_components/auth_oidc
+            echo "${hass_oidc_auth_version}" > /config/custom_components/auth_oidc/.version
             echo "auth_oidc ${hass_oidc_auth_version} installed"
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
## Root Cause

The initContainer script in `home-assistant.yaml` used `${TARGET}` as a shell variable, but the chart values file is processed by Flux postBuild envsubst before it reaches Kubernetes. Flux consumed `${TARGET}` as a variable substitution — but `TARGET` is not a defined cluster variable, so it was replaced with an empty string.

Deployed script became:
- `rm -rf ""` — removes current working directory (dangerous but exits 0)
- `cp -r /tmp/hass-oidc-auth-*/custom_components/auth_oidc ""` — fails: no such file or directory
- `echo "v1.1.1" > "/.version"` — writes to container root instead of the PVC

Result: initContainer exits 1 on every start, HA pod stuck in `Init:Error`.

## Fix

Replace all `${TARGET}` shell variable references with the literal path `/config/custom_components/auth_oidc`. `${hass_oidc_auth_version}` is intentionally kept — it IS a defined Flux cluster variable (in `versions.env`) and is correctly substituted to `v1.1.1` at reconcile time.

## Envsubst simulation (post-fix, with `${hass_oidc_auth_version}` → `v1.1.1`):

```sh
set -eu
if [ -f /config/custom_components/auth_oidc/.version ] && [ "$(cat /config/custom_components/auth_oidc/.version)" = "v1.1.1" ]; then
  echo "auth_oidc v1.1.1 already installed, skipping"
  exit 0
fi
echo "Installing hass-oidc-auth v1.1.1..."
rm -rf /config/custom_components/auth_oidc
wget -qO /tmp/oidc.tar.gz "https://github.com/christiaangoossens/hass-oidc-auth/archive/refs/tags/v1.1.1.tar.gz"
mkdir -p /config/custom_components
tar -xzf /tmp/oidc.tar.gz -C /tmp
cp -r /tmp/hass-oidc-auth-*/custom_components/auth_oidc /config/custom_components/auth_oidc
echo "v1.1.1" > /config/custom_components/auth_oidc/.version
echo "auth_oidc v1.1.1 installed"
```

All paths are correct. Version sentinel written to the PVC at `/config/custom_components/auth_oidc/.version` so idempotency check works across pod restarts.

## Other `${...}` in the PR diff verified clean

- `hass-config-configmap.yaml`: `${internal_domain}`, `${external_domain}`, `${cluster_pod_subnet}` — all are valid Flux cluster vars, intentionally substituted. No shell variables.
- `home-assistant.yaml` container spec: `${home_assistant_version}` — valid Flux cluster var.

## Test Plan

- [ ] `task k8s:validate`: 0 Invalid, 0 Errors (confirmed)
- [ ] After merge: initContainer completes successfully (exit 0)
- [ ] `/config/custom_components/auth_oidc/` present on the PVC
- [ ] HA pod reaches Running state
- [ ] Idempotency: second pod restart skips reinstall (reads `.version` sentinel)

Claude-Session: https://claude.ai/code/session_01SLajhrZwVC3ERfnd8W5gAT