### PR TITLE
fix(external-dns): remove invalid --target flag, use gateway annotation instead

### DIFF
--- a/kubernetes/clusters/live/charts/external-dns.yaml
+++ b/kubernetes/clusters/live/charts/external-dns.yaml
@@ -12,10 +12,6 @@ domainFilters:
 
 policy: sync
 
-extraArgs:
-  target:
-    - gw.ionfury.tv
-
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65534

--- a/kubernetes/clusters/live/charts/external-dns.yaml
+++ b/kubernetes/clusters/live/charts/external-dns.yaml
@@ -12,6 +12,10 @@ domainFilters:
 
 policy: sync
 
+extraArgs:
+  target:
+    - gw.ionfury.tv
+
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65534

--- a/kubernetes/platform/config/gateway/external-gateway.yaml
+++ b/kubernetes/platform/config/gateway/external-gateway.yaml
@@ -4,6 +4,8 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: external
+  annotations:
+    external-dns.alpha.kubernetes.io/target: gw.ionfury.tv
 spec:
   infrastructure:
     parametersRef:


### PR DESCRIPTION
## Summary

Hotfix for crashloop introduced by #1425.

- Remove `extraArgs.target` — `--target` is not a valid external-dns flag; caused `CrashLoopBackOff` immediately on deploy
- Add `external-dns.alpha.kubernetes.io/target: gw.ionfury.tv` annotation to the external Gateway — correct mechanism; external-dns reads this from the parent Gateway when processing HTTPRoutes and creates CNAME records pointing at the DDNS hostname

## Test plan

- [ ] external-dns pod starts cleanly (no more crash)
- [ ] Cloudflare records flip from A (`192.168.91.23`) → CNAME (`gw.ionfury.tv`)

https://claude.ai/code/session_01JGb1GkCKYmJM8FRsV9PpSb