### PR TITLE
fix(vaultwarden): enable drift detection to restore missing HTTPRoute

### DIFF
--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -22,6 +22,7 @@ spec:
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
       dependsOn: [cloudnative-pg, secret-generator]
+      driftDetection: true
     - name: zipline
       namespace: zipline
       chart:
@@ -354,6 +355,10 @@ spec:
         strategy:
           name: RetryOnFailure
         timeout: 10m
+      <<- if and (hasKey inputs "driftDetection") inputs.driftDetection >>
+      driftDetection:
+        mode: enabled
+      <<- end >>
       valuesFrom:
         - kind: ConfigMap
           name: cluster-values


### PR DESCRIPTION
## Summary

- Adds opt-in `driftDetection: true` flag support to the cluster ResourceSet template, emitting `driftDetection: { mode: enabled }` on the generated HelmRelease when set
- Enables the flag for vaultwarden, which lost its HTTPRoute to an out-of-band deletion that went undetected (no drift detection configured)
- On merge → deploy, helm-controller detects the missing HTTPRoute and recreates it, resolving the active `CanaryCheckFailure` and `CanaryCheckHighFailureRate` alerts

## Root cause

HelmRelease v189 (2026-05-26) rendered and applied the vaultwarden HTTPRoute, recording it in inventory. A subsequent out-of-band deletion went undetected because `driftDetection` was not configured — helm-controller only applies manifests during installs/upgrades, not continuously.

## Test plan

- [ ] Merge and confirm OCI artifact promotes to live
- [ ] `kubectl --context live get httproute -n vaultwarden` shows the `vaultwarden` HTTPRoute recreated
- [ ] `vault.internal.tomnowak.work/alive` returns 200
- [ ] `CanaryCheckFailure` and `CanaryCheckHighFailureRate` alerts clear in Alertmanager

https://claude.ai/code/session_01X7i35onCuNimfo7SN5cymy