### PR TITLE
fix(homepage): correct icon names for tandoor and lldap

### DIFF
--- a/kubernetes/clusters/live/charts/lldap.yaml
+++ b/kubernetes/clusters/live/charts/lldap.yaml
@@ -103,7 +103,7 @@ route:
       gethomepage.dev/enabled: "true"
       gethomepage.dev/name: "LLDAP"
       gethomepage.dev/group: "Apps"
-      gethomepage.dev/icon: "light-ldap.svg"
+      gethomepage.dev/icon: "lldap.svg"
       gethomepage.dev/pod-selector: "app.kubernetes.io/name=lldap"
     parentRefs:
       - name: internal

--- a/kubernetes/clusters/live/charts/tandoor.yaml
+++ b/kubernetes/clusters/live/charts/tandoor.yaml
@@ -147,7 +147,7 @@ route:
       gethomepage.dev/enabled: "true"
       gethomepage.dev/name: "Tandoor"
       gethomepage.dev/group: "Apps"
-      gethomepage.dev/icon: "tandoor.svg"
+      gethomepage.dev/icon: "tandoor-recipes.svg"
       gethomepage.dev/pod-selector: "app.kubernetes.io/name=tandoor"
     parentRefs:
       - name: external


### PR DESCRIPTION
## Summary

- `tandoor.svg` → `tandoor-recipes.svg` (correct dashboard-icons name)
- `light-ldap.svg` → `lldap.svg` (correct dashboard-icons name)

Both were returning 404 from the homarr-labs/dashboard-icons CDN, causing homepage to fall back to the generic "logo" placeholder.

## Test plan

- [ ] Verify Tandoor shows recipe book icon on homepage
- [ ] Verify LLDAP shows its icon on homepage