### PR TITLE
feat(redlib): encode preferred default settings

### DIFF
--- a/kubernetes/clusters/live/charts/redlib.yaml
+++ b/kubernetes/clusters/live/charts/redlib.yaml
@@ -22,8 +22,15 @@ controllers:
         env:
           TZ: UTC
           REDLIB_PORT: "8080"
+          REDLIB_DEFAULT_THEME: "system"
+          REDLIB_DEFAULT_LAYOUT: "compact"
+          REDLIB_DEFAULT_WIDE: "true"
+          REDLIB_DEFAULT_POST_SORT: "hot"
+          REDLIB_DEFAULT_COMMENT_SORT: "confidence"
+          REDLIB_DEFAULT_VIDEO_QUALITY: "best"
+          REDLIB_DEFAULT_FIXED_NAVBAR: "true"
           REDLIB_DEFAULT_SHOW_NSFW: "false"
-          REDLIB_DEFAULT_HIDE_HLS_NOTIFICATION: "true"
+          REDLIB_DEFAULT_HIDE_HLS_NOTIFICATION: "false"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary

- Set compact layout, wide UI, fixed navbar as defaults
- Set comment sort to confidence, post sort to hot, video quality to best
- Set theme to system
- Fix `REDLIB_DEFAULT_HIDE_HLS_NOTIFICATION` from `true` → `false`

## Test plan

- [ ] Flux reconciles HelmRelease on live cluster
- [ ] Redlib pod restarts and picks up new env vars
- [ ] `/settings` page reflects compact layout, wide UI, fixed navbar, confidence comment sort

https://claude.ai/code/session_015rRCDoPuBDauqV2C1efuSZ