### PR TITLE
fix(paperless): clear SSA-orphaned valuesFrom on migrated HelmRelease

### DIFF
--- a/kubernetes/clusters/CLAUDE.md
+++ b/kubernetes/clusters/CLAUDE.md
@@ -63,6 +63,8 @@ Cluster-specific Helm releases via ResourceSet (mirrors platform pattern). The R
 
 **Migrating an app from the legacy pattern:** ownership transfer between Flux owners races with garbage collection. Always land a prep PR first that annotates the app's objects with `kustomize.toolkit.fluxcd.io/prune: disabled` (config resources) and sets `pruneDisabled: true` on the app's input in `resourcesets/helm-charts.yaml` (generated HelmRepository/HelmRelease/wrapper Kustomization). Only after that deploys, move the files.
 
+**SSA field-ownership leak:** the migration moves the HelmRelease across field managers (flux-operator → kustomize-controller), and server-side apply only removes a field when the *owning* manager applies without it. Any field present in the legacy spec but absent in the new one is orphaned on the live object. In practice this is `spec.valuesFrom`: the new HelmRelease must declare `valuesFrom: []` explicitly to claim the field and clear the stale `cluster-values` reference, otherwise the HelmRelease fails with `key not found` once the values key is removed from `charts/`.
+
 ### Dependency Model
 
 Dependency order: platform → config.yaml, helm-charts.yaml, and apps.yaml (all dependsOn platform).

--- a/kubernetes/clusters/live/apps/paperless/helmrelease.yaml
+++ b/kubernetes/clusters/live/apps/paperless/helmrelease.yaml
@@ -32,6 +32,11 @@ spec:
     strategy:
       name: RetryOnFailure
     timeout: 10m
+  # Explicit empty list is required (not merely absent): the legacy ResourceSet's
+  # flux-operator field manager still owns spec.valuesFrom on the live object, and
+  # SSA only removes a field when the owning manager applies without it. Setting []
+  # transfers ownership to kustomize-controller; may be dropped after migration.
+  valuesFrom: []
   values:
     # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
     # https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template


### PR DESCRIPTION
## Problem

Post-#1421, live paperless HelmRelease is `Ready: False`:

```
could not resolve ConfigMap chart values reference 'flux-system/cluster-values' with key 'paperless.yaml': key not found
```

The live object carries **both** the new inline `values` and the legacy `valuesFrom` reference. Root cause is a server-side-apply field-ownership leak:

- Legacy HelmRelease was applied by **flux-operator** (cluster-resources ResourceSet), which owns `spec.valuesFrom` (`managedFields` confirms: manager `flux-operator`, operation `Apply`).
- New HelmRelease is applied by **kustomize-controller**, whose manifest simply omits `valuesFrom`. SSA only deletes a field when the *owning* manager applies without it, so the field is orphaned — flux-operator will never apply this object again (input removed + prune disabled).
- When #1421 also removed `paperless.yaml` from the `cluster-values` ConfigMap, helm-controller could no longer resolve the stale reference.

Workload impact: none. Pod untouched (25h+ age), last helm upgrade succeeded (v189); only subsequent reconciles fail.

## Fix

Declare `valuesFrom: []` explicitly in `apps/paperless/helmrelease.yaml`. kustomize-controller claims the field via SSA and sets it empty; helm-controller then resolves values from the inline `values` only. Purely declarative — no manual patch on live.

Once kustomize-controller owns the field, a later cleanup PR may drop the line entirely (removal by the owning manager deletes the field).

## Docs

Added the SSA field-ownership leak to the migration procedure in `kubernetes/clusters/CLAUDE.md` — every remaining app migration crosses the same manager boundary and must include `valuesFrom: []`.

## Validation

- `task k8s:validate-live` passes
- `kustomize build` preserves the empty array (`valuesFrom: []` present in rendered output)

## Post-merge verification

- [ ] `kubectl --context live get hr paperless -n flux-system -o jsonpath='{.spec.valuesFrom}'` returns `[]`
- [ ] HelmRelease `Ready: True`, Kustomization `paperless` health check passes
- [ ] Pod not restarted, PVCs untouched

https://claude.ai/code/session_01JHmQzFkRyMtMbupsSzgWpv