### PR TITLE
fix(monitoring): correct double-underscore in Longhorn snapshot KSM metric names

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -161,7 +161,7 @@ kube-state-metrics:
               namespace: [metadata, namespace]
               volume: [spec, volume]
             metrics:
-              - name: _info
+              - name: info
                 help: >-
                   Longhorn snapshot info. Emits 1 per snapshot; the checksum label is the
                   hash string (empty when not yet computed). Use checksum!="" to identify
@@ -174,7 +174,7 @@ kube-state-metrics:
                       user_created: [status, userCreated]
                       ready_to_use: [status, readyToUse]
                       checksum: [status, checksum]
-              - name: _created_seconds
+              - name: created_seconds
                 help: >-
                   Unix timestamp of when the Longhorn snapshot CR was created
                   (metadata.creationTimestamp parsed to seconds). Use this to detect

--- a/kubernetes/platform/config/monitoring/longhorn-snapshot-hash-alerts.yaml
+++ b/kubernetes/platform/config/monitoring/longhorn-snapshot-hash-alerts.yaml
@@ -33,7 +33,7 @@ spec:
             )
             unless
             count by (volume, snapshot) (
-              kube_customresource_longhorn_snapshot_info{
+              longhorn_snapshot_info{
                 customresource_group="longhorn.io",
                 customresource_kind="Snapshot",
                 user_created="true",
@@ -60,7 +60,7 @@ spec:
         # interval plus a margin. The snapshot-frequent job runs weekly (cron: "0 20 * * 5", retain: 2).
         # Threshold = 8 days (691200s) = 7-day cadence + 1-day margin.
         #
-        # Uses kube_customresource_longhorn_snapshot_created_seconds emitted by KSM CustomResourceState
+        # Uses longhorn_snapshot_created_seconds emitted by KSM CustomResourceState
         # from metadata.creationTimestamp. KSM parses RFC3339 timestamps to float unix seconds.
         #
         # VALIDATION CAVEAT: The exact float value emitted for metadata.creationTimestamp should be
@@ -72,7 +72,7 @@ spec:
             (
               time()
               - max by (volume) (
-                  kube_customresource_longhorn_snapshot_created_seconds{
+                  longhorn_snapshot_created_seconds{
                     customresource_group="longhorn.io",
                     customresource_kind="Snapshot"
                   } > 0


### PR DESCRIPTION
## Summary

- **Root cause**: KSM `metricNamePrefix` + `_` + `name` concatenation produced `longhorn_snapshot__info` (double underscore) because `name` had a leading underscore (`_info`, `_created_seconds`)
- Fix `name: _info` → `name: info` and `name: _created_seconds` → `name: created_seconds` in the KSM CustomResourceState config in `kube-prometheus-stack.yaml`
- Fix alert rules in `longhorn-snapshot-hash-alerts.yaml` to reference `longhorn_snapshot_info` and `longhorn_snapshot_created_seconds` (the correct names) instead of the non-existent `kube_customresource_longhorn_snapshot_*` prefix

## Test plan

- [ ] `task k8s:validate` passes (validated locally: 0 errors, 0 invalid)
- [ ] After merge and Flux reconciliation, confirm `longhorn_snapshot_info` (157 series) and `longhorn_snapshot_created_seconds` (157 series) appear in Prometheus — the double-underscore variants should disappear on next KSM scrape cycle
- [ ] Confirm `LonghornSnapshotUnhashed` and `LonghornSnapshotStale` alert rules load without "no-data" / vector mismatch errors in Prometheus rule evaluation

https://claude.ai/code/session_01473AtRS1vkDMzyc18idHxL