### PR TITLE
feat(home-assistant): add code-server sidecar for HA config editing

### DIFF
--- a/kubernetes/clusters/live/charts/home-assistant.yaml
+++ b/kubernetes/clusters/live/charts/home-assistant.yaml
@@ -54,6 +54,49 @@ controllers:
             memory: 128Mi
 
     containers:
+      code-server:
+        image:
+          repository: codercom/code-server
+          tag: "${code_server_version}"
+        args:
+          - --bind-addr=0.0.0.0:8080
+          - --auth=none
+          - /home/coder/hass-config
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: [ALL]
+          runAsNonRoot: false
+          runAsUser: 0
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            memory: 512Mi
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /healthz
+                port: 8080
+              initialDelaySeconds: 10
+              periodSeconds: 30
+              failureThreshold: 3
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /healthz
+                port: 8080
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              failureThreshold: 3
+
       app:
         image:
           repository: ghcr.io/home-assistant/home-assistant
@@ -118,6 +161,8 @@ service:
     ports:
       http:
         port: 8123
+      code-server:
+        port: 8080
 
 serviceMonitor:
   app:
@@ -149,10 +194,35 @@ route:
       - backendRefs:
           - identifier: app
             port: 8123
+  code-server:
+    enabled: true
+    annotations:
+      gethomepage.dev/enabled: "true"
+      gethomepage.dev/name: "HA Config Editor"
+      gethomepage.dev/group: "Home"
+      gethomepage.dev/icon: "code.svg"
+      gethomepage.dev/pod-selector: "app.kubernetes.io/name=home-assistant"
+    parentRefs:
+      - name: internal
+        namespace: istio-gateway
+    hostnames:
+      - "hass-code.${internal_domain}"
+    rules:
+      - backendRefs:
+          - identifier: app
+            port: 8080
 
 persistence:
   config:
     existingClaim: hass-config
+    advancedMounts:
+      home-assistant:
+        app:
+          - path: /config
+        install-oidc-component:
+          - path: /config
+        code-server:
+          - path: /home/coder/hass-config
   tmp:
     type: emptyDir
     globalMounts:
@@ -160,7 +230,9 @@ persistence:
   hass-config-yaml:
     type: configMap
     name: hass-config
-    globalMounts:
-      - path: /config/configuration.yaml
-        subPath: configuration.yaml
-        readOnly: true
+    advancedMounts:
+      home-assistant:
+        app:
+          - path: /config/configuration.yaml
+            subPath: configuration.yaml
+            readOnly: true

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -100,6 +100,8 @@ papra_version=26.6.1-rootless
 home_assistant_version=2025.12.5
 # renovate: datasource=github-releases depName=hass-oidc-auth packageName=christiaangoossens/hass-oidc-auth
 hass_oidc_auth_version=v1.1.1
+# renovate: datasource=docker depName=code-server packageName=codercom/code-server
+code_server_version=4.131.0
 
 # Palworld
 # renovate: datasource=docker depName=ghcr.io/thijsvanloef/palworld-server-docker

--- a/kubernetes/platform/config/gateway/platform-auth-policy.yaml
+++ b/kubernetes/platform/config/gateway/platform-auth-policy.yaml
@@ -23,3 +23,4 @@ spec:
               - "hubble.${internal_domain}"
               - "garage.${internal_domain}"
               - "grafana.${internal_domain}"
+              - "hass-code.${internal_domain}"


### PR DESCRIPTION
## Summary

- Adds code-server 4.131.0 as a sidecar container within the existing Home Assistant pod, allowing browser-based editing of the HA config via VS Code
- The sidecar shares the `hass-config` PVC (which is ReadWriteOnce) by running in the same pod — no new PVC or access mode change needed
- Exposes the editor at `hass-code.<internal_domain>` via the internal gateway, protected by the existing oauth2-proxy AuthorizationPolicy (same auth as Grafana, Prometheus, Longhorn, etc.)
- Code-server's built-in auth is disabled (`--auth=none`) since the gateway layer handles authentication

## Changes

- `kubernetes/clusters/live/charts/home-assistant.yaml`: adds `code-server` sidecar container (port 8080), updates persistence to use `advancedMounts` so both HA and code-server mount the PVC at their respective paths, adds service port `code-server: 8080`, adds `route.code-server` HTTPRoute for `hass-code.${internal_domain}`
- `kubernetes/clusters/live/versions.env`: adds `code_server_version=4.131.0` with Renovate annotation for automatic tracking
- `kubernetes/platform/config/gateway/platform-auth-policy.yaml`: adds `hass-code.${internal_domain}` to the list of oauth2-proxy-protected hostnames

## Test plan

- [ ] Validate passes: `task k8s:validate` (confirmed clean — 0 invalid, 0 errors)
- [ ] Renovate validate passes: `task renovate:validate` (confirmed)
- [ ] After merge, confirm Home Assistant pod restarts with two containers (HA + code-server)
- [ ] Confirm `hass-code.<internal_domain>` redirects to oauth2-proxy login before serving the editor
- [ ] Confirm code-server opens `/home/coder/hass-config` and HA config files are visible and editable
- [ ] Confirm HA itself continues to function at `hass.<internal_domain>`

https://claude.ai/code/session_01RFFRZfZB2aFummSvMttpwG