### PR TITLE
feat(monitoring): ingress gateway dashboards + external geoip enrichment

### DIFF
--- a/.taskfiles/kubernetes/scripts/generate-crd-schemas.py
+++ b/.taskfiles/kubernetes/scripts/generate-crd-schemas.py
@@ -14,6 +14,13 @@ import sys
 
 import yaml
 
+# Some CRDs (e.g. tuppr's matchType) use a bare "=" scalar, which YAML resolves
+# to the tag:yaml.org,2002:value tag. PyYAML's SafeLoader has no constructor for
+# it and crashes, so treat it as a plain string.
+yaml.SafeLoader.add_constructor(
+    "tag:yaml.org,2002:value", yaml.SafeLoader.construct_yaml_str
+)
+
 
 def crd_to_jsonschema(crd: dict) -> list[tuple[str, dict]]:
     """Extract JSON schemas from a CRD, one per version. Returns [(filename, schema)]."""

--- a/kubernetes/platform/charts/alloy.yaml
+++ b/kubernetes/platform/charts/alloy.yaml
@@ -4,9 +4,69 @@ fullnameOverride: alloy
 controller:
   type: daemonset
   priorityClassName: platform
+  # Shared scratch volume holding the MaxMind GeoLite2 City DB. Per-pod (DaemonSet)
+  # so every node's Alloy has a local copy for access-log geo enrichment.
+  volumes:
+    extra:
+      - name: geoip
+        emptyDir: { }
+  # Blocking one-shot download so the mmdb exists before Alloy starts and its
+  # stage.geoip references a present file (FREQUENCY=0 = run once and exit).
+  initContainers:
+    - name: geoipupdate-init
+      # renovate: datasource=docker depName=ghcr.io/maxmind/geoipupdate
+      image: &geoipupdate ghcr.io/maxmind/geoipupdate:v8.0.0
+      env:
+        - name: GEOIPUPDATE_EDITION_IDS
+          value: GeoLite2-City
+        - name: GEOIPUPDATE_DB_DIR
+          value: /geoip
+        - name: GEOIPUPDATE_FREQUENCY
+          value: "0"
+      envFrom:
+        - secretRef:
+            name: maxmind-geoip-license
+      volumeMounts:
+        - name: geoip
+          mountPath: /geoip
+      resources:
+        requests:
+          cpu: 5m
+          memory: 32Mi
+        limits:
+          memory: 64Mi
+  # Sidecar refreshing the DB daily (FREQUENCY in hours). GeoLite2 updates a few
+  # times per week; a long-lived Alloy pod would otherwise drift stale.
+  extraContainers:
+    - name: geoipupdate
+      image: *geoipupdate
+      env:
+        - name: GEOIPUPDATE_EDITION_IDS
+          value: GeoLite2-City
+        - name: GEOIPUPDATE_DB_DIR
+          value: /geoip
+        - name: GEOIPUPDATE_FREQUENCY
+          value: "24"
+      envFrom:
+        - secretRef:
+            name: maxmind-geoip-license
+      volumeMounts:
+        - name: geoip
+          mountPath: /geoip
+      resources:
+        requests:
+          cpu: 5m
+          memory: 32Mi
+        limits:
+          memory: 64Mi
 alloy:
   mounts:
     varlog: true
+    # Read-only view of the geoip DB maintained by the geoipupdate containers.
+    extra:
+      - name: geoip
+        mountPath: /geoip
+        readOnly: true
   configMap:
     content: |
       // Discover pods on this node only (prevents FD exhaustion from cluster-wide scrape)
@@ -42,6 +102,12 @@ alloy:
           source_labels = ["__meta_kubernetes_pod_node_name"]
           target_label  = "node"
         }
+        // Expose the Gateway API gateway name (external / internal) as a label so
+        // geoip enrichment below can scope itself to external ingress access logs.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_gateway_networking_k8s_io_gateway_name"]
+          target_label  = "gateway"
+        }
         rule {
           source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_name"]
           separator     = "/"
@@ -61,6 +127,43 @@ alloy:
           selector = "{app=\"loki\"}"
           action   = "drop"
         }
