### PR TITLE
fix(home-assistant): run code-server as coder user (uid 1000)

### DIFF
--- a/kubernetes/clusters/live/charts/home-assistant.yaml
+++ b/kubernetes/clusters/live/charts/home-assistant.yaml
@@ -67,8 +67,8 @@ controllers:
           readOnlyRootFilesystem: false
           capabilities:
             drop: [ALL]
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsNonRoot: true
+          runAsUser: 1000
         resources:
           requests:
             cpu: 50m


### PR DESCRIPTION
## Summary

- `runAsUser: 0` caused `Permission denied` on `/home/coder/` — directory is `700` owned by uid `1000` (`coder`)
- code-server container could not traverse its own home directory or reach the `hass-config` volume mount at `/home/coder/hass-config`
- Fix: `runAsUser: 1000`, `runAsNonRoot: true` — matches the image's default `coder` user

## Test plan

- [ ] Pod restarts with 2/2 containers ready
- [ ] `hass-code.internal.tomnowak.work` opens code-server with HA config directory loaded (no "Workspace does not exist" error)
- [ ] Config files visible in file explorer

https://claude.ai/code/session_01RFFRZfZB2aFummSvMttpwG