### PR TITLE
fix(renovate): pin floating image tags and fix broken geoipupdate annotation

### DIFF
--- a/kubernetes/clusters/live/apps/paperless/helmrelease.yaml
+++ b/kubernetes/clusters/live/apps/paperless/helmrelease.yaml
@@ -65,7 +65,8 @@ spec:
           init-run:
             image:
               repository: busybox
-              tag: latest
+              # renovate: datasource=docker depName=busybox
+              tag: "1.38.0"
             command:
               - /bin/sh
               - -c

--- a/kubernetes/clusters/live/charts/factorio.yaml
+++ b/kubernetes/clusters/live/charts/factorio.yaml
@@ -17,7 +17,7 @@ controllers:
         image:
           repository: factoriotools/factorio
           # renovate: datasource=docker depName=factoriotools/factorio
-          tag: stable
+          tag: "2.1.14"
           pullPolicy: Always
         env:
           LOAD_LATEST_SAVE: "true"

--- a/kubernetes/clusters/live/charts/jfa-go.yaml
+++ b/kubernetes/clusters/live/charts/jfa-go.yaml
@@ -15,7 +15,8 @@ controllers:
       app:
         image:
           repository: hrfee/jfa-go
-          tag: latest
+          # renovate: datasource=docker depName=hrfee/jfa-go
+          tag: v0.6.0
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false

--- a/kubernetes/platform/charts/alloy.yaml
+++ b/kubernetes/platform/charts/alloy.yaml
@@ -15,7 +15,7 @@ controller:
   initContainers:
     - name: geoipupdate-init
       # renovate: datasource=docker depName=ghcr.io/maxmind/geoipupdate
-      image: &geoipupdate ghcr.io/maxmind/geoipupdate:v8.0.0
+      image: ghcr.io/maxmind/geoipupdate:v8.0.0
       env:
         - name: GEOIPUPDATE_EDITION_IDS
           value: GeoLite2-City
@@ -39,7 +39,7 @@ controller:
   # times per week; a long-lived Alloy pod would otherwise drift stale.
   extraContainers:
     - name: geoipupdate
-      image: *geoipupdate
+      image: ghcr.io/maxmind/geoipupdate:v8.0.0
       env:
         - name: GEOIPUPDATE_EDITION_IDS
           value: GeoLite2-City


### PR DESCRIPTION
## Summary

Closes coverage gaps found during a full Renovate image audit. All deployed container images should be tracked with pinned semver tags that Renovate can update.

- **alloy** (`platform/charts/alloy.yaml`): The `&geoipupdate`/`*geoipupdate` YAML anchor on the `image:` field broke the Renovate regex — the regex matches `image: <repo>:<tag>` but the anchor inserts extra text (`&geoipupdate`) between `image:` and the repo string. Fixed by expanding both containers to explicit image strings.

- **paperless** (`apps/paperless/helmrelease.yaml`): busybox init container had `tag: latest` with no Renovate annotation. Pinned to `1.38.0` (latest stable) and added annotation.

- **jfa-go** (`clusters/live/charts/jfa-go.yaml`): `tag: latest` with no annotation. Pinned to `v0.6.0` (latest) and added annotation.

- **factorio** (`clusters/live/charts/factorio.yaml`): Annotation existed but `tag: stable` is a floating tag Renovate cannot compare against semver. Pinned to `2.1.14` (latest stable release).

**Valheim excluded**: `lloesche/valheim-server` publishes only `latest` and git SHA tags — no semver exists to pin or track with Renovate.

## Test plan

- [x] `task k8s:validate` passes (YAML lint, ResourceSet expansion, Helm templating, schema validation, deprecation check)
- [ ] Renovate dry-run detects the newly-annotated images on next scheduled run
- [ ] No unexpected pod restarts after merge (factorio pin is a version bump from `stable`)

https://claude.ai/code/session_01WznVbTBn2uRGP43RVi4ZPn