### PR TITLE
fix(renovate): group hubble-relay image with cilium chart

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -120,7 +120,8 @@
     },
     {
       "matchDepNames": [
-        "cilium"
+        "cilium",
+        "quay.io/cilium/hubble-relay"
       ],
       "groupName": "cilium",
       "automerge": true


### PR DESCRIPTION
## Summary

- Adds `quay.io/cilium/hubble-relay` to the cilium Renovate group's `matchDepNames` array
- Ensures the hubble-relay container image pin (added by a parallel agent to `kubernetes/platform/charts/cilium.yaml`) is always updated in the same PR as the Cilium Helm chart version
- No other Renovate rules are modified

## Test plan

- [x] `task renovate:validate` passes with no errors
- [ ] Verify next Renovate Cilium update PR includes both `cilium` chart and `quay.io/cilium/hubble-relay` image in a single grouped PR

https://claude.ai/code/session_01FnBf7osEcoZx3L5c679shv