### PR TITLE
fix(paperless): use client_secret_basic for Authelia OIDC token auth

### DIFF
--- a/kubernetes/clusters/live/apps/paperless/helmrelease.yaml
+++ b/kubernetes/clusters/live/apps/paperless/helmrelease.yaml
@@ -131,7 +131,7 @@ spec:
                     key: client-secret
               PAPERLESS_SOCIALACCOUNT_PROVIDERS:
                 dependsOn: PAPERLESS_OIDC_CLIENT_SECRET
-                value: '{"openid_connect": {"OAUTH_PKCE_ENABLED": true, "APPS": [{"provider_id": "authelia", "name": "Authelia", "client_id": "paperless", "secret": "$(PAPERLESS_OIDC_CLIENT_SECRET)", "settings": {"server_url": "https://auth.${external_domain}/.well-known/openid-configuration"}}]}}'
+                value: '{"openid_connect": {"OAUTH_PKCE_ENABLED": true, "APPS": [{"provider_id": "authelia", "name": "Authelia", "client_id": "paperless", "secret": "$(PAPERLESS_OIDC_CLIENT_SECRET)", "settings": {"server_url": "https://auth.${external_domain}/.well-known/openid-configuration", "token_auth_method": "client_secret_basic"}}]}}'
               # Filename format — organise media into year/correspondent/date-title hierarchy
               # NOTE: changing PAPERLESS_FILENAME_FORMAT on an existing instance causes paperless
               # to re-file every document in the media volume on next startup (high I/O on the


### PR DESCRIPTION
## Summary

- Paperless OIDC login via Authelia was failing with `invalid_client` — Authelia requires `client_secret_basic` for the paperless client registration, but django-allauth defaults to `client_secret_post`
- Adds `"token_auth_method": "client_secret_basic"` to `PAPERLESS_SOCIALACCOUNT_PROVIDERS` settings to match what Authelia expects

## Error

```
Social authentication error for provider `Authelia`: unknown (Error retrieving access token:
{"error":"invalid_client","error_description":"...unsupported authentication method...
'client_secret_post', however the OAuth 2.0 client registration does not allow this method."})
```

## Test plan

- [ ] Login to paperless via Authelia OIDC succeeds after deploy

https://claude.ai/code/session_01Un2wgw3x5koXrRrbAKYhet