+
+        // Geo-enrich external ingress access logs. Scoped by the gateway label so
+        // only the external gateway's Envoy JSON access logs pay the parse cost.
+        // The client IP comes from x_forwarded_for (real IP now that the gateway
+        // Service uses externalTrafficPolicy: Local). geoip fields are attached as
+        // structured metadata (geoip_lat/geoip_lon/geoip_country_code) — not stream
+        // labels — so unbounded lat/lon values never inflate Loki's index.
+        stage.match {
+          selector = "{namespace=\"istio-gateway\", gateway=\"external\"}"
+
+          stage.json {
+            expressions = {
+              xff = "x_forwarded_for",
+            }
+          }
+          // x_forwarded_for may be "client, proxy1, ..."; take the first hop.
+          stage.regex {
+            expression = "^(?P<geoip_ip>[^,\\s]+)"
+            source     = "xff"
+          }
+          stage.geoip {
+            source  = "geoip_ip"
+            db      = "/geoip/GeoLite2-City.mmdb"
+            db_type = "city"
+          }
+          // Private/LAN IPs don't resolve, leaving geoip fields empty — those lines
+          // simply carry no coordinates and are ignored by the map.
+          stage.structured_metadata {
+            values = {
+              geoip_country_code = "",
+              geoip_city         = "geoip_city_name",
+              geoip_lat          = "geoip_location_latitude",
+              geoip_lon          = "geoip_location_longitude",
+            }
+          }
+        }
+
         forward_to = [loki.process.drop_old_entries.receiver]
       }
 

--- a/kubernetes/platform/config/gateway/gateway-deployment-defaults.yaml
+++ b/kubernetes/platform/config/gateway/gateway-deployment-defaults.yaml
@@ -14,3 +14,11 @@ data:
   podDisruptionBudget: |
     spec:
       maxUnavailable: 1
+  # Preserve the real client source IP end-to-end. With Cilium L2 the node
+  # holding the LB IP forwards only to a local gateway pod (no SNAT), so the
+  # client IP reaches Envoy's access log — required for geoip enrichment.
+  # HA is retained: Cilium announces the LB IP only from nodes with a ready
+  # gateway pod (external + internal both run multiple replicas).
+  service: |
+    spec:
+      externalTrafficPolicy: Local

