### PR TITLE
feat(longhorn): add snapshot hash watchdog alerts and KSM CRS metrics

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -140,6 +140,53 @@ kube-state-metrics:
           replacement: $1
           sourceLabels: ["__meta_kubernetes_pod_node_name"]
           targetLabel: kubernetes_node
+  rbac:
+    extraRules:
+      - apiGroups: ["longhorn.io"]
+        resources: ["snapshots"]
+        verbs: ["list", "watch"]
+  customResourceState:
+    enabled: true
+    config:
+      kind: CustomResourceStateMetrics
+      spec:
+        resources:
+          - groupVersionKind:
+              group: longhorn.io
+              version: v1beta2
+              kind: Snapshot
+            metricNamePrefix: longhorn_snapshot
+            labelsFromPath:
+              snapshot: [metadata, name]
+              namespace: [metadata, namespace]
+              volume: [spec, volume]
+            metrics:
+              - name: _info
+                help: >-
+                  Longhorn snapshot info. Emits 1 per snapshot; the checksum label is the
+                  hash string (empty when not yet computed). Use checksum!="" to identify
+                  hashed snapshots. user_created="true" snapshots without a checksum will
+                  force a slow block-by-block delta rebuild on every node reboot.
+                each:
+                  type: Info
+                  info:
+                    labelsFromPath:
+                      user_created: [status, userCreated]
+                      ready_to_use: [status, readyToUse]
+                      checksum: [status, checksum]
+              - name: _created_seconds
+                help: >-
+                  Unix timestamp of when the Longhorn snapshot CR was created
+                  (metadata.creationTimestamp parsed to seconds). Use this to detect
+                  stale snapshots older than the recurring-job interval.
+                  NOTE: This metric uses metadata.creationTimestamp (not status.creationTime).
+                  Both are RFC3339 strings; KSM natively parses RFC3339 to float unix seconds
+                  for Gauge valueFrom fields.
+                each:
+                  type: Gauge
+                  gauge:
+                    path: [metadata, creationTimestamp]
+                    nilIsZero: true
 grafana:
   enabled: false
   forceDeployDashboards: true

--- a/kubernetes/platform/config/monitoring/kustomization.yaml
+++ b/kubernetes/platform/config/monitoring/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
   - grafana-alerts.yaml
   - loki-mixin-alerts.yaml
   - loki-mixin-recording-rules.yaml
+  - longhorn-snapshot-hash-alerts.yaml
   - kromgo-recording-rules.yaml
   - flux-podmonitor.yaml
   - flux-alerts.yaml

