### PR TITLE
fix(istio): remove static restartedAt trap and harden istio-csr auth failure alerting

### DIFF
--- a/kubernetes/platform/charts/istio-ztunnel.yaml
+++ b/kubernetes/platform/charts/istio-ztunnel.yaml
@@ -8,5 +8,10 @@ profile: ambient
 # ztunnel authenticates with its own identity but requests certs for workloads on its node
 caAddress: cert-manager-istio-csr.cert-manager.svc:443
 
-podAnnotations:
-  kubectl.kubernetes.io/restartedAt: "2026-07-12T17:00:00Z"
+# WARNING: never add a static kubectl.kubernetes.io/restartedAt annotation here.
+# Although the stomping mechanism differs from the gateway (HelmController only reconciles
+# on drift/schedule, not continuously), a static timestamp still reverts any operator-
+# initiated `kubectl rollout restart ds/ztunnel` on the next Helm reconcile cycle. This
+# silently undoes the recovery action needed when a kubelet bug (kubernetes/kubernetes#138689)
+# freezes the audience:istio-ca projected token past expiry. Remove and leave podAnnotations
+# absent so rollout restarts are not silently reverted.

--- a/kubernetes/platform/config/gateway/gateway-deployment-defaults.yaml
+++ b/kubernetes/platform/config/gateway/gateway-deployment-defaults.yaml
@@ -10,7 +10,15 @@ data:
       template:
         metadata:
           annotations:
-            kubectl.kubernetes.io/restartedAt: "2026-07-12T17:00:00Z"
+            {}
+            # WARNING: never add a static kubectl.kubernetes.io/restartedAt timestamp here.
+            # Istiod regenerates the gateway Deployment from this ConfigMap on every reconcile
+            # loop. A static timestamp makes the pod template hash unchanging, so any operator-
+            # initiated `kubectl rollout restart` is silently stomped back to the static value
+            # and the ReplicaSet is never replaced — the restart appears to succeed but does
+            # nothing. This directly caused a 12-hour mTLS outage (2026-08-03) when the correct
+            # recovery action (cycling gateway pods to obtain fresh audience:istio-ca projected
+            # tokens) was blocked by this trap (kubernetes/kubernetes#138689).
   podDisruptionBudget: |
     spec:
       maxUnavailable: 1

--- a/kubernetes/platform/config/monitoring/istio-alerts.yaml
+++ b/kubernetes/platform/config/monitoring/istio-alerts.yaml
@@ -192,9 +192,81 @@ spec:
               Renewal should have occurred at 72h remaining. cert-manager or istio-csr
               may be failing to rotate the certificate.
 
