### PR TITLE
feat(sure): allow Cilium egress to Yahoo Finance for securities prices

### DIFF
--- a/kubernetes/clusters/live/config/sure/network-policy.yaml
+++ b/kubernetes/clusters/live/config/sure/network-policy.yaml
@@ -54,3 +54,27 @@ spec:
         - ports:
             - port: "11434"
               protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+# Permits Sure to reach Yahoo Finance for securities price history (the enabled
+# securities provider). Without this, mutual/index-fund holdings have no price
+# history, so investment balance charts collapse to $0 on all past dates and
+# spike only on the latest sync day.
+# - fc.yahoo.com: cookie fetch for crumb authentication
+# - query1.finance.yahoo.com: data endpoints (getcrumb, search, quoteSummary, chart)
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: sure-yahoo-finance-egress
+  namespace: sure
+spec:
+  description: "Allow Sure egress to Yahoo Finance API (fc.yahoo.com, query1.finance.yahoo.com:443)"
+  endpointSelector: { }
+  egress:
+    - toFQDNs:
+        - matchName: fc.yahoo.com
+        - matchName: query1.finance.yahoo.com
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP


### PR DESCRIPTION
## What

Adds a `toFQDNs` CiliumNetworkPolicy allowing the `sure` namespace to reach Yahoo Finance:
- `fc.yahoo.com` — cookie fetch for crumb authentication
- `query1.finance.yahoo.com` — data endpoints (getcrumb, search, quoteSummary, chart)

Both TCP/443.

## Why

Sure's **Yahoo Finance** securities provider is enabled in the app, but the settings page reports it as *"currently unavailable / could not be reached."* The `sure` namespace uses the `internal` network-policy profile (DNS-only egress), which blocks all external HTTPS except explicit per-host carve-outs. SimpleFIN and SnapTrade already have such carve-outs; Yahoo did not.

### Downstream impact this fixes

Without a working securities provider, Sure's `MarketDataImporter` cannot populate `security_prices`, so mutual/index-fund holdings (FXNAX, FZROX, VFFVX, etc.) stay `offline` with **zero** historical prices. The balance `Holding::ReverseCalculator` skips any historical date it can't price, so an investment position only has value on the single day SimpleFIN rides a price along on the holding row (today). Result: investment balances read **\$0 for all past dates** and **spike to full value on the most recent sync day** — the large last-day net-worth spike on the dashboard.

Restoring provider connectivity lets Sure fetch real historical NAVs, value the positions across the full window, and flatten the spike.

## Approach

Least-privilege per-host `toFQDNs` egress, mirroring the existing `sure-simplefin-egress` / `sure-snaptrade-egress` policies. No profile change (avoids opening blanket HTTPS egress). Cilium's DNS L7 proxy is auto-enabled by the `toFQDNs` rule, and rotating Yahoo CDN IPs are handled via continuous DNS-response allowlisting.

## Verification

After deploy: the Yahoo Finance provider health check on the Self-Hosting settings page should go green, and `security_prices` should begin populating for online-resolvable securities on the next market-data sync.

## Known follow-ups (out of scope)

- The **Tom 401k** holding uses an opaque plan-internal fund code (`3862`), not a real ticker — no public provider can price it. It will need a manual valuation or a code-level flat-carry fallback.
- Fidelity **ZERO** funds (FZROX/FZILX) are proprietary and may not resolve on Yahoo; to be verified post-deploy.