--- a/kubernetes/platform/config/monitoring/gateway-ingress-dashboards.yaml
+++ b/kubernetes/platform/config/monitoring/gateway-ingress-dashboards.yaml
@@ -1,0 +1,1553 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-gateway-ingress-overview
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "true"
+  annotations:
+    grafana_folder: Network
+data:
+  gateway-ingress-overview.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [
+        {
+          "asDropdown": false,
+          "title": "Detail \u2192",
+          "type": "link",
+          "url": "/d/gateway-ingress-detail",
+          "icon": "external link",
+          "includeVars": true,
+          "keepTime": true,
+          "targetBlank": false,
+          "tags": []
+        }
+      ],
+      "panels": [
+        {
+          "type": "row",
+          "collapsed": false,
+          "title": "Golden Signals",
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1
+        },
+        {
+          "type": "stat",
+          "title": "Request Rate",
+          "description": "Total ingress request rate through the selected gateway.",
+          "gridPos": {
+            "h": 5,
+            "w": 4,
+            "x": 0,
+            "y": 1
+          },
+          "id": 2,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\"}[$__rate_interval]))",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "reqps",
+              "decimals": 2
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          }
+        },
+        {
+          "type": "stat",
+          "title": "Success Rate",
+          "description": "Percent non-5xx. Below SLO fires GatewayAvailabilityBudgetBurning*. Lower is worse.",
+          "gridPos": {
+            "h": 5,
+            "w": 4,
+            "x": 4,
+            "y": 1
+          },
+          "id": 3,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "100 * sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\",response_code!~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\"}[$__rate_interval])), 1e-9)",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 95
+                  },
+                  {
+                    "color": "green",
+                    "value": 99
+                  }
+                ]
+              },
+              "unit": "percent",
+              "decimals": 2
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          }
+        },
+        {
+          "type": "stat",
+          "title": "5xx Error Rate",
+          "description": "Percent of 5xx responses. Higher is worse; drives availability error budget.",
+          "gridPos": {
+            "h": 5,
+            "w": 4,
+            "x": 8,
+            "y": 1
+          },
+          "id": 4,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "100 * sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\",response_code=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\"}[$__rate_interval])), 1e-9)",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 5
+                  }
+                ]
+              },
+              "unit": "percent",
+              "decimals": 2
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          }
+        },
+        {
+          "type": "stat",
+          "title": "4xx Error Rate",
+          "description": "Percent of 4xx (client/auth). Context, not an SLO breach.",
+          "gridPos": {
+            "h": 5,
+            "w": 4,
+            "x": 12,
+            "y": 1
+          },
+          "id": 5,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "100 * sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\",response_code=~\"4..\"}[$__rate_interval])) / clamp_min(sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\"}[$__rate_interval])), 1e-9)",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 20
+                  },
+                  {
+                    "color": "red",
+                    "value": 50
+                  }
+                ]
+              },
+              "unit": "percent",
+              "decimals": 2
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          }
+        },
+        {
+          "type": "stat",
+          "title": "p95 Latency",
+          "description": "95th percentile duration. Above per-app SLO fires GatewayLatencyBudgetBurning*.",
+          "gridPos": {
+            "h": 5,
+            "w": 4,
+            "x": 16,
+            "y": 1
+          },
+          "id": 6,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"source\",source_workload=\"$gateway\"}[$__rate_interval])) by (le))",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1000
+                  },
+                  {
+                    "color": "red",
+                    "value": 2500
+                  }
+                ]
+              },
+              "unit": "ms",
+              "decimals": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          }
+        },
+        {
+          "type": "stat",
+          "title": "p99 Latency",
+          "description": "99th percentile (tail). Sustained spikes = saturation or upstream stalls.",
+          "gridPos": {
+            "h": 5,
+            "w": 4,
+            "x": 20,
+            "y": 1
+          },
+          "id": 7,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"source\",source_workload=\"$gateway\"}[$__rate_interval])) by (le))",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 2500
+                  },
+                  {
+                    "color": "red",
+                    "value": 5000
+                  }
+                ]
+              },
+              "unit": "ms",
+              "decimals": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          }
+        },
+        {
+          "type": "row",
+          "collapsed": false,
+          "title": "Traffic Origin & Share",
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 6
+          },
+          "id": 8
+        },
+        {
+          "type": "geomap",
+          "title": "Client Origin (external)",
+          "description": "Geo origin of external ingress clients from Alloy geoip-enriched access logs (structured metadata geoip_lat/geoip_lon). Populated once the geo pipeline is deployed; empty for the internal gateway.",
+          "gridPos": {
+            "h": 13,
+            "w": 14,
+            "x": 0,
+            "y": 7
+          },
+          "id": 9,
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "refId": "A",
+              "queryType": "range",
+              "editorMode": "code",
+              "expr": "{namespace=\"istio-gateway\", gateway=\"external\"} | geoip_lat != \"\""
+            }
+          ],
+          "transformations": [
+            {
+              "id": "extractFields",
+              "options": {
+                "source": "labels",
+                "keepLabels": true
+              }
+            },
+            {
+              "id": "convertFieldType",
+              "options": {
+                "conversions": [
+                  {
+                    "targetField": "geoip_lat",
+                    "destinationType": "number"
+                  },
+                  {
+                    "targetField": "geoip_lon",
+                    "destinationType": "number"
+                  }
+                ]
+              }
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "options": {
+            "view": {
+              "id": "zero",
+              "lat": 25,
+              "lon": 0,
+              "zoom": 1.6
+            },
+            "basemap": {
+              "type": "default",
+              "name": "Basemap"
+            },
+            "controls": {
+              "showZoom": true,
+              "mouseWheelZoom": true,
+              "showAttribution": true,
+              "showScale": false,
+              "showMeasure": false,
+              "showDebug": false
+            },
+            "layers": [
+              {
+                "type": "markers",
+                "name": "Clients",
+                "location": {
+                  "mode": "coords",
+                  "latitude": "geoip_lat",
+                  "longitude": "geoip_lon"
+                },
+                "config": {
+                  "showLegend": false,
+                  "style": {
+                    "size": {
+                      "fixed": 6
+                    },
+                    "color": {
+                      "fixed": "orange"
+                    },
+                    "opacity": 0.6
+                  }
+                },
+                "tooltip": true
+              }
+            ]
+          }
+        },
+        {
+          "type": "piechart",
+          "title": "Traffic Share by Endpoint",
+          "description": "Request-rate distribution across upstream apps for the selected gateway (fan-out map).",
+          "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 14,
+            "y": 7
+          },
+          "id": 10,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\"}[$__range])) by (destination_workload)",
+              "legendFormat": "{{destination_workload}}",
+              "refId": "A",
+              "instant": true,
+              "format": "time_series"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "values": [
+                "percent"
+              ]
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "type": "table",
+          "title": "Top Countries (external)",
+          "description": "Request count by client country (geoip_country_code) from enriched access logs. Populated post-deploy.",
+          "gridPos": {
+            "h": 6,
+            "w": 10,
+            "x": 14,
+            "y": 14
+          },
+          "id": 11,
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "refId": "A",
+              "queryType": "instant",
+              "editorMode": "code",
+              "expr": "sum by (geoip_country_code) (count_over_time({namespace=\"istio-gateway\", gateway=\"external\"} | json | geoip_country_code != \"\" [$__range]))"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "renameByName": {
+                  "geoip_country_code": "Country",
+                  "Value": "Requests"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "sort": [
+                  {
+                    "field": "Requests",
+                    "desc": true
+                  }
+                ]
+              }
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "show": false
+            }
+          }
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": [
+        "istio",
+        "gateway",
+        "ingress",
+        "network"
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "gateway",
+            "label": "Gateway",
+            "type": "custom",
+            "query": "Internal : internal-istio, External : external-istio",
+            "current": {
+              "text": "External",
+              "value": "external-istio"
+            },
+            "options": [
+              {
+                "text": "Internal",
+                "value": "internal-istio",
+                "selected": false
+              },
+              {
+                "text": "External",
+                "value": "external-istio",
+                "selected": true
+              }
+            ],
+            "includeAll": false,
+            "multi": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Ingress Gateway Overview",
+      "uid": "gateway-ingress-overview",
+      "version": 1
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-gateway-ingress-detail
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "true"
+  annotations:
+    grafana_folder: Network
+data:
+  gateway-ingress-detail.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [
+        {
+          "asDropdown": false,
+          "title": "\u2190 Overview",
+          "type": "link",
+          "url": "/d/gateway-ingress-overview",
+          "icon": "external link",
+          "includeVars": true,
+          "keepTime": true,
+          "targetBlank": false,
+          "tags": []
+        }
+      ],
+      "panels": [
+        {
+          "type": "row",
+          "collapsed": false,
+          "title": "Traffic \u2014 Rate, Errors, Duration",
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1
+        },
+        {
+          "type": "timeseries",
+          "title": "Request Rate by Response Class",
+          "description": "Request rate split by HTTP status class. Rising 5xx (red) is the availability signal.",
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 1
+          },
+          "id": 2,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\",response_code=~\"2..\"}[$__rate_interval]))",
+              "legendFormat": "2xx",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\",response_code=~\"3..\"}[$__rate_interval]))",
+              "legendFormat": "3xx",
+              "refId": "B"
+            },
+            {
+              "expr": "sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\",response_code=~\"4..\"}[$__rate_interval]))",
+              "legendFormat": "4xx",
+              "refId": "C"
+            },
+            {
+              "expr": "sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\",response_code=~\"5..\"}[$__rate_interval]))",
+              "legendFormat": "5xx",
+              "refId": "D"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 40,
+                "gradientMode": "opacity",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "unit": "reqps",
+              "decimals": 3
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "2xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "fixed",
+                      "fixedColor": "green"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "3xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "fixed",
+                      "fixedColor": "blue"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "4xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "fixed",
+                      "fixedColor": "yellow"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "5xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "fixed",
+                      "fixedColor": "red"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "type": "timeseries",
+          "title": "Error Ratio",
+          "description": "Share of 4xx/5xx. 5xx is the SLO breach; 4xx is client/auth noise.",
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 1
+          },
+          "id": 3,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "100 * sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\",response_code=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\"}[$__rate_interval])), 1e-9)",
+              "legendFormat": "5xx %",
+              "refId": "A"
+            },
+            {
+              "expr": "100 * sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\",response_code=~\"4..\"}[$__rate_interval])) / clamp_min(sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\"}[$__rate_interval])), 1e-9)",
+              "legendFormat": "4xx %",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "unit": "percent",
+              "decimals": 2
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "5xx %"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "fixed",
+                      "fixedColor": "red"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "4xx %"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "fixed",
+                      "fixedColor": "yellow"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "type": "timeseries",
+          "title": "Request Duration Percentiles",
+          "description": "p50/p95/p99 latency for the selected gateway only.",
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 1
+          },
+          "id": 4,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\"}[$__rate_interval])) by (le))",
+              "legendFormat": "p50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\"}[$__rate_interval])) by (le))",
+              "legendFormat": "p95",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\"}[$__rate_interval])) by (le))",
+              "legendFormat": "p99",
+              "refId": "C"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "unit": "ms",
+              "decimals": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "type": "row",
+          "collapsed": false,
+          "title": "Endpoints & Health",
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 5
+        },
+        {
+          "type": "table",
+          "title": "Per-Endpoint RED",
+          "description": "Rate, error and duration per upstream app for the selected gateway. Sortable; low success red, slow p95 highlights. Auto-discovers apps.",
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 6,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\"}[$__range])) by (destination_workload)",
+              "legendFormat": "",
+              "refId": "A",
+              "instant": true,
+              "format": "table"
+            },
+            {
+              "expr": "100 * sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\",response_code!~\"5..\"}[$__range])) by (destination_workload) / clamp_min(sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\"}[$__range])) by (destination_workload), 1e-9)",
+              "legendFormat": "",
+              "refId": "B",
+              "instant": true,
+              "format": "table"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\"}[$__range])) by (destination_workload, le))",
+              "legendFormat": "",
+              "refId": "C",
+              "instant": true,
+              "format": "table"
+            },
+            {
+              "expr": "sum(rate(istio_response_bytes_sum{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\"}[$__range])) by (destination_workload)",
+              "legendFormat": "",
+              "refId": "D",
+              "instant": true,
+              "format": "table"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "destination_workload",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time 1": true,
+                  "Time 2": true,
+                  "Time 3": true,
+                  "Time 4": true
+                },
+                "renameByName": {
+                  "destination_workload": "Endpoint",
+                  "Value #A": "Req/s",
+                  "Value #B": "Success %",
+                  "Value #C": "p95 (ms)",
+                  "Value #D": "Resp bytes/s"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "sort": [
+                  {
+                    "field": "Req/s",
+                    "desc": true
+                  }
+                ]
+              }
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                }
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "mode": "gradient",
+                      "type": "gauge"
+                    }
+                  },
+                  {
+                    "id": "min",
+                    "value": 90
+                  },
+                  {
+                    "id": "max",
+                    "value": 100
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 95
+                        },
+                        {
+                          "color": "green",
+                          "value": 99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Req/s"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "reqps"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 3
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "p95 (ms)"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "ms"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 0
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "mode": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 1000
+                        },
+                        {
+                          "color": "red",
+                          "value": 2500
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Resp bytes/s"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "Bps"
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "enablePagination": false,
+              "show": false
+            }
+          }
+        },
+        {
+          "type": "heatmap",
+          "title": "Latency Distribution",
+          "description": "Request duration histogram over time. Bands drifting up = degradation.",
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "id": 7,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "legendFormat": "{{le}}",
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "calculate": false,
+            "cellGap": 1,
+            "color": {
+              "scheme": "Spectral",
+              "mode": "scheme",
+              "steps": 64,
+              "reverse": true
+            },
+            "yAxis": {
+              "unit": "ms",
+              "axisPlacement": "left"
+            },
+            "tooltip": {
+              "show": true,
+              "yHistogram": true
+            },
+            "legend": {
+              "show": false
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "tooltip": false,
+                  "viz": false,
+                  "legend": false
+                }
+              }
+            },
+            "overrides": []
+          }
+        },
+        {
+          "type": "timeseries",
+          "title": "Response Flags (non-normal)",
+          "description": "Envoy response flags excluding '-'. DC/UC/UF/UH = connection wedges; correlates with GatewayZeroResponseCode.",
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 12,
+            "y": 16
+          },
+          "id": 8,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\",response_flags!=\"-\"}[$__rate_interval])) by (response_flags)",
+              "legendFormat": "{{response_flags}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "unit": "reqps",
+              "decimals": 3
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "type": "timeseries",
+          "title": "Throughput",
+          "description": "Request bytes in / response bytes out through the gateway.",
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 18,
+            "y": 16
+          },
+          "id": 9,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(istio_request_bytes_sum{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\"}[$__rate_interval]))",
+              "legendFormat": "in",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(istio_response_bytes_sum{reporter=\"source\",source_workload=\"$gateway\",destination_workload=~\"$destination\"}[$__rate_interval]))",
+              "legendFormat": "out",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": [
+        "istio",
+        "gateway",
+        "ingress",
+        "network"
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "gateway",
+            "label": "Gateway",
+            "type": "custom",
+            "query": "Internal : internal-istio, External : external-istio",
+            "current": {
+              "text": "External",
+              "value": "external-istio"
+            },
+            "options": [
+              {
+                "text": "Internal",
+                "value": "internal-istio",
+                "selected": false
+              },
+              {
+                "text": "External",
+                "value": "external-istio",
+                "selected": true
+              }
+            ],
+            "includeAll": false,
+            "multi": false
+          },
+          {
+            "name": "destination",
+            "label": "Endpoint",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "query": {
+              "query": "label_values(istio_requests_total{reporter=\"source\",source_workload=\"$gateway\"}, destination_workload)",
+              "refId": "dest"
+            },
+            "refresh": 2,
+            "includeAll": true,
+            "allValue": ".*",
+            "multi": true,
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            },
+            "sort": 1
+          }
+        ]
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Ingress Gateway Detail",
+      "uid": "gateway-ingress-detail",
+      "version": 1
+    }

