### PR TITLE
feat(external-dns): target gw.ionfury.tv DDNS for live cluster DNS records

### DIFF
--- a/kubernetes/clusters/live/charts/external-dns.yaml
+++ b/kubernetes/clusters/live/charts/external-dns.yaml
@@ -12,6 +12,10 @@ domainFilters:
 
 policy: sync
 
+extraArgs:
+  target:
+    - gw.ionfury.tv
+
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65534


### PR DESCRIPTION
## Summary

- Adds `--target=gw.ionfury.tv` to the live cluster's external-dns Helm values
- external-dns will now create **CNAME records** pointing at the DDNS hostname instead of **A records** pointing at the internal gateway IP (`192.168.91.23`)
- Cloudflare CNAME records track the public IP dynamically via UniFi DDNS — no more stale internal IPs in public DNS

## Test plan

- [ ] Verify external-dns pod reconciles cleanly after merge
- [ ] Confirm Cloudflare records change from A → CNAME pointing to `gw.ionfury.tv`
- [ ] Confirm external access to a sample service (e.g. `auth.ionfury.tv`) resolves correctly through the DDNS chain

https://claude.ai/code/session_01JGb1GkCKYmJM8FRsV9PpSb