--- a/kubernetes/platform/config/monitoring/longhorn-snapshot-hash-alerts.yaml
+++ b/kubernetes/platform/config/monitoring/longhorn-snapshot-hash-alerts.yaml
@@ -1,0 +1,117 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: longhorn-snapshot-hash-alerts
+  labels:
+    app.kubernetes.io/name: longhorn
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: longhorn-snapshot-hash
+      rules:
+        # LonghornSnapshotUnhashed
+        #
+        # Root cause: Longhorn v1.12 performs a fast "checksum-skip" rebuild when a replica is
+        # re-synced after reboot, IF status.checksum is populated on every snapshot. When a
+        # user-created snapshot has an empty checksum, Longhorn falls back to a full block-by-block
+        # delta rebuild (16-24h on HDD volumes). This happens silently on every node reboot.
+        #
+        # The native longhorn_snapshot_actual_size_bytes metric provides snapshot/volume/user_created
+        # labels but has NO checksum field. We expose longhorn_snapshot_info from kube-state-metrics
+        # CustomResourceState with a checksum label (empty string when un-hashed).
+        #
+        # Expression logic:
+        #   - LHS: user_created snapshots that exist (have actual_size_bytes)
+        #   - RHS: user_created snapshots that have a populated checksum (checksum!="")
+        #   - unless: set subtraction — alerts for any snapshot in LHS that has NO matching entry in RHS
+        - alert: LonghornSnapshotUnhashed
+          expr: |
+            count by (volume, snapshot) (
+              longhorn_snapshot_actual_size_bytes{user_created="true"}
+            )
+            unless
+            count by (volume, snapshot) (
+              kube_customresource_longhorn_snapshot_info{
+                customresource_group="longhorn.io",
+                customresource_kind="Snapshot",
+                user_created="true",
+                checksum!=""
+              }
+            )
+          for: 6h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Longhorn snapshot {{ $labels.snapshot }} on volume {{ $labels.volume }} has no checksum"
+            description: >-
+              User-created snapshot {{ $labels.snapshot }} on volume {{ $labels.volume }} has an
+              empty status.checksum and has been in this state for over 6 hours.
+              Without a checksum, Longhorn cannot use the fast checksum-skip rebuild path. On every
+              node reboot or replica re-sync, this volume will fall back to a full block-by-block
+              delta rebuild (typically 16-24h on HDD). Fix: ensure the snapshot-data-integrity
+              setting is enabled and trigger a hash operation before any node upgrade or reboot.
+              See: https://longhorn.io/docs/latest/snapshots-and-backups/snapshot-space-management/
+
+        # LonghornSnapshotStale
+        #
+        # Alerts when the oldest/newest snapshot per volume is older than the configured recurring-job
+        # interval plus a margin. The snapshot-frequent job runs weekly (cron: "0 20 * * 5", retain: 2).
+        # Threshold = 8 days (691200s) = 7-day cadence + 1-day margin.
+        #
+        # Uses kube_customresource_longhorn_snapshot_created_seconds emitted by KSM CustomResourceState
+        # from metadata.creationTimestamp. KSM parses RFC3339 timestamps to float unix seconds.
+        #
+        # VALIDATION CAVEAT: The exact float value emitted for metadata.creationTimestamp should be
+        # verified against a live KSM scrape after deployment. If this metric is absent or emits 0,
+        # investigate KSM CRS timestamp parsing (confirmed by KSM docs: "RFC3339 times are parsed to
+        # float timestamp" for Gauge valueFrom fields).
+        - alert: LonghornSnapshotStale
+          expr: |
+            (
+              time()
+              - max by (volume) (
+                  kube_customresource_longhorn_snapshot_created_seconds{
+                    customresource_group="longhorn.io",
+                    customresource_kind="Snapshot"
+                  } > 0
+                )
+            ) > 691200
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} has no recent snapshot"
+            description: >-
+              Volume {{ $labels.volume }} has no snapshot created in the last 8 days (threshold:
+              691200s = 7-day weekly recurring-job cadence + 1-day margin). The snapshot-frequent
+              recurring job runs weekly (Fridays at 20:00). Either the recurring job failed, the
+              volume is not enrolled in the snapshot group, or snapshots are being deleted before
+              the next one is created. Check Longhorn recurring job status and volume snapshot groups.
+
+    - name: longhorn-replica-rebuild
+      rules:
+        # LonghornReplicaRebuildStuck
+        #
+        # Watchdog for longhorn_engine_rebuild_progress (native metric, 0-100 scale).
+        # A value stuck between 0 and 100 for over 2h indicates a stalled rebuild.
+        # Tuned for HDD: a legitimate large delta rebuild on spinning disk can take > 1h,
+        # so 2h is used instead of 1h to avoid noise during normal large rebuilds.
+        # Adjust for your hardware — on all-NVMe setups, 30m is a reasonable threshold.
+        - alert: LonghornReplicaRebuildStuck
+          expr: |
+            longhorn_engine_rebuild_progress > 0
+            and
+            longhorn_engine_rebuild_progress < 100
+          for: 2h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Longhorn replica rebuild on {{ $labels.engine }} stuck at {{ $value }}%"
+            description: >-
+              Engine {{ $labels.engine }} (replica from {{ $labels.rebuild_src }} to
+              {{ $labels.rebuild_dst }}) has been rebuilding at {{ $value }}% for over 2 hours.
+              On HDD, a large delta rebuild can legitimately take 1-3h; if this alert persists
+              beyond 4h, investigate disk I/O saturation, network issues, or a stalled engine
+              process. Volume: {{ $labels.pvc }}/{{ $labels.pvc_namespace }}.


### PR DESCRIPTION
## Summary

**Root incident**: A user-created Longhorn snapshot with an empty `status.checksum` silently forces Longhorn into a 16-24h block-by-block delta rebuild on every node reboot (or replica re-sync), instead of the fast checksum-skip path. This is undetectable until a reboot happens — the goal is early warning *before* a node upgrade.

