### PR TITLE
fix(longhorn): enable immediate snapshot checksums for fast replica rebuild

### DIFF
--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -31,6 +31,16 @@ defaultSettings:
   autoCleanupSystemGeneratedSnapshot: true
   snapshotMaxCount: 3
   longGRPCTimeOut: 345600
+  # Ensure snapshot checksums are computed immediately after every snapshot so
+  # fast-rebuild (changed-blocks-only sync) is available at replica rebuild time.
+  # Without this, checksums are only computed by the 7-day cronjob; a large
+  # base snapshot's checksum is usually absent when a post-upgrade rebuild
+  # starts, and Longhorn silently falls back to a full delta scan (observed:
+  # 8.6Ti volume scanning at <1% per 2 min, ~0 MB/s net transfer). With the
+  # checksum precomputed, Longhorn uses fast-rebuild = minutes instead of ~24h.
+  snapshotDataIntegrityImmediateCheckAfterSnapshotCreation: true
+  engineReplicaTimeout: 30
+  replicaFileSyncHttpClientTimeout: 120
 csi:
   attacherReplicaCount: ${default_replica_count}
   provisionerReplicaCount: ${default_replica_count}


### PR DESCRIPTION
## Incident Summary

During Talos node upgrades, Longhorn was performing full-rebuild (delta scan) of multi-Ti HDD volumes, taking ~24 hours per node.

## Root Cause

Longhorn's fast replica rebuild requires snapshot checksums to be precomputed at rebuild time. The cluster already had `snapshot-data-integrity: fast-check` configured (prerequisite met), but `snapshot-data-integrity-immediate-check-after-snapshot-creation: false` (the default). Checksums were only computed by a 7-day cronjob (`0 0 */7 * *`). A large base snapshot's checksum was almost never ready when a post-reboot rebuild started, so Longhorn silently fell back to the full delta rebuild path — block-by-block checksum comparison of the entire volume on slow HDD. Observed: an 8.6Ti snapshot scanning at <1% per 2 minutes, ~0 MB/s transferred (reading/hashing the full volume, not copying changed blocks).

## Changes

**File:** `kubernetes/platform/charts/longhorn.yaml`

Three settings added under `defaultSettings:`:

### `snapshotDataIntegrityImmediateCheckAfterSnapshotCreation: true` (primary fix)
Instructs Longhorn to compute the snapshot checksum immediately after every snapshot is created, rather than waiting for the periodic cronjob. With the checksum cached, the next rebuild uses the fast path: only changed blocks in the volume head are synced. Expected effect: rebuild time drops from ~24h to minutes.

### `engineReplicaTimeout: 30`
Raises the engine-to-replica timeout from the default 8s to the documented maximum of 30s. On slow HDDs mid-rebuild, a temporary I/O stall can exceed 8s and cause the engine to error/restart the source replica, interrupting the rebuild entirely.

### `replicaFileSyncHttpClientTimeout: 120`
Raises the file-sync HTTP client timeout from the default 30s to 120s. Large snapshot files on slow disks can take longer than 30s to transfer, causing the HTTP client to declare failure and abort the sync.

## Expected Effect

After this change, every new snapshot will have its checksum computed immediately. The next Talos upgrade cycle will find the checksum already present and use fast-rebuild (changed-blocks-only) instead of a full delta scan. Rebuild time: minutes instead of ~24 hours.

## Relationship to Existing Fix

This complements `replicaReplenishmentWaitInterval: 1800` (PR #1491), which ensures the failed replica is reused (fast delta) rather than replaced (full copy) after a node reboot. Both settings are required: replenishment wait ensures the right replica is chosen; immediate checksum ensures that replica can use the fast-rebuild code path.

## Prerequisite Note

Existing large snapshots that predate this change will not have checksums cached yet. The benefit applies once a new snapshot is taken (or the 7-day cronjob next runs) after this setting is enabled. Taking a fresh snapshot of large HDD volumes immediately after this change is deployed will ensure the next upgrade cycle is fully covered.

## Runbook Gate (Change 2 — Skipped)

`docs/runbooks/talos-version-reconcile.md` does not exist on `main` (it lives on branch `worktree-talos-reconcile-runbook`). The pre-flight gate (verify immediate-check is enabled; take a fresh snapshot of large volumes; confirm checksums are ready before starting node upgrades) should be added to that runbook when it is merged.

https://claude.ai/code/session_01NjzetNXeqCARVnUFW7c6T9