### PR TITLE
fix(longhorn): raise replica-replenishment-wait-interval to survive Talos upgrades

### DIFF
--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -21,6 +21,11 @@ defaultSettings:
   createDefaultDiskLabeledNodes: true
   storageReservedPercentageForDefaultDisk: 10
   nodeDownPodDeletionPolicy: delete-both-statefulset-and-deployment-pod
+  # Wait for a rebooted node to rejoin before replenishing its replicas. Talos
+  # upgrades take a node offline longer than the 600s default, causing Longhorn
+  # to full-rebuild multi-Ti replicas every upgrade. 1800s covers a single-node
+  # upgrade so the node returns and Longhorn does a fast delta rebuild instead.
+  replicaReplenishmentWaitInterval: 1800
   storageOverProvisioningPercentage: 500
   storageMinimalAvailablePercentage: 10
   autoCleanupSystemGeneratedSnapshot: true


### PR DESCRIPTION
## Problem

Talos upgrades repeatedly stall — nodes left at mixed versions (v1.13.2 / .6 / .7) because each node upgrade triggers a **full 10Ti rebuild** of the `media-library` volume that outlasts the 4h Saturday maintenance window, blocking tuppr's Longhorn health check.

## Root cause (5-whys)

1. Upgrade never finishes → each node upgrade puts the 10Ti media volume into a full rebuild longer than the maintenance window; tuppr's Longhorn `healthy` check (30m) blocks the next node.
2. Full rebuild per node → when a node reboots, Longhorn provisions a brand-new full replica elsewhere instead of reusing the offline one.
3. Fresh replica instead of reuse → node offline > `replica-replenishment-wait-interval` (**600s default**); Talos drain+reboot+image+rejoin exceeds 10 min, so Longhorn replenishes to restore count=3.
4. Rebuild takes all day → full 10Ti copy onto `slow`/HDD disks at near-zero throughput (observed 0 MBps, 39% stuck).
5. Not told it's maintenance → chart `defaultSettings` never tuned the replenishment interval for the upgrade window.

The Longhorn replica data lives on a Talos **UserVolume partition that survives upgrades**, so the offline replica is reusable — Longhorn was discarding it unnecessarily.

## Fix

Set `replicaReplenishmentWaitInterval: 1800` in `kubernetes/platform/charts/longhorn.yaml` `defaultSettings`. 1800s covers a single-node Talos upgrade, so the node rejoins with its on-disk replica intact and Longhorn performs a **fast delta rebuild** instead of a full 10Ti copy.

- Replica count unchanged (stays 3).
- Minimal, highest-leverage change; validated with `task k8s:validate` (36 charts templated, no deprecations).

## Live evidence at time of diagnosis

| Fact | Value |
|------|-------|
| `replica-replenishment-wait-interval` | 600s (default) |
| media-library `pvc-cd6ba345` | 10Ti RWX, 3 replicas, class `slow` (HDD), **degraded** |
| current rebuild | 1 replica `WO`, 39%, **0 MBps** |
| nodes | 5, Talos mixed v1.13.2 / .6 / .7 |

## Follow-ups (deferred, not in this PR)

- Dedicated `media-bulk` storage class (fewer/no frequent snapshots) if rebuild throughput remains a concern.
- Consider bumping tuppr Longhorn health-check timeout 30m → 45m as buffer.

https://claude.ai/code/session_01FGcTHDXgRDDVHKvqveYorB