### PR TITLE
feat(helm-releases): make drift detection the default for all HelmReleases

### DIFF
--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -22,7 +22,6 @@ spec:
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
       dependsOn: [cloudnative-pg, secret-generator]
-      driftDetection: true
     - name: zipline
       namespace: zipline
       chart:
@@ -355,7 +354,7 @@ spec:
         strategy:
           name: RetryOnFailure
         timeout: 10m
-      <<- if and (hasKey inputs "driftDetection") inputs.driftDetection >>
+      <<- if not (and (hasKey inputs "driftDetectionDisabled") inputs.driftDetectionDisabled) >>
       driftDetection:
         mode: enabled
       <<- end >>


### PR DESCRIPTION
## Summary

> **Depends on #1429** — merge that first.

Inverts the drift detection model: all HelmReleases generated by the cluster ResourceSet now enable `driftDetection: { mode: enabled }` by default. Any release needing to opt out can set `driftDetectionDisabled: true` on its input.

- Removes the per-app `driftDetection: true` flag added in #1429 (now redundant)
- Inverts the template conditional from opt-in to opt-out
- Applies drift detection to all ~35 cluster HelmReleases with no per-app config required

## Why default-on

Helm-controller without drift detection only applies manifests during install/upgrade. Out-of-band resource deletions go undetected indefinitely — exactly what caused the vaultwarden outage. Drift detection is the correct default for a declarative GitOps platform where "drift is a bug."

## Risk

On first reconcile after deploy, helm-controller checks all managed resources. Any release with a missing resource will trigger a corrective upgrade. This is intended behavior — self-healing is the goal.

## Test plan

- [ ] Merge #1429 first
- [ ] Merge this PR and confirm artifact promotes to live
- [ ] `kubectl --context live get helmrelease -A -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.driftDetection.mode}{"\n"}{end}'` shows `enabled` for all cluster ResourceSet releases
- [ ] No unexpected HelmRelease failures after reconcile

https://claude.ai/code/session_01X7i35onCuNimfo7SN5cymy