### PR TITLE
fix(cilium): pin hubble-relay image to v1.20.0

### DIFF
--- a/kubernetes/platform/charts/cilium.yaml
+++ b/kubernetes/platform/charts/cilium.yaml
@@ -38,6 +38,9 @@ hubble:
     enabled: true
   relay:
     enabled: true
+    image:
+      # renovate: datasource=docker depName=quay.io/cilium/hubble-relay
+      tag: v1.20.0
   ui:
     enabled: true
 # L2 announcements kept active during BGP migration for rollback capability


### PR DESCRIPTION
## Summary

- hubble-relay is crashlooping on live with `failed to start gops agent: open /home/gops/1: read-only file system`
- Root cause: hubble-relay image is `v1.19.4` while the Cilium chart is at `1.20.0`; the v1.19.4 image expects a writable `/home/gops/` which the 1.20 chart pod spec makes read-only
- This pins `hubble.relay.image.tag` to `v1.20.0` in the Cilium Helm values, matching the deployed chart version
- A Renovate annotation (`datasource=docker depName=quay.io/cilium/hubble-relay`) keeps the pin in sync with future chart upgrades via the existing YAML container-image custom manager in `renovate.json5`

## Test plan

- [ ] `task k8s:validate` passes (verified locally — no deprecations, all 36 charts templated successfully)
- [ ] After merge, Flux reconciles the Cilium HelmRelease and hubble-relay pods restart with image `v1.20.0`
- [ ] `kubectl -n kube-system get pods -l app.kubernetes.io/name=hubble-relay` shows `Running`
- [ ] No further `failed to start gops agent` errors in hubble-relay logs

https://claude.ai/code/session_01FnBf7osEcoZx3L5c679shv