--- a/kubernetes/platform/config/monitoring/kustomization.yaml
+++ b/kubernetes/platform/config/monitoring/kustomization.yaml
@@ -46,4 +46,6 @@ resources:
   - velero-dashboard.yaml
   - network-throughput-dashboard.yaml
   - platform-home-dashboard.yaml
+  - gateway-ingress-dashboards.yaml
+  - maxmind-geoip-secret.yaml
   - grafana-dashboard-loki-logs.yaml

--- a/kubernetes/platform/config/monitoring/maxmind-geoip-secret.yaml
+++ b/kubernetes/platform/config/monitoring/maxmind-geoip-secret.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: maxmind-geoip-license
+  namespace: monitoring
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: maxmind-geoip-license
+    # Key names match the geoipupdate container env vars so the DaemonSet can
+    # consume them directly via envFrom (GEOIPUPDATE_ACCOUNT_ID / _LICENSE_KEY).
+    template:
+      engineVersion: v2
+      data:
+        GEOIPUPDATE_ACCOUNT_ID: "{{ .accountId }}"
+        GEOIPUPDATE_LICENSE_KEY: "{{ .licenseKey }}"
+  data:
+    - secretKey: accountId
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/maxmind-account-id
+    - secretKey: licenseKey
+      remoteRef:
+        key: /homelab/kubernetes/${cluster_name}/maxmind-license-key

