### PR TITLE
fix(istio): harden ztunnel against projected SA token expiry (k8s#138689)

### DIFF
--- a/kubernetes/platform/config.yaml
+++ b/kubernetes/platform/config.yaml
@@ -103,6 +103,10 @@ spec:
       namespace: ""
       path: kubernetes/platform/config/infrastructure-policies
       dependsOn: [cilium]
+    - name: ztunnel-refresh-config
+      namespace: ""
+      path: kubernetes/platform/config/ztunnel-refresh
+      dependsOn: [istiod, istio-csr]
   resourcesTemplate: |
     ---
     apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/kubernetes/platform/config/monitoring/istio-alerts.yaml
+++ b/kubernetes/platform/config/monitoring/istio-alerts.yaml
@@ -149,6 +149,29 @@ spec:
               Ztunnel DaemonSet has {{ $value }} pods not ready. Some nodes may
               not have Ambient mode mesh connectivity.
 
+        # Ztunnel CA authentication failures at istiod (projected SA token expired or rejected)
+        # citadel_server_authentication_failure_count is incremented by istiod's CA server
+        # (security/pkg/server/ca/monitoring.go) each time a CSR is rejected due to token
+        # authentication failure — the exact failure mode from kubernetes/kubernetes#138689
+        # where a kubelet bug freezes the projected SA JWT past expiry.
+        # Distinct from IstioCsrTokenRejectionHigh (which tracks istio-csr gRPC rejections):
+        # this metric tracks istiod's own CA endpoint rejecting ztunnel CSRs.
+        - alert: ZtunnelCaAuthFailure
+          expr: |
+            sum(rate(citadel_server_authentication_failure_count[5m])) > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Istiod CA is rejecting workload certificate signing requests (token auth failure)"
+            description: >-
+              Istiod's CA server is rejecting CSRs due to authentication failures at
+              {{ $value | humanize }} failures/s. This is the signature of an expired or
+              frozen projected service account token (kubernetes/kubernetes#138689).
+              Ztunnel on affected nodes cannot obtain SPIFFE mTLS certificates, breaking
+              all HBONE mesh paths on those nodes even though ztunnel appears Running.
+              Immediate remediation: kubectl rollout restart ds/ztunnel -n istio-system
+
     - name: istio-csr
       rules:
         # istio-csr availability

--- a/kubernetes/platform/config/tuppr/kubernetes-upgrade.yaml
+++ b/kubernetes/platform/config/tuppr/kubernetes-upgrade.yaml
@@ -55,3 +55,16 @@ spec:
         status.phase == 'Ready' &&
           (!has(status.isRollingUpdate) || !status.isRollingUpdate)
       timeout: 10m
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      name: ztunnel
+      namespace: istio-system
+      description: Ztunnel DaemonSet must be fully ready (desired == ready) before the
+        next node is upgraded. In-place Kubernetes upgrades do not cycle DaemonSet pods,
+        so a kubelet bug (kubernetes/kubernetes#138689) that freezes projected SA tokens
+        past expiry can leave ztunnel running but unable to obtain SPIFFE certs, breaking
+        all HBONE mesh paths on that node. Blocking here surfaces the failure before it
+        propagates to additional nodes.
+      expr: |
+        status.desiredNumberScheduled == status.numberReady
+      timeout: 15m

--- a/kubernetes/platform/config/tuppr/talos-upgrade.yaml
+++ b/kubernetes/platform/config/tuppr/talos-upgrade.yaml
@@ -59,3 +59,15 @@ spec:
         status.phase == 'Ready' &&
           (!has(status.isRollingUpdate) || !status.isRollingUpdate)
       timeout: 10m
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      name: ztunnel
+      namespace: istio-system
+      description: Ztunnel DaemonSet must be fully ready (desired == ready) before the
+        next node is upgraded. Talos upgrades reboot nodes, which restarts the kubelet
+        and allows the projected SA token to be refreshed — but if a prior node already
+        has a frozen token (kubernetes/kubernetes#138689), detecting it here prevents
+        propagating a broken mesh state to additional nodes during a rolling upgrade.
+      expr: |
+        status.desiredNumberScheduled == status.numberReady
+      timeout: 15m

--- a/kubernetes/platform/config/ztunnel-refresh/job.yaml
+++ b/kubernetes/platform/config/ztunnel-refresh/job.yaml
@@ -1,0 +1,119 @@
+---
+# D2 — ztunnel token refresh Job
+#
+# This Job is keyed to ${kubernetes_version}: when Flux substitutes a new
+# version, it creates a new Job (new name) and prunes the old one, guaranteeing
+# a fresh projected SA token is minted by the kubelet after every Kubernetes
+# version bump.
+#
+# RBAC: ServiceAccount ztunnel-refresh with a namespace-scoped Role granting
+# only get/patch on the ztunnel DaemonSet in istio-system.
+#
+# Network: the istio-system CNP already allows kube-apiserver egress on 6443/443.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ztunnel-refresh-k8s-${kubernetes_version}
+  namespace: istio-system
+  labels:
+    app.kubernetes.io/name: ztunnel-refresh
+    app.kubernetes.io/component: maintenance
+spec:
+  activeDeadlineSeconds: 900
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      serviceAccountName: ztunnel-refresh
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: script
+          configMap:
+            name: ztunnel-refresh-script
+            defaultMode: 0555
+      containers:
+        - name: refresh
+          # renovate: datasource=docker depName=bitnamilegacy/kubectl
+          image: docker.io/bitnamilegacy/kubectl:1.33.4
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["/bin/bash", "/scripts/ztunnel-refresh.sh"]
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ztunnel-refresh-script
+  namespace: istio-system
+data:
+  ztunnel-refresh.sh: |
+    #!/bin/bash
+    # ztunnel-refresh.sh
+    #
+    # D2 mitigation for kubernetes/kubernetes#138689: kubelet bug that freezes
+    # projected SA tokens past expiry during control-plane restart on k8s v1.36.x.
+    #
+    # This Job is keyed to the Kubernetes version (via Job name) so it re-runs on
+    # every version bump, ensuring ztunnel always receives a fresh projected SA token.
+    #
+    # Phases:
+    #   1. Wait for istiod Deployment to be Available (CA reachable).
+    #   2. Wait for istio-csr Deployment to be Available (cert pipeline up).
+    #   3. Patch ztunnel DaemonSet to trigger a rolling restart via restartedAt annotation.
+
+    set -euo pipefail
+
+    POLL_INTERVAL="${POLL_INTERVAL:-10}"
+    ISTIOD_TIMEOUT="${ISTIOD_TIMEOUT:-300}"
+    CSR_TIMEOUT="${CSR_TIMEOUT:-120}"
+    NAMESPACE="${NAMESPACE:-istio-system}"
+    CERT_MANAGER_NS="${CERT_MANAGER_NS:-cert-manager}"
+
+    wait_available() {
+      local ns="$1" kind="$2" name="$3" timeout="$4"
+      local deadline=$(( SECONDS + timeout ))
+      echo "Waiting for $kind/$name in $ns to be Available (timeout ${timeout}s)..."
+      while [ "$SECONDS" -lt "$deadline" ]; do
+        available=$(kubectl get "$kind" "$name" -n "$ns" \
+          -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null || true)
+        if [ "$available" = "True" ]; then
+          echo "$kind/$name is Available."
+          return 0
+        fi
+        echo "  $kind/$name not yet Available (${available:-unknown}), retrying in ${POLL_INTERVAL}s..."
+        sleep "$POLL_INTERVAL"
+      done
+      echo "ERROR: $kind/$name in $ns did not become Available within ${timeout}s." >&2
+      return 1
+    }
+
+    # Phase 1: Gate on istiod.
+    wait_available "$NAMESPACE" deployment istiod "$ISTIOD_TIMEOUT"
+
+    # Phase 2: Gate on istio-csr.
+    wait_available "$CERT_MANAGER_NS" deployment cert-manager-istio-csr "$CSR_TIMEOUT"
+
+    # Phase 3: Rolling restart of ztunnel by bumping spec.template annotation.
+    RESTART_TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    echo "Patching ztunnel DaemonSet at ${RESTART_TS} to trigger rolling restart..."
+    kubectl patch daemonset ztunnel -n "$NAMESPACE" \
+      --type=merge \
+      -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/restartedAt\":\"${RESTART_TS}\"}}}}}"
+
+    echo "Rolling restart of ztunnel initiated. New pods will obtain fresh projected SA tokens."
+    echo "Done."

--- a/kubernetes/platform/config/ztunnel-refresh/kustomization.yaml
+++ b/kubernetes/platform/config/ztunnel-refresh/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rbac.yaml
+  - job.yaml

--- a/kubernetes/platform/config/ztunnel-refresh/rbac.yaml
+++ b/kubernetes/platform/config/ztunnel-refresh/rbac.yaml
@@ -1,0 +1,70 @@
+---
+# RBAC for the ztunnel-refresh Job (D2 — kubernetes/kubernetes#138689 mitigation).
+#
+# Minimum verbs required:
+#   istio-system:
+#     - get deployments/istiod        (pre-flight: gate on istiod readiness)
+#     - get/patch daemonsets/ztunnel  (action: trigger rolling restart)
+#   cert-manager:
+#     - get deployments/cert-manager-istio-csr (pre-flight: gate on istio-csr readiness)
+#
+# All roles are scoped to named resources to prevent privilege escalation.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ztunnel-refresh
+  namespace: istio-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ztunnel-refresh
+  namespace: istio-system
+rules:
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    resourceNames: ["ztunnel"]
+    verbs: ["get", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: ["istiod"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ztunnel-refresh
+  namespace: istio-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ztunnel-refresh
+subjects:
+  - kind: ServiceAccount
+    name: ztunnel-refresh
+    namespace: istio-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ztunnel-refresh-csr-reader
+  namespace: cert-manager
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: ["cert-manager-istio-csr"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ztunnel-refresh-csr-reader
+  namespace: cert-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ztunnel-refresh-csr-reader
+subjects:
+  - kind: ServiceAccount
+    name: ztunnel-refresh
+    namespace: istio-system

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -9,6 +9,9 @@
 # renovate: datasource=github-releases depName=talos packageName=siderolabs/talos
 talos_version=v1.13.7
 # renovate: datasource=github-tags depName=kubernetes packageName=kubernetes/kubernetes extractVersion=^v(?<version>.*)$
+# TODO(k8s#138689): kubelet in v1.36.x freezes projected SA tokens past expiry during control-plane restart.
+# When kubernetes/kubernetes#138689 is fixed and released, adopt the patch to resolve the root cause of the
+# ztunnel JWT expiry incident (2026-08). Until then, D1 self-heal probe and F pre-flight guardrail mitigate it.
 kubernetes_version=1.36.3
 # renovate: datasource=github-releases depName=cilium packageName=cilium/cilium extractVersion=^v(?<version>.*)$
 cilium_version=1.20.0


### PR DESCRIPTION
## Incident Summary

A live mesh-wide outage occurred after an in-place Kubernetes upgrade to v1.36.3. The root cause is a kubelet bug ([kubernetes/kubernetes#138689](https://github.com/kubernetes/kubernetes/issues/138689)) that **freezes projected service account JWTs past their expiry** when the control plane is restarted. Because Tuppr's \`KubernetesUpgrade\` upgrades nodes in-place and never cycles DaemonSet pods, ztunnel continued running but with a stale, expired JWT. Istiod rejected every certificate signing request. Ztunnel could not obtain SPIFFE mTLS certificates, every HBONE path on affected nodes broke, and the pod appeared \`Running\` and \`Ready\` throughout. Manual \`kubectl rollout restart ds/ztunnel -n istio-system\` recovered the mesh.

## Remediation Architecture

| Layer | Change | Purpose |
|-------|--------|---------|
| D1 | **HELD** | Not viable at Istio 1.30 (see analysis below) |
| **D2** | Version-keyed ztunnel refresh Job | **Primary remediation** — fresh token on every k8s version bump |
| F | Tuppr healthCheck for ztunnel DaemonSet | Pre-flight guardrail — blocks rolling upgrade if mesh is broken |
| Alert | ZtunnelCaAuthFailure PrometheusRule | Detection — fires on istiod CA auth rejections |
| E | versions.env tracking comment | Eventual cure — adopt upstream fix when released |

---

## D1 — ztunnel self-heal probe: HELD (non-viable)

**Source-code evidence (ztunnel release-1.30):** `src/app.rs` registers exactly two readiness tasks: `state_manager` (first XDS update received) and `proxy` (listener started). The `SecretManager` that performs CA cert fetching (`src/cert_fetcher.rs`) is not registered as a readiness blocker — it starts asynchronously and cert fetch failures are only logged. The readiness endpoint (`/healthz/ready` on port 15021) returns 200 even when the pod is completely unable to obtain SPIFFE certs. Verified by reading `src/readiness.rs` (BlockReady drop-based mechanism) and `src/app.rs` (task registration site).

A liveness probe against `/healthz/ready` would not detect the broken-but-ready failure mode and could cause spurious restarts on normal transient istiod blips. D1 is not implemented.

**TODO:** Re-evaluate at Istio 1.32+ — check whether a CA cert bootstrap task has been added to the readiness system in later releases before re-proposing.

---

## D2 — Version-keyed ztunnel refresh Job (primary remediation)

**Trigger mechanism:** The Job is named `ztunnel-refresh-k8s-${kubernetes_version}`. When Flux substitutes a new version string from the `platform-versions` ConfigMap (generated from `versions.env`), the Job name changes. Flux prunes the old completed Job and creates a new one — guaranteeing a rolling restart of ztunnel (and thus a fresh kubelet-minted projected SA token) after every Kubernetes version bump.

**Pre-flight gates:** The script waits for `istiod` (Deployment Available, 300s timeout) and `cert-manager-istio-csr` (Deployment Available, 120s timeout) before patching ztunnel. This ensures the restart targets a healthy control plane — not a still-initializing one.

**Restart mechanism:** `kubectl patch daemonset ztunnel --type=merge -p '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"<timestamp>"}}}}}` — identical to `kubectl rollout restart`, triggers a controlled rolling restart of ztunnel pods.

**Flux wiring:**
- New Kustomization entry `ztunnel-refresh-config` in `config.yaml` with `namespace: ""` (no targetNamespace override — resources use their declared `istio-system` namespaces) and `dependsOn: [istiod, istio-csr]`
- Path: `kubernetes/platform/config/ztunnel-refresh/`

**RBAC (minimum privilege, named-resource scoped):**
- `istio-system` Role: `get/patch` on `daemonsets/ztunnel`, `get` on `deployments/istiod`
- `cert-manager` Role: `get` on `deployments/cert-manager-istio-csr`
- Both bound to ServiceAccount `ztunnel-refresh` in `istio-system`

**Network policy:** No changes needed. The existing `istio-system` CiliumNetworkPolicy already permits egress to `kube-apiserver` on 6443/443 for all endpoints in the namespace.

**Image:** `docker.io/bitnamilegacy/kubectl:1.33.4` — same image family as the velero-restore gate-job precedent; pinned to latest stable semver at time of authoring; tracked by Renovate via inline annotation.

---

## F — Tuppr pre-flight guardrail

Added `healthCheck` asserting `status.desiredNumberScheduled == status.numberReady` for the `ztunnel` DaemonSet to both `kubernetes-upgrade.yaml` and `talos-upgrade.yaml`. Timeout: 15m. Blocks the next node upgrade if the mesh data plane is not fully healthy, surfacing any pre-existing breakage before it propagates.

---

## E — kubernetes_version tracking comment

Added a comment on `kubernetes_version` in `versions.env` referencing [kubernetes/kubernetes#138689](https://github.com/kubernetes/kubernetes/issues/138689). When Renovate proposes a patch bump containing the fix, the PR reviewer has context to confirm the bug is resolved and remove the TODO.

---

## Alert — ZtunnelCaAuthFailure

Added to the `istio-ztunnel` rule group in `istio-alerts.yaml`. Metric: `citadel_server_authentication_failure_count` (istiod CA server, `security/pkg/server/ca/monitoring.go`). Fires when any sustained CA auth rejection rate > 0 for 5m — the direct istiod-side signal of the incident failure mode. Distinct from the existing `IstioCsrTokenRejectionHigh` (which tracks the istio-csr gRPC side).

---

## Test Plan

- [ ] \`task k8s:validate\` passes (confirmed before each commit)
- [ ] \`task renovate:validate\` passes (confirmed)
- [ ] After merge and artifact promotion: verify \`ztunnel-refresh-config\` Kustomization appears in \`flux get kustomizations\`
- [ ] After merge: verify Job \`ztunnel-refresh-k8s-1.36.3\` is created in \`istio-system\` and completes successfully
- [ ] After next Kubernetes version bump: confirm Flux prunes old Job and creates \`ztunnel-refresh-k8s-<new-version>\`
- [ ] Verify \`ZtunnelCaAuthFailure\` PrometheusRule loads in Prometheus (\`/api/v1/rules\`)
- [ ] After next upgrade: confirm Tuppr ztunnel healthCheck blocks on DaemonSet readiness before proceeding
- [ ] When kubernetes/kubernetes#138689 fix is released: adopt patch, remove TODO from versions.env

https://claude.ai/code/session_01NjzetNXeqCARVnUFW7c6T9