### PR TITLE
chore(deps): add renovate annotation for redlib image

### DIFF
--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -74,6 +74,7 @@ flaresolverr_version=v3.5.0
 sabnzbd_version=5.1.0
 # renovate: datasource=docker depName=it-tools packageName=ghcr.io/corentinth/it-tools versioning=loose
 it_tools_version=2024.10.22-7ca5933
+# renovate: datasource=docker depName=redlib packageName=quay.io/redlib/redlib versioning=loose
 redlib_version=sha-a4d36e9
 # Exporter versions
 # renovate: datasource=docker depName=qbittorrent-exporter packageName=ghcr.io/martabal/qbittorrent-exporter


### PR DESCRIPTION
## Summary

- `redlib_version` in `kubernetes/clusters/live/versions.env` had no `# renovate:` annotation, so Renovate silently ignored it
- Adds `datasource=docker depName=redlib packageName=quay.io/redlib/redlib versioning=loose` to enable tracking of `sha-*` tags on quay.io
- Current deployed tag (`sha-a4d36e9`) is already the latest published image — no version bump needed

## Test plan

- [ ] Renovate dependency dashboard shows `redlib` after next Renovate run
- [ ] Renovate opens a PR when a new `sha-*` tag is published to `quay.io/redlib/redlib`