### PR TITLE
feat(garage): add PDB to maintain write quorum during node drains

### DIFF
--- a/kubernetes/platform/config/garage/garage-pdb.yaml
+++ b/kubernetes/platform/config/garage/garage-pdb.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: garage-storage
+  namespace: garage
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      garage.rajsingh.info/cluster: garage
+      garage.rajsingh.info/tier: storage

--- a/kubernetes/platform/config/garage/kustomization.yaml
+++ b/kubernetes/platform/config/garage/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - admin-secret.yaml
   - garage-cluster.yaml
+  - garage-pdb.yaml
   - garage-s3-ingress.yaml
   - garage-route.yaml
   - garage-canary.yaml


### PR DESCRIPTION
## Summary

- Adds `PodDisruptionBudget` for garage storage pods with `minAvailable: 2`
- Selector targets `garage.rajsingh.info/cluster: garage` + `garage.rajsingh.info/tier: storage` — matches all 3 storage pods precisely
- Without this, node drains can evict all 3 StatefulSet pods simultaneously (one per StatefulSet, so Kubernetes doesn't know they're related)

## Test plan

- [ ] Verify PDB applies: `kubectl --context live get pdb -n garage`
- [ ] Confirm selector matches 3 pods: `kubectl --context live get pdb garage-storage -n garage -o yaml`
- [ ] Validate node drain respects budget during next maintenance window

https://claude.ai/code/session_01NiRkQAGc7kEAsdbxDTEy9T