### PR TITLE
chore(paperless): disable pruning ahead of app-folder migration

### DIFF
--- a/kubernetes/clusters/live/config/paperless/kustomization.yaml
+++ b/kubernetes/clusters/live/config/paperless/kustomization.yaml
@@ -2,6 +2,10 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+# Migration prep: prevent garbage collection while ownership transfers from the
+# cluster-config Kustomization to the per-app cluster-apps Kustomization.
+commonAnnotations:
+  kustomize.toolkit.fluxcd.io/prune: disabled
 resources:
   - namespace.yaml
   - data-pvc.yaml

--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -234,6 +234,7 @@ spec:
       dependsOn: [sonarr, radarr, sonarr4k, radarr4k, bazarr, sabnzbd]
     - name: paperless
       namespace: paperless
+      pruneDisabled: true
       chart:
         name: app-template
         version: "${app_template_version}"
@@ -302,6 +303,10 @@ spec:
     metadata:
       name: << inputs.name >>
       namespace: << inputs.provider.namespace >>
+      <<- if and (hasKey inputs "pruneDisabled") inputs.pruneDisabled >>
+      annotations:
+        fluxcd.controlplane.io/prune: disabled
+      <<- end >>
     spec:
       interval: 10m
       <<- if hasPrefix "oci://" inputs.chart.url >>
@@ -314,6 +319,10 @@ spec:
     metadata:
       name: << inputs.name >>
       namespace: << inputs.provider.namespace >>
+      <<- if and (hasKey inputs "pruneDisabled") inputs.pruneDisabled >>
+      annotations:
+        fluxcd.controlplane.io/prune: disabled
+      <<- end >>
     spec:
       <<- if inputs.dependsOn >>
       dependsOn:
@@ -356,6 +365,10 @@ spec:
     metadata:
       name: << inputs.name >>
       namespace: << inputs.provider.namespace >>
+      <<- if and (hasKey inputs "pruneDisabled") inputs.pruneDisabled >>
+      annotations:
+        fluxcd.controlplane.io/prune: disabled
+      <<- end >>
     spec:
       <<- if inputs.dependsOn >>
       dependsOn:


### PR DESCRIPTION
## Summary

Phase 1 of 2 migrating paperless-on-live into a self-contained per-app folder (`kubernetes/clusters/live/apps/paperless/`).

This PR only adds prune-protection annotations so that when ownership of the paperless objects transfers from `cluster-config` / `cluster-resources` to the new per-app Kustomization in Phase 2, neither old owner can garbage-collect them — regardless of reconcile ordering. Without this, a prune-before-adopt race could delete the Longhorn PVCs (data loss) or helm-uninstall the release.

## Changes

- `config/paperless/kustomization.yaml`: `commonAnnotations` adds `kustomize.toolkit.fluxcd.io/prune: disabled` to all 10 config resources (namespace, both PVCs, secrets, egress policies, canary)
- `resourcesets/helm-charts.yaml`: new optional per-input `pruneDisabled` flag; template renders `fluxcd.controlplane.io/prune: disabled` on the generated HelmRepository, HelmRelease, and wrapper Kustomization. Set only on the paperless input; access guarded with `hasKey` (flux-operator templating uses strict map access — unguarded access breaks expansion for all inputs)

## Verification

- `flux-operator build rset` on the cluster ResourceSet: expansion succeeds, exactly 3 annotated objects, all paperless
- `task k8s:validate` and `task k8s:validate-live` pass
- Zero behavioral change: annotations only; no spec fields touched, helm no-op

## Rollout plan

1. Merge this → artifact deploys → annotations land on live objects
2. Phase 2 PR (stacked): create `live/apps/` registry ResourceSet + `apps/paperless/` folder with HelmRelease (inline values) + all config resources; remove old entries from `charts/`, `config/`, and the cluster ResourceSet
3. Optional Phase 3: drop the transitional annotations (PVCs/namespace keep theirs as permanent data protection)

## Note for reviewers

Local/CI validation never template-expands cluster-level ResourceSets (only platform ones) — the `hasKey` bug was invisible to `task k8s:validate` and was caught only by manual `flux-operator build rset`. Follow-up worth filing: extend `_expand-resourcesets` to cluster ResourceSets.

https://claude.ai/code/session_01JHmQzFkRyMtMbupsSzgWpv