### PR TITLE
feat(sure): switch securities egress from Yahoo to Twelve Data

### DIFF
--- a/kubernetes/clusters/live/config/sure/network-policy.yaml
+++ b/kubernetes/clusters/live/config/sure/network-policy.yaml
@@ -56,24 +56,26 @@ spec:
               protocol: TCP
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
-# Permits Sure to reach Yahoo Finance for securities price history (the enabled
-# securities provider). Without this, mutual/index-fund holdings have no price
-# history, so investment balance charts collapse to $0 on all past dates and
-# spike only on the latest sync day.
-# - fc.yahoo.com: cookie fetch for crumb authentication
-# - query1.finance.yahoo.com: data endpoints (getcrumb, search, quoteSummary, chart)
+# Permits Sure to reach Twelve Data for securities price history (the enabled
+# securities provider). Without a reachable provider, mutual/index-fund holdings
+# have no price history, so investment balance charts collapse to $0 on all past
+# dates and spike only on the latest sync day.
+#
+# Replaces the previous Yahoo Finance egress: Yahoo's unauthenticated API
+# semi-permanently IP-rate-limits datacenter egress (persistent HTTP 429 from
+# the cluster), making it unusable server-side. Twelve Data is a keyed API with
+# no IP-reputation gating.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: sure-yahoo-finance-egress
+  name: sure-twelvedata-egress
   namespace: sure
 spec:
-  description: "Allow Sure egress to Yahoo Finance API (fc.yahoo.com, query1.finance.yahoo.com:443)"
+  description: "Allow Sure egress to Twelve Data API (api.twelvedata.com:443)"
   endpointSelector: { }
   egress:
     - toFQDNs:
-        - matchName: fc.yahoo.com
-        - matchName: query1.finance.yahoo.com
+        - matchName: api.twelvedata.com
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## What

Replaces the `sure-yahoo-finance-egress` CiliumNetworkPolicy with `sure-twelvedata-egress`, allowing the `sure` namespace to reach `api.twelvedata.com:443`.

## Why

The Yahoo egress from #1546 established connectivity, but Yahoo's unauthenticated API **semi-permanently IP-rate-limits the cluster's datacenter egress** — live fetches return HTTP 429 hours after first contact and do not recover. This is well-documented behavior: Yahoo throttles cloud/datacenter/VPN IP ranges by reputation, so no key or backoff fixes it from a homelab.

Without a reachable securities provider, Sure's `MarketDataImporter` cannot populate `security_prices`; offline mutual/index-fund holdings have no historical prices, the balance `ReverseCalculator` drops unpriced historical positions, and investment balances collapse to \$0 on all past dates while spiking on the latest sync day (the dashboard net-worth spike).

**Twelve Data** is a keyed API (free 800 credits/day) with no IP-reputation gating, covering US funds/ETFs. Single host, standard `toFQDNs` carve-out matching the SimpleFIN/SnapTrade pattern.

## Human step required

A Twelve Data API key must be entered in Sure's **Self-Hosting → Financial Data Providers** settings (Twelve Data enabled, Yahoo disabled). The key is app-side config, not repo state.

## After merge

Once the key is set and this deploys: `security_prices` backfills for provider-resolvable funds, balances rematerialize on the next account sync, and the net-worth spike flattens.

## Known residual (unchanged)

- **Tom 401k** holding `3862` is a plan-internal fund code no market feed carries — needs a manual valuation regardless of provider.
- Fidelity **ZERO** funds (FZROX/FZILX) coverage on Twelve Data to be verified post-deploy.