### PR TITLE
feat(k8s): deploy konflate to live cluster

### DIFF
--- a/kubernetes/clusters/live/charts/konflate.yaml
+++ b/kubernetes/clusters/live/charts/konflate.yaml
@@ -1,0 +1,31 @@
+---
+# https://github.com/home-operations/konflate/blob/main/charts/konflate/values.yaml
+config:
+  repo: "github://${github_org}/${github_repository}"
+  clusterPath: kubernetes/clusters/live
+
+secret:
+  existingSecret: konflate-secret
+
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: internal
+      namespace: istio-gateway
+  hostnames:
+    - "konflate.${internal_domain}"
+
+serviceMonitor:
+  enabled: true
+
+persistence:
+  enabled: true
+  storageClass: longhorn
+  size: 5Gi
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 256Mi
+  limits:
+    memory: 1Gi

--- a/kubernetes/clusters/live/charts/kustomization.yaml
+++ b/kubernetes/clusters/live/charts/kustomization.yaml
@@ -21,6 +21,7 @@ configMapGenerator:
       - houndarr.yaml
       - immich.yaml
       - it-tools.yaml
+      - konflate.yaml
       - jellyfin-exporter.yaml
       - jfa-go.yaml
       - jellyfin.yaml

--- a/kubernetes/clusters/live/config/konflate/external-secret.yaml
+++ b/kubernetes/clusters/live/config/konflate/external-secret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: konflate-secret
+  namespace: konflate
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: konflate-secret
+  data:
+    - secretKey: KONFLATE_TOKEN
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/konflate
+        property: token

--- a/kubernetes/clusters/live/config/konflate/kustomization.yaml
+++ b/kubernetes/clusters/live/config/konflate/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - external-secret.yaml

--- a/kubernetes/clusters/live/config/konflate/namespace.yaml
+++ b/kubernetes/clusters/live/config/konflate/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: konflate
+  labels:
+    istio.io/dataplane-mode: ambient
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+    network-policy.homelab/profile: internal-egress

--- a/kubernetes/clusters/live/config/kustomization.yaml
+++ b/kubernetes/clusters/live/config/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - booter
   - external-dns
   - it-tools
+  - konflate
   - redlib
   - zipline
   - vaultwarden

--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -288,6 +288,14 @@ spec:
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
       dependsOn: [cloudnative-pg, secret-generator, external-secrets]
+    - name: konflate
+      namespace: konflate
+      chart:
+        name: konflate
+        version: "${konflate_version}"
+        url: oci://ghcr.io/home-operations/charts
+      dependsOn: [external-secrets]
+
   resourcesTemplate: |
     ---
     apiVersion: source.toolkit.fluxcd.io/v1

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -103,3 +103,7 @@ home_assistant_version=2025.7.4
 # Content-addressed hash — only changes when extensions change, not on version bumps
 # Regenerate: POST https://factory.talos.dev/schematics with extensions YAML
 talos_pxe_schematic_id=613e1592b2da41ae5e265e8789429f22e121aab91cb4deb6bc3c0b6262961245
+
+# Konflate
+# renovate: datasource=helm depName=konflate registryUrl=oci://ghcr.io/home-operations/charts
+konflate_version=0.4.3


### PR DESCRIPTION
## Summary

- Deploys [konflate](https://github.com/home-operations/konflate) to the live cluster — a GitOps PR review tool that renders Flux diffs at PR merge-base and head, surfacing resource blast radius, container image changes, and danger lints in a three-panel web UI
- Adds the HelmRelease via the cluster ResourceSet pattern (OCI chart `oci://ghcr.io/home-operations/charts/konflate` at v0.4.3)
- Uses `secret.existingSecret` to reference a GitHub token pulled from AWS SSM via ExternalSecret — no secrets committed
- Routes the UI internally at `konflate.${internal_domain}` via the existing internal HTTPRoute gateway
- Enables 5Gi Longhorn persistence (recommended for non-trivial repos to cache source trees and retain merged PR diffs)
- Enables ServiceMonitor for Prometheus metrics scraping

## Files Changed

| File | Purpose |
|------|---------|
| `kubernetes/clusters/live/charts/konflate.yaml` | Helm chart values (repo URI, secret ref, route, persistence, serviceMonitor) |
| `kubernetes/clusters/live/config/konflate/namespace.yaml` | `konflate` namespace with `internal-egress` network policy (internal UI ingress + GitHub API egress) |
| `kubernetes/clusters/live/config/konflate/external-secret.yaml` | ExternalSecret pulling GitHub token from SSM `/homelab/kubernetes/${cluster_name}/konflate` |
| `kubernetes/clusters/live/config/konflate/kustomization.yaml` | Config kustomization aggregator |
| `kubernetes/clusters/live/config/kustomization.yaml` | Added `konflate` config directory reference |
| `kubernetes/clusters/live/charts/kustomization.yaml` | Added `konflate.yaml` to `cluster-values` ConfigMap generator |
| `kubernetes/clusters/live/resourcesets/helm-charts.yaml` | Added `konflate` ResourceSet input (dependsOn: `external-secrets`) |
| `kubernetes/clusters/live/versions.env` | Added `konflate_version=0.4.3` with Renovate annotation |

## Prerequisites

Before merging, provision the SSM secret at `/homelab/kubernetes/live/konflate` with a `token` property containing a GitHub Personal Access Token (read:repo scope is sufficient for public repos; `repo` scope needed for private). The ExternalSecret will remain in a failed state until this secret exists.

## Test Plan

- [ ] Validate SSM secret `/homelab/kubernetes/live/konflate` is provisioned with a GitHub token before merge
- [ ] After merge and artifact promotion to live, verify `konflate` namespace is created with correct labels
- [ ] Verify ExternalSecret `konflate-secret` syncs successfully in the `konflate` namespace
- [ ] Verify HelmRelease `konflate` installs successfully
- [ ] Verify the UI is reachable at `konflate.internal.tomnowak.work`
- [ ] Verify PRs from the `ionfury/homelab` repository are rendered in the UI
- [ ] Verify ServiceMonitor is scraped by Prometheus

https://claude.ai/code/session_01DTq3QdWjVRq2DjPwhCieMG