### PR TITLE
fix(sure): connect to CNPG primary (-rw) instead of transaction pooler

### DIFF
--- a/kubernetes/clusters/live/charts/sure.yaml
+++ b/kubernetes/clusters/live/charts/sure.yaml
@@ -19,8 +19,11 @@ controllers:
           RAILS_FORCE_SSL: "false"
           RAILS_ASSUME_SSL: "true"
           RAILS_LOG_TO_STDOUT: "true"
-          # Database — shared CNPG platform cluster via pooler
-          DB_HOST: platform-pooler-rw.database.svc.cluster.local
+          # Database — shared CNPG platform cluster, direct primary (-rw) service.
+          # NOT the pgbouncer pooler: its transaction pool mode breaks Rails DDL
+          # migrations (prepared statements + advisory locks aren't pool-safe),
+          # which crashloops the web container on boot when a migration is pending.
+          DB_HOST: platform-rw.database.svc.cluster.local
           DB_PORT: "5432"
           POSTGRES_DB: sure
           POSTGRES_USER: sure
@@ -140,7 +143,7 @@ controllers:
         env:
           SELF_HOSTED: "true"
           RAILS_LOG_TO_STDOUT: "true"
-          DB_HOST: platform-pooler-rw.database.svc.cluster.local
+          DB_HOST: platform-rw.database.svc.cluster.local
           DB_PORT: "5432"
           POSTGRES_DB: sure
           POSTGRES_USER: sure


### PR DESCRIPTION
## Symptom

`sure` web container crashloops (176+ restarts) after the 0.7.3 bump (#1489). Old 0.7.2 pods still serve, so no full outage — the rollout is stuck one bad pod short and drifting from desired state.

## Root cause — NOT the version

`sure` connects to the DB via the shared CNPG pgbouncer pooler `platform-pooler-rw` (**`poolMode: transaction`**). Rails DDL migrations are incompatible with transaction pooling. The real error, from the Postgres primary log on the `sure` sessions:

```
SQLSTATE 26000: prepared statement "a1" does not exist   (query: DEALLOCATE a1)
SQLSTATE 25P02: current transaction is aborted           (query: SELECT 'boolean'::regtype::oid)
```

`SELECT 'boolean'::regtype::oid` is what Rails runs to resolve the boolean type for the `add_column :boolean` in `AddBalanceReversalToEnableBankingAccounts`. Under transaction pooling, backends are shared per-transaction, so the named prepared statement / advisory lock doesn't survive → `DEALLOCATE` fails → txn aborts → migration dies → web crashloops. The **worker** container stays up because it never issues DDL.

**Why now:** `db:prepare` runs every boot but only executes DDL when a migration is pending. 0.7.2 had none pending; 0.7.3's migration is the first to traverse the pooler → latent misconfig surfaced. A revert would only defer the failure to the next migration.

## Fix

Point both `web` and `worker` at the direct primary service `platform-rw.database.svc.cluster.local`, bypassing pgbouncer. Rails migrations need a session-capable connection (prepared statements + advisory locks).

- Keeps sure at **0.7.3** (fix-forward, no revert / Renovate hold).
- **No network-policy change:** sure ns already has `access.network-policy.homelab/postgres=true`, and `access-postgres-egress` permits egress to all database-namespace pods on 5432 (pooler and primary alike).
- Validated with `task k8s:validate` (36 charts, no deprecated APIs).

## Evidence

| Fact | Value |
|------|-------|
| pooler mode | `transaction` (repo + live) |
| sure DB_HOST (before) | `platform-pooler-rw.database.svc.cluster.local` |
| crashing container | `web` (0.7.3), migration `20260627101954` |
| worker container | Running fine (no DDL) |
| direct service | `platform-rw` exists (172.19.75.5) |

## Follow-up (not in this PR)

Other Rails/DDL apps sharing this pooler may carry the same latent issue — worth auditing which apps point at `platform-pooler-rw` vs `platform-rw`.

https://claude.ai/code/session_01FGcTHDXgRDDVHKvqveYorB