### PR TITLE
feat(redlib): 2 replicas with zero-downtime rolling update

### DIFF
--- a/kubernetes/clusters/live/charts/redlib.yaml
+++ b/kubernetes/clusters/live/charts/redlib.yaml
@@ -4,7 +4,12 @@
 controllers:
   redlib:
     type: deployment
-    replicas: 1
+    replicas: 2
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
 
     pod:
       securityContext:


### PR DESCRIPTION
## Summary

- Scale redlib to 2 replicas for availability
- Add explicit `RollingUpdate` strategy: `maxSurge: 1`, `maxUnavailable: 0`

`maxUnavailable: 0` means Kubernetes always spins up a healthy new pod before terminating the old one — no downtime during version upgrades or pod restarts.

## Test plan

- [ ] Flux reconciles; 2 redlib pods Running
- [ ] `kubectl rollout status deployment/redlib -n redlib` completes cleanly
- [ ] Redlib accessible throughout a forced rollout (`kubectl rollout restart`)

https://claude.ai/code/session_015rRCDoPuBDauqV2C1efuSZ