--- a/kubernetes/platform/references/bootstrap-secrets.md
+++ b/kubernetes/platform/references/bootstrap-secrets.md
@@ -9,6 +9,8 @@ When bootstrapping a new cluster, populate these SSM parameters before the clust
 | `/homelab/kubernetes/<cluster>/cloudflare-api-token` | Cloudflare API token for DNS challenges | JSON: `{"token": "<value>"}` |
 | `/homelab/kubernetes/<cluster>/discord-webhook-secret` | Discord webhook URL for Alertmanager | Plain string: webhook URL |
 | `/homelab/kubernetes/shared/istio-mesh-ca` | Shared Istio mesh root CA (all clusters) | JSON: `{"tls.crt": "<base64>", "tls.key": "<base64>"}` |
+| `/homelab/kubernetes/<cluster>/maxmind-account-id` | MaxMind account ID for GeoLite2 (gateway geoip enrichment) | Plain string: numeric account ID |
+| `/homelab/kubernetes/<cluster>/maxmind-license-key` | MaxMind license key for GeoLite2 downloads | Plain string: license key |
 
 ## Bootstrap-Managed Secrets
 


### PR DESCRIPTION
## What

Two one-screen Grafana dashboards for Istio ingress (Network folder), toggled internal/external via a `$gateway` variable, plus the geo pipeline that lights up the client-origin map.

