### PR TITLE
revert(tuppr): restore replicaCount to 3 after longhorn snapshot stabilization

### DIFF
--- a/kubernetes/platform/charts/tuppr.yaml
+++ b/kubernetes/platform/charts/tuppr.yaml
@@ -1,6 +1,6 @@
 ---
 # https://github.com/home-operations/tuppr
-replicaCount: 0
+replicaCount: 3
 monitoring:
   serviceMonitor:
     enabled: true


### PR DESCRIPTION
## Summary

This is the closing step after successful reboot-rebuild validation following the removal of the `snapshot-frequent` Longhorn recurring job.

tuppr was scaled to `replicaCount: 0` in #1528 to prevent upgrade operations during storage instability caused by the CoW merge treadmill. This PR restores it to `replicaCount: 3`.

**IMPORTANT: Do not merge until:**
- PR fix/longhorn-remove-snapshot-treadmill is merged and deployed to live
- A node reboot has been performed and the replica rebuild confirmed to use the fast checksum-skip path (not a full delta rebuild)
- No `LonghornReplicaRebuildStuck` alerts firing

## Test plan

- [ ] `task k8s:validate` passes (confirmed before commit)
- [ ] `fix/longhorn-remove-snapshot-treadmill` is merged and deployed
- [ ] Reboot-rebuild validation completed successfully (fast path confirmed)
- [ ] tuppr pods come up healthy after merge
- [ ] No pending TalosUpgrade or KubernetesUpgrade CRs that should not run yet

https://claude.ai/code/session_01473AtRS1vkDMzyc18idHxL