### PR TITLE
feat(home-assistant): add Ollama network policies

### DIFF
--- a/kubernetes/clusters/live/config/ai-prereqs/network-policy.yaml
+++ b/kubernetes/clusters/live/config/ai-prereqs/network-policy.yaml
@@ -80,3 +80,23 @@ spec:
         - ports:
             - port: "11434"
               protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: ai-ollama-from-home-assistant
+  namespace: ai
+spec:
+  description: "Ollama ingress from Home Assistant for the Home Assistant Ollama integration"
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: ollama
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home-assistant
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP

--- a/kubernetes/clusters/live/config/home-assistant/hass-ollama-egress.yaml
+++ b/kubernetes/clusters/live/config/home-assistant/hass-ollama-egress.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: hass-ollama-egress
+  namespace: home-assistant
+spec:
+  description: "Allow Home Assistant egress to Ollama API for the Home Assistant Ollama integration"
+  endpointSelector: { }
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP

--- a/kubernetes/clusters/live/config/home-assistant/kustomization.yaml
+++ b/kubernetes/clusters/live/config/home-assistant/kustomization.yaml
@@ -13,4 +13,5 @@ resources:
   - hass-cnpg-garage-key.yaml
   - hass-oidc-client-secret-replica.yaml
   - hass-google-caldav-secret.yaml
+  - hass-ollama-egress.yaml
   - canary.yaml


### PR DESCRIPTION
## Summary

- Adds a `CiliumNetworkPolicy` in the `home-assistant` namespace granting egress to Ollama (port 11434 TCP) in the `ai` namespace
- Adds a matching `CiliumNetworkPolicy` in the `ai` namespace granting ingress from the `home-assistant` namespace to Ollama (port 11434 TCP)
- Registers `hass-ollama-egress.yaml` in the home-assistant `kustomization.yaml`

Both policies are required because Cilium enforces network policy in both directions. Together they enable the Home Assistant Ollama integration to communicate with the in-cluster Ollama service.

## Test plan

- [ ] Verify `hass-ollama-egress` CNP is created in the `home-assistant` namespace after merge and Flux reconciliation
- [ ] Verify `ai-ollama-from-home-assistant` CNP is created in the `ai` namespace
- [ ] Confirm Home Assistant can reach Ollama at `ollama.ai.svc:11434` (e.g., via HA Ollama integration config test)
- [ ] Confirm no new DROPPED flows appear in Hubble for home-assistant → ai traffic on port 11434

https://claude.ai/code/session_0168XDq7Wxh5yBBBPwHcXUyP