### PR TITLE
fix(home-assistant): correct Google CalDAV URL

### DIFF
--- a/kubernetes/clusters/live/config/home-assistant/hass-config-configmap.yaml
+++ b/kubernetes/clusters/live/config/home-assistant/hass-config-configmap.yaml
@@ -56,9 +56,10 @@ data:
 
     # Google Calendar via CalDAV (read-only).
     # Credentials are injected from /config/secrets.yaml (mounted from hass-google-caldav-secret).
+    # caldav library discovers calendars via principal lookup — email not needed in URL.
     calendar:
       - platform: caldav
-        url: https://www.google.com/calendar/dav/!secret google_caldav_email/user
+        url: https://apidata.googleusercontent.com/caldav/v2/
         username: !secret google_caldav_email
         password: !secret google_caldav_password
 


### PR DESCRIPTION
## Summary

- `!secret` cannot be interpolated mid-string in HA YAML — the URL was literally `https://www.google.com/calendar/dav/!secret google_caldav_email/user`, causing a 404
- Google's CalDAV principal endpoint changed to `apidata.googleusercontent.com/caldav/v2/`
- The caldav library discovers calendars via principal lookup from credentials — email is not needed in the URL path

## Test plan

- [ ] HA restarts without config parse errors
- [ ] `calendar.*` entities appear in HA for Google calendars
- [ ] No 404 errors in HA logs for caldav

https://claude.ai/code/session_01RFFRZfZB2aFummSvMttpwG