**Why no native metric exists**: In Longhorn v1.12.0, `longhorn-manager` exposes `longhorn_snapshot_actual_size_bytes{snapshot, volume, user_created}` but carries **no checksum field or snapshot age field**. The hash state and creation timestamp live exclusively in the `snapshot.longhorn.io/v1beta2` CRD status fields (`status.checksum`, `status.creationTime`, `metadata.creationTimestamp`).

## Changes

### 1. KSM CustomResourceState — new metrics from Snapshot CRDs

Added to `kubernetes/platform/charts/kube-prometheus-stack.yaml` under `kube-state-metrics`:

- **`rbac.extraRules`**: grants KSM `list`/`watch` on `snapshots.longhorn.io` resources
- **`customResourceState.enabled: true`** with two metrics:
  - `kube_customresource_longhorn_snapshot_info` (type: Info, value always 1) — labels: `snapshot`, `volume` (from `spec.volume`), `user_created`, `ready_to_use`, `checksum` (empty string when not yet hashed)
  - `kube_customresource_longhorn_snapshot_created_seconds` (type: Gauge) — value from `metadata.creationTimestamp`, which KSM parses natively from RFC3339 to unix float seconds (confirmed by KSM docs: *"RFC3339 times are parsed to float timestamp"*)

KSM version shipped with kube-prometheus-stack v87.21.0 is **kube-state-metrics 8.1.3** (app version 2.15.x). The CRS schema used (`kind: CustomResourceStateMetrics`, `metricNamePrefix`, `type: Info/Gauge`, `labelsFromPath`) is verified against the [KSM main branch CRS docs](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md).

### 2. PrometheusRule — three alerts

File: `kubernetes/platform/config/monitoring/longhorn-snapshot-hash-alerts.yaml`

| Alert | Severity | For | Expression shape |
|-------|----------|-----|------------------|
| **LonghornSnapshotUnhashed** | warning | 6h | `count(actual_size_bytes{user_created="true"}) unless count(snapshot_info{user_created="true", checksum!=""})` — set-subtraction: user-created snapshots that exist but have no populated checksum |
| **LonghornSnapshotStale** | warning | 1h | `time() - max(snapshot_created_seconds > 0) by (volume) > 691200` — newest snapshot older than 8 days (weekly recurring-job cadence + 1d margin; `snapshot-frequent` cron is `0 20 * * 5`) |
| **LonghornReplicaRebuildStuck** | warning | 2h | `longhorn_engine_rebuild_progress > 0 and < 100` — stuck rebuild watchdog, tuned 2h for HDD (large legitimate delta can exceed 1h) |

### 3. Kustomization registration

`longhorn-snapshot-hash-alerts.yaml` added to `kubernetes/platform/config/monitoring/kustomization.yaml`.

## Validation Caveats

- **CRS RFC3339 parsing**: `metadata.creationTimestamp` as a Gauge is confirmed supported by KSM docs. The `LonghornSnapshotStale` alert adds a `> 0` guard to suppress any NaN/zero values from failed parses. Verify the metric emits correct unix timestamps after the first KSM rollout by checking `kube_customresource_longhorn_snapshot_created_seconds` in Prometheus.
- **LonghornSnapshotUnhashed join**: The expression joins `longhorn_snapshot_actual_size_bytes` (native, from longhorn-manager) with `kube_customresource_longhorn_snapshot_info` (from KSM CRS) on `{volume, snapshot}` labels. The `snapshot` label in `actual_size_bytes` maps to the snapshot name; the KSM CRS emits the same value from `metadata.name`. Verify label alignment on first scrape.
- Validation: `task k8s:validate` passes — Valid: 93/0/0 (resources) and 501/0/0 (helm templates). yamllint clean.

## Test plan

- [ ] After merge → deploy: check `kubectl get configmap -n monitoring -l app.kubernetes.io/name=kube-state-metrics` for a CRS ConfigMap
- [ ] Verify KSM scrapes: `kube_customresource_longhorn_snapshot_info` and `kube_customresource_longhorn_snapshot_created_seconds` appear in Prometheus
- [ ] Confirm `checksum` label is empty string for un-hashed snapshots, non-empty for hashed ones
- [ ] Confirm `LonghornSnapshotUnhashed` fires for any existing user-created snapshot without a checksum
- [ ] Confirm `LonghornReplicaRebuildStuck` does NOT fire during a normal in-progress rebuild < 2h

https://claude.ai/code/session_01NjzetNXeqCARVnUFW7c6T9