### PR TITLE
chore(tuppr): scale down to 0 replicas

### DIFF
--- a/kubernetes/platform/charts/tuppr.yaml
+++ b/kubernetes/platform/charts/tuppr.yaml
@@ -1,6 +1,6 @@
 ---
 # https://github.com/home-operations/tuppr
-replicaCount: 3
+replicaCount: 0
 monitoring:
   serviceMonitor:
     enabled: true


### PR DESCRIPTION
## Summary

- Scales tuppr from 3 replicas to 0 in `kubernetes/platform/charts/tuppr.yaml`
- Flux will converge live cluster to 0 running pods on merge

## Test plan

- [x] `task k8s:validate` passes

https://claude.ai/code/session_01473AtRS1vkDMzyc18idHxL