**Dashboards** (previewed live against real traffic during authoring):
- **Overview** (`gateway-ingress-overview`) — golden-signal RED tiles, client-origin geomap, traffic-share donut, top-countries. Fits one 1080p screen.
- **Detail** (`gateway-ingress-detail`) — RED timeseries (rate-by-class / error ratio / latency percentiles), per-endpoint RED table, latency heatmap, response flags, throughput. `$destination` filter. Fits one screen.
- Cross-linked; `$gateway` + time range carry across.

**Geo pipeline** (external gateway only):
```
client -> external Envoy (Local: real IP in x_forwarded_for) -> JSON access log
  -> Alloy: match gateway=external -> json -> regex(first IP) -> stage.geoip(GeoLite2-City)
  -> structured metadata geoip_lat/geoip_lon/geoip_country_code -> Loki -> geomap + top-countries
DB: geoipupdate init(one-shot) + sidecar(24h) -> shared emptyDir per node
```

## Why

No dedicated ingress dashboard existed — only 3 merged gateway panels buried in platform-signals. This gives per-gateway RED, per-endpoint breakdown, and geographic origin of external clients.

## Design notes

- `externalTrafficPolicy: Local` on the shared gateway deployment-defaults ConfigMap preserves the real client IP (Cilium L2, no SNAT). Applies to **both** gateways; HA retained via 3-replica spread.
- geoip lat/lon stored as Loki **structured metadata**, not stream labels — avoids index cardinality blowup.
- geoipupdate egress reuses the existing `monitoring` `world:443` allowance (no new netpol).
- `geoipupdate` pinned to v8.0.0 with Renovate annotation.

## Prerequisite (done)

SSM params populated:
- `/homelab/kubernetes/live/maxmind-account-id`
- `/homelab/kubernetes/live/maxmind-license-key`

(documented in `references/bootstrap-secrets.md`)

## Post-deploy validation (cannot test pre-merge)

- Alloy river geoip stages execute only at runtime (validate templates the config string, not the pipeline).
- geomap coords rendering (structured-metadata -> numeric field transform) may need one live tweak once real points flow.
- `externalTrafficPolicy: Local` rollout — watch external ingress continuity.

## Validation

`task k8s:validate` passes (yaml lint, 36 charts templated, no deprecated APIs, no duplicate keys).

https://claude.ai/code/session_015Xn8bQ2jDvQrDuZXXN5H2P