### PR TITLE
fix(tuppr): restore replicaCount to 3

### DIFF
--- a/kubernetes/platform/charts/tuppr.yaml
+++ b/kubernetes/platform/charts/tuppr.yaml
@@ -1,6 +1,6 @@
 ---
 # https://github.com/home-operations/tuppr
-replicaCount: 0
+replicaCount: 3
 monitoring:
   serviceMonitor:
     enabled: true


### PR DESCRIPTION
## Summary

Reverts f659065c (\"pause tuppr\", 7 days ago). Restores tuppr to 3 replicas so it can resume managing Talos and Kubernetes upgrades.

## Test plan

- [ ] Confirm artifact promotes to live
- [ ] `kubectl --context live get deploy tuppr -n system-upgrade` shows `3/3 Ready`

https://claude.ai/code/session_01X7i35onCuNimfo7SN5cymy