### PR TITLE
fix(renovate): use docker datasource for OCI-hosted konflate chart

### DIFF
--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -111,5 +111,5 @@ palworld_server_version=v2.7.1
 talos_pxe_schematic_id=613e1592b2da41ae5e265e8789429f22e121aab91cb4deb6bc3c0b6262961245
 
 # Konflate
-# renovate: datasource=helm depName=konflate registryUrl=oci://ghcr.io/home-operations/charts
+# renovate: datasource=docker depName=konflate packageName=ghcr.io/home-operations/charts/konflate
 konflate_version=0.4.3


### PR DESCRIPTION
## Summary

- Fixes Renovate failing on every run since #1423 merged on 2026-07-25
- `datasource=helm` cannot parse `oci://` URLs — it expects HTTP repos with `index.yaml`
- Changed to `datasource=docker` with `packageName=ghcr.io/home-operations/charts/konflate`, matching how other OCI-hosted `home-operations` images are tracked in `versions.env`

## Root cause

```
ERROR: Request Error: cannot parse url
  "url": "index.yaml"
  "baseUrl": "oci://ghcr.io/home-operations/charts/"
  "resolvedUrl": "oci://ghcr.io/home-operations/charts/index.yaml"
```

Single ERROR-level log → Renovate exits non-zero → every GHA run reports failure.

## Test plan

- [ ] Merge and confirm next Renovate GHA run exits 0
- [ ] Verify Renovate can look up `konflate` version updates

https://claude.ai/code/session_014BgkAg5RHUmN4XZhy8PyZk