-        # istio-csr token rejection rate — indicates workloads have stale projected
-        # service account tokens, typically caused by a prolonged mesh outage where
-        # in-memory token caches were not refreshed.
+        # istio-csr CA authentication failure — any rejection rate above a small baseline
+        # is a signal that one or more mesh components hold a frozen or expired
+        # audience:istio-ca projected service account token (kubernetes/kubernetes#138689).
+        # A kubelet bug in v1.36.x freezes these tokens across control-plane restarts; the
+        # affected pod cannot obtain a new SPIFFE cert and istio-csr rejects its CSR
+        # continuously at ~10/min per affected pod. Even a single pod in this state produces
+        # a sustained stream of auth failures pointing directly at the root cause.
+        #
+        # grpc_server_handled_total is exposed by istio-csr's gRPC interceptor and labeled
+        # by grpc_service and grpc_code. Unauthenticated is the canonical gRPC status code
+        # returned when JWT validation fails ("service account token has expired").
+        #
+        # Two severity tiers:
+        #   warning  — any non-zero rejection rate (catches single-pod cases early)
+        #   critical — sustained > 0.05/s (roughly one pod failing continuously, ~3/min)
+        #
+        # Runbook: enumerate audience:istio-ca pods, then cycle them.
+        #   kubectl get pods -A -o json | jq -r '.items[] |
+        #     select(.spec.volumes[]?.projected.sources[]?.serviceAccountToken.audience? == "istio-ca") |
+        #     "\(.metadata.creationTimestamp)  \(.metadata.namespace)/\(.metadata.name)"' | sort
+        #   kubectl rollout restart ds/ztunnel -n istio-system
+        #   kubectl rollout restart deploy/external-istio deploy/internal-istio -n istio-gateway
+        - alert: IstioCsrAuthFailure
+          expr: |
+            sum(rate(grpc_server_handled_total{
+              namespace="cert-manager",
+              grpc_service=~".*IstioCertificateService.*",
+              grpc_code="Unauthenticated"
+            }[5m])) > 0
+          for: 3m
+          labels:
+            severity: warning
+          annotations:
+            summary: "istio-csr is rejecting certificate requests (token auth failure)"
+            description: >-
+              istio-csr is rejecting {{ $value | humanize }} token authentication
+              requests/s via gRPC Unauthenticated errors. This is the signature of an expired
+              or frozen audience:istio-ca projected service account token
+              (kubernetes/kubernetes#138689). Affected pods cannot obtain SPIFFE mTLS
+              certificates; if left unresolved this escalates to mesh 503s within minutes.
+              Enumerate affected pods and cycle them:
+              kubectl get pods -A -o json | jq -r '.items[] |
+                select(.spec.volumes[]?.projected.sources[]?.serviceAccountToken.audience? == "istio-ca") |
+                "\(.metadata.creationTimestamp)  \(.metadata.namespace)/\(.metadata.name)"' | sort
+              Then: kubectl rollout restart ds/ztunnel -n istio-system
+              And: kubectl rollout restart deploy/external-istio deploy/internal-istio -n istio-gateway
+
+        - alert: IstioCsrAuthFailureCritical
+          expr: |
+            sum(rate(grpc_server_handled_total{
+              namespace="cert-manager",
+              grpc_service=~".*IstioCertificateService.*",
+              grpc_code="Unauthenticated"
+            }[5m])) > 0.05
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "istio-csr sustained auth rejection rate — mesh mTLS at risk"
+            description: >-
+              istio-csr is sustaining {{ $value | humanize }} token authentication
+              rejections/s. At this rate one or more audience:istio-ca pods are completely
+              unable to renew SPIFFE certificates, which will cause or has already caused
+              Envoy UC/UF/URX upstream failures and 503s on ingress gateways
+              (kubernetes/kubernetes#138689 — kubelet v1.36.x frozen projected token bug).
+              Immediate action required. Enumerate affected pods and cycle them:
+              kubectl get pods -A -o json | jq -r '.items[] |
+                select(.spec.volumes[]?.projected.sources[]?.serviceAccountToken.audience? == "istio-ca") |
+                "\(.metadata.creationTimestamp)  \(.metadata.namespace)/\(.metadata.name)"' | sort
+              Then: kubectl rollout restart ds/ztunnel -n istio-system
+              And: kubectl rollout restart deploy/external-istio deploy/internal-istio -n istio-gateway
+
+        # istio-csr token rejection rate — retained as warning alias for pre-existing
+        # alert name (referenced in runbooks/dashboards). Prefer IstioCsrAuthFailure above
+        # which fires earlier (3m vs 5m) and includes a full runbook.
         - alert: IstioCsrTokenRejectionHigh
           expr: |
             sum(rate(grpc_server_handled_total{


### PR DESCRIPTION
## Summary

Post-incident fixes from the 2026-08-03 mTLS outage caused by kubernetes/kubernetes#138689 (kubelet v1.36.x freezes projected `audience:istio-ca` SA tokens after a control-plane restart).

- **Remove static `restartedAt` annotation** from gateway ConfigMap and ztunnel Helm values — a static timestamp silently blocks `kubectl rollout restart` by making the pod template hash unchanging, which was the direct cause of a 12-hour recovery delay.
- **Add two-tier istio-csr auth failure alerts** — early warning (any rejection, 3m) and critical (sustained rate, 5m), both with an enumeration runbook for `audience:istio-ca` pods.

---

## Item 1: Remove static `restartedAt` (gateway + ztunnel)

**Root cause of the 12-hour delay:** `gateway-deployment-defaults.yaml` contained a hardcoded `kubectl.kubernetes.io/restartedAt: "2026-07-12T17:00:00Z"`. Istiod regenerates each gateway Deployment from the Gateway CR on every reconcile loop. This static timestamp meant the pod template hash never changed — `kubectl rollout restart` wrote a fresh timestamp, istiod immediately stomped it back, and no new ReplicaSet was ever created. The restart silently did nothing.

`charts/istio-ztunnel.yaml` had the same annotation; while HelmController reconciles less aggressively than istiod, it would have reverted any manual restart on the next Helm reconcile cycle.

Both annotations are removed. Warning comments are added explaining why a static `restartedAt` must never be reintroduced.

**One-time rollout on merge:** removing the static annotation changes the pod template hash for all gateway Deployments. Flux will trigger a rolling restart of `external-istio` and `internal-istio` in `istio-gateway` when it reconciles. This is intentional — pods come up with fresh projected tokens — and is safe: the PodDisruptionBudget (`maxUnavailable: 1`) is preserved in the ConfigMap and was verified in the file.

---

## Item 4: istio-csr CA authentication failure alerts

The existing `IstioCsrTokenRejectionHigh` alert (warning, `> 0.1/s`, 5m) fires on the correct metric but did not surface as the actionable signal during the incident. Two new alerts added to `istio-alerts.yaml`:

| Alert | Severity | Threshold | Window | Purpose |
|-------|----------|-----------|--------|---------|
| `IstioCsrAuthFailure` | warning | `> 0` | 3m | Any auth rejection — catches a single frozen pod within minutes |
| `IstioCsrAuthFailureCritical` | critical | `> 0.05/s` | 5m | Sustained failure (~3/min) — mesh mTLS disruption imminent or in progress |

**Metric choice:** `grpc_server_handled_total{grpc_code="Unauthenticated"}` exposed by istio-csr's gRPC interceptor. This is a confirmed real metric — it was the source of the `10/min` rejection stream in the incident logs. The `grpc_service=~".*IstioCertificateService.*"` filter scopes it to istio cert requests specifically.

**Avoiding duplication with commit `590254b9`:** that unmerged commit adds `ZtunnelCaAuthFailure` on `citadel_server_authentication_failure_count` (istiod's own CA endpoint, security/pkg/server/ca/monitoring.go). The new alerts here target `grpc_server_handled_total` (istio-csr's gRPC layer) — a distinct signal, a distinct metric, a distinct component. They cover the same incident class from a different vantage point. No files from `590254b9` are referenced or depended on; these alerts are independently mergeable regardless of whether that branch lands.

**Runbook** in both alert descriptions:
```sh
kubectl get pods -A -o json | jq -r '.items[] |
  select(.spec.volumes[]?.projected.sources[]?.serviceAccountToken.audience? == "istio-ca") |
  "\(.metadata.creationTimestamp)  \(.metadata.namespace)/\(.metadata.name)"' | sort
kubectl rollout restart ds/ztunnel -n istio-system
kubectl rollout restart deploy/external-istio deploy/internal-istio -n istio-gateway
```

---

## Test plan

- [x] `task k8s:validate` passed — 0 errors, 0 invalid resources, no deprecated APIs
- [ ] After merge: verify Flux reconciles gateway Deployments and issues a rolling restart (desired one-time behavior)
- [ ] After merge: verify `IstioCsrAuthFailure` and `IstioCsrAuthFailureCritical` appear in Prometheus rules UI
- [ ] Simulate: temporarily lower threshold or inject test traffic to confirm alert routing to Alertmanager

https://claude.ai/code/session_01PNAz9tH4pU9ShVv8UNNMXk