### PR TITLE
revert(longhorn,renovate): re-enable RecurringJobs and Renovate schedule post-incident

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -2,9 +2,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Renovate
 on:
-  # Temp disabled
-  # schedule:
-  #   - cron: "0 * * * *"
+  schedule:
+    - cron: "0 * * * *"
 
   workflow_dispatch:
     inputs:

--- a/kubernetes/platform/config/longhorn/kustomization.yaml
+++ b/kubernetes/platform/config/longhorn/kustomization.yaml
@@ -5,20 +5,8 @@ kind: Kustomization
 
 resources:
   - prometheus-rules.yaml
-  # TEMPORARILY SUSPENDED 2026-07-22 (incident): filesystem-trim's daily coalesce
-  # mutates the source snapshot chain of the media-library volume
-  # (pvc-cd6ba345-906b-4a8a-be87-bbc8328b3219) mid-rebuild, tearing down and
-  # restarting the Longhorn replica rebuild from scratch every day at ~09:48 UTC.
-  # The rebuild needs ~50-60h uninterrupted on HDD. Restore this line once the
-  # volume is back to robustness=healthy (both replicas RW).
-  # - recurring-jobs/filesystem-trim-daily.yaml
-  # HELD OUT OF LIVE 2026-07-22 (incident): #1398 added this job but it never
-  # promoted (cluster is under lockdown, live frozen at rev 0.1.1073). The media
-  # volume still carries the `snapshot-frequent` group label, so promoting this
-  # job now would start taking snapshots on that volume mid-rebuild and add a
-  # second source-chain mutator, risking another rebuild reset. Re-introduce only
-  # after the media rebuild completes AND the job is re-scoped off the HDD tier.
-  # - recurring-jobs/snapshot-frequent.yaml
+  - recurring-jobs/filesystem-trim-daily.yaml
+  - recurring-jobs/snapshot-frequent.yaml
   - routes/
   - storage-classes/fast-ephemeral.yaml
   - storage-classes/fast.yaml


### PR DESCRIPTION
## What

Restores the temporary suspensions from the media-library (`pvc-cd6ba345`) replica-rebuild incident:

- **longhorn**: re-add `filesystem-trim-daily` + `snapshot-frequent` RecurringJobs (`config/longhorn/kustomization.yaml`)
- **renovate**: restore the hourly `schedule` cron (`.github/workflows/renovate.yaml`)

## Why now

Root cause was the 24h `long-grpc-timeout` bounding `ReplicaAdd` per attempt — an 8.9 TiB HDD volume needs ~57h to rebuild, so it could never finish. Fixed by raising to 96h in #1405. The filesystem-trim "source-chain mutation" theory was a red herring; both jobs are safe to run.

## :warning: DRAFT — merge gate

**Do not merge until the media-library rebuild completes** — `robustness=healthy`, 3 RW replicas. As of opening: 2 RW + 1 WO rebuilding (~41%). The media volume carries both `recurring-job-group` labels, so on merge these jobs immediately resume touching it; merging mid-rebuild reintroduces snapshot/trim activity on the rebuild source chain.

Verify before marking ready:
```
kubectl -n longhorn-system get engines.longhorn.io -l longhornvolume=pvc-cd6ba345-906b-4a8a-be87-bbc8328b3219 -o jsonpath='{.items[0].status.replicaModeMap}'
```
All three replicas must read `RW`.

## Not included (separate follow-ups)

- `longGRPCTimeOut: 345600` (#1405) — **keep**, not a revert; 24h default cannot cover a full HDD rebuild
- tuppr `replicaCount: 0` — un-pause **last**, re-arms node-draining upgrades

https://claude.ai/code/session_01XUnN6zRrh7fyAVdBgv3NDc