### PR TITLE
fix(vaultwarden): allow SSO login for existing local accounts

### DIFF
--- a/kubernetes/clusters/live/charts/vaultwarden.yaml
+++ b/kubernetes/clusters/live/charts/vaultwarden.yaml
@@ -59,6 +59,7 @@ controllers:
                 name: vaultwarden-oidc-client-secret
                 key: client-secret
           SSO_SCOPES: "openid profile email offline_access"
+          SSO_ALLOW_EXISTING_USERS: "true"
           ENABLE_METRICS: "true"
           METRICS_TOKEN:
             valueFrom:


### PR DESCRIPTION
## Summary
- Adds `SSO_ALLOW_EXISTING_USERS: "true"` to Vaultwarden env config
- Fixes "Existing SSO user with same email" error on SSO login
- Users with pre-existing local password accounts can now authenticate via Authelia OIDC

## Test plan
- [ ] Log into vault.${internal_domain} via SSO — should succeed without error
- [ ] Confirm vault unlocks and all items are accessible

https://claude.ai/code/session_01C88pRNbd1BtEyHGw1SK6XD