### PR TITLE
fix(garage): enforce hard topology spread constraint to prevent quorum loss

### DIFF
--- a/kubernetes/platform/config/garage/garage-cluster.yaml
+++ b/kubernetes/platform/config/garage/garage-cluster.yaml
@@ -35,6 +35,14 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: garage
+            garage.rajsingh.info/tier: storage
 
   database:
     engine: lmdb


### PR DESCRIPTION
## Summary

- Adds `topologySpreadConstraints` under `spec.storage` in the `GarageCluster` CR with `whenUnsatisfiable: DoNotSchedule`
- Constrains Garage storage pods (matched by `app.kubernetes.io/name: garage` + `garage.rajsingh.info/tier: storage`) to spread across distinct nodes (`kubernetes.io/hostname`)
- Prevents a repeat of the incident where all 3 pods co-located on node41 (Longhorn volume topology overrode the default soft spread), breaking quorum

The field path `spec.storage.topologySpreadConstraints` was verified in the live GarageCluster v1beta2 CRD schema. Label selectors were derived from actual running pods on the live cluster.

## Test plan

- [ ] Validate passes: `task k8s:validate` (already confirmed clean)
- [ ] After merge, confirm Garage pods reschedule across separate nodes (or stay pending if nodes are unavailable — that is the desired safe behavior)
- [ ] Confirm `kubectl get pods -n garage -o wide` shows each pod on a distinct node

https://claude.ai/code/session_016GAyd6FKZqEKDJrrhy2Ndx