### PR TITLE
feat(network-policy): add label-driven Home Assistant egress CCNP

### DIFF
--- a/.claude/skills/network-policy/references/profiles.md
+++ b/.claude/skills/network-policy/references/profiles.md
@@ -28,12 +28,22 @@ Platform namespaces (`kube-system`, `monitoring`, `database`, etc.) use hand-cra
 
 Add to the namespace in `kubernetes/platform/namespaces.yaml`:
 
-| Label | Port | Resource |
-|-------|------|---------|
-| `access.network-policy.homelab/postgres: "true"` | 5432 | PostgreSQL (shared platform cluster) |
-| `access.network-policy.homelab/dragonfly: "true"` | 6379 | Dragonfly/Redis cache |
-| `access.network-policy.homelab/garage-s3: "true"` | 3900 | Garage S3 object storage |
-| `access.network-policy.homelab/kube-api: "true"` | 6443 | Kubernetes API |
+| Label | Port | Resource | Notes |
+|-------|------|---------|-------|
+| `access.network-policy.homelab/postgres: "true"` | 5432 | PostgreSQL (shared platform cluster) | Add to requesting namespace |
+| `access.network-policy.homelab/dragonfly: "true"` | 6379 | Dragonfly/Redis cache | Add to requesting namespace |
+| `access.network-policy.homelab/garage-s3: "true"` | 3900 | Garage S3 object storage | Add to requesting namespace |
+| `access.network-policy.homelab/kube-api: "true"` | 6443 | Kubernetes API | Add to requesting namespace |
+| `access.network-policy.homelab/home-assistant: "true"` | per-app | Allows HA egress into this namespace | Add to TARGET app namespace |
+
+> **`home-assistant` label — inverted semantics.** Unlike the other labels (which go on the requester and
+> grant fixed-port egress to a platform service), this label goes on the **target app namespace** and
+> allows Home Assistant to reach that app. The shared CCNP (`access-home-assistant.yaml`) is L3-only
+> (no `toPorts`); the actual port is enforced by a per-app `CiliumNetworkPolicy` in the target namespace
+> granting ingress from the `home-assistant` namespace on the app's API port. Cilium intersects both
+> rules — the effective allowed port is what the per-app ingress CNP declares.
+> Two changes are required per integration: (1) add this label to the target app namespace, and
+> (2) create a per-app ingress CNP pinning the app's API port.
 
 ## Drop Classification
 
@@ -45,6 +55,7 @@ Add to the namespace in `kubernetes/platform/namespaces.yaml`:
 | Egress to internet `:443` dropped | Profile doesn't allow HTTPS egress | Switch to `internal-egress` or `standard` |
 | Ingress from `istio-gateway` dropped | Profile doesn't allow gateway ingress | Switch to `internal`, `internal-egress`, or `standard` |
 | Ingress from `monitoring:prometheus` dropped | Missing baseline | Should not happen — check baseline CCNP |
+| HA egress to app namespace dropped | Target app namespace missing `access.network-policy.homelab/home-assistant=true` AND/OR missing per-app ingress CNP | Add the label to the target namespace and create a per-app CNP allowing ingress from `home-assistant` on the app's API port |
 
 ## Hubble Debug Commands
 

--- a/kubernetes/clusters/live/config/ai-prereqs/namespace.yaml
+++ b/kubernetes/clusters/live/config/ai-prereqs/namespace.yaml
@@ -9,5 +9,6 @@ metadata:
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/warn: restricted
     network-policy.homelab/profile: internal-egress
+    access.network-policy.homelab/home-assistant: "true"
     access.network-policy.homelab/postgres: "true"
     access.network-policy.homelab/dragonfly: "true"

--- a/kubernetes/clusters/live/config/ai-prereqs/network-policy.yaml
+++ b/kubernetes/clusters/live/config/ai-prereqs/network-policy.yaml
@@ -80,3 +80,23 @@ spec:
         - ports:
             - port: "11434"
               protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: ai-ollama-from-home-assistant
+  namespace: ai
+spec:
+  description: "Ollama ingress from Home Assistant for the Home Assistant Ollama integration"
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: ollama
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home-assistant
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP

--- a/kubernetes/platform/config/network-policy/CLAUDE.md
+++ b/kubernetes/platform/config/network-policy/CLAUDE.md
@@ -47,8 +47,9 @@ network-policy/
 │   └── system-upgrade.yaml        # Tuppr upgrade controller
 ├── shared-resources/    # Opt-in access to shared services
 │   ├── access-dragonfly.yaml      # Dragonfly (Redis) access
-│   ├── access-postgres.yaml       # Database access
-│   └── access-garage-s3.yaml      # Object storage access
+│   ├── access-garage-s3.yaml      # Object storage access
+│   ├── access-home-assistant.yaml # Home Assistant egress to labeled app namespaces
+│   └── access-postgres.yaml       # Database access
 └── kustomization.yaml
 ```
 
@@ -71,8 +72,18 @@ Namespaces can opt-in to additional capabilities via labels:
 |-------|------------|
 | `access.network-policy.homelab/kube-api=true` | Egress to Kubernetes API (port 6443) |
 | `access.network-policy.homelab/dragonfly=true` | Egress to Dragonfly in cache namespace (port 6379) |
-| `access.network-policy.homelab/postgres=true` | Egress to PostgreSQL in database namespace (port 5432) |
 | `access.network-policy.homelab/garage-s3=true` | Egress to Garage S3 in garage namespace (port 3900) |
+| `access.network-policy.homelab/home-assistant=true` | Allows Home Assistant to egress into this namespace (see note below) |
+| `access.network-policy.homelab/postgres=true` | Egress to PostgreSQL in database namespace (port 5432) |
+
+> **Note — `home-assistant` label semantics differ from the others.** All other access labels go on the
+> **requesting** namespace and open egress to a fixed platform service+port. The `home-assistant` label
+> goes on the **target app** namespace and grants Home Assistant egress access inbound to that app.
+> The shared CCNP (`access-home-assistant.yaml`) is intentionally L3-only (no `toPorts`); port enforcement
+> is provided by a per-app `CiliumNetworkPolicy` in the target namespace that allows ingress from the
+> `home-assistant` namespace on the app's specific API port. Cilium intersects the two rules, so the
+> effective port is what the app's ingress CNP declares — not a global shared value. Do not add this
+> label to the `home-assistant` namespace itself; add it to the namespaces of apps that HA needs to call.
 
 ## Escape Hatch
 

--- a/kubernetes/platform/config/network-policy/shared-resources/access-home-assistant.yaml
+++ b/kubernetes/platform/config/network-policy/shared-resources/access-home-assistant.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumclusterwidenetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: access-home-assistant-egress
+spec:
+  description: >-
+    Allow Home Assistant to egress to app namespaces labeled for HA integration.
+    Port enforcement is delegated to the per-app ingress CNP; Cilium intersects
+    the egress (this rule, L3-only) with the ingress (per-app CNP, L3+port) so
+    the effective allowed port is what the app declares — not this policy.
+    Usage: Add label access.network-policy.homelab/home-assistant=true to the
+    TARGET app namespace, plus a per-app CiliumNetworkPolicy allowing ingress
+    from the home-assistant namespace on the app's API port.
+    Example per-app ingress CNP (in the target app namespace):
+      spec:
+        endpointSelector: {}
+        ingress:
+          - fromEndpoints:
+              - matchLabels:
+                  io.kubernetes.pod.namespace: home-assistant
+            toPorts:
+              - ports:
+                  - port: "8000"
+                    protocol: TCP
+  endpointSelector:
+    matchLabels:
+      io.kubernetes.pod.namespace: home-assistant
+  egress:
+    - toEndpoints:
+        - matchExpressions:
+            - key: io.cilium.k8s.namespace.labels.access.network-policy.homelab/home-assistant
+              operator: In
+              values: ["true"]

--- a/kubernetes/platform/config/network-policy/shared-resources/kustomization.yaml
+++ b/kubernetes/platform/config/network-policy/shared-resources/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - access-dragonfly.yaml
   - access-garage-s3.yaml
+  - access-home-assistant.yaml
   - access-postgres.yaml


### PR DESCRIPTION
## Summary

- Adds a shared `CiliumClusterwideNetworkPolicy` (`access-home-assistant-egress`) that lets Home Assistant pods egress to any app namespace carrying the label `access.network-policy.homelab/home-assistant=true`.
- The CCNP is intentionally L3-only (no `toPorts`). Port enforcement is the responsibility of a per-app `CiliumNetworkPolicy` in the target namespace; Cilium intersects the egress and ingress rules, so the effective port is what the app declares — not a global value.
- Updates the kustomization, the network-policy `CLAUDE.md` access-labels table, and the skills `profiles.md` catalog and drop table to document the new label and its inverted semantics (label goes on the *target* app namespace, not the requester).
- **Migrates the first real consumer: Home Assistant → Ollama.** The `ai` namespace is labeled with `access.network-policy.homelab/home-assistant=true`, and a `ai-ollama-from-home-assistant` CNP pins ingress from the `home-assistant` namespace on port 11434. This supersedes the hand-rolled `hass-ollama-egress.yaml` on branch `feat/hass-ollama-network-policies`; that branch can be closed without merging.

## Why this design

The existing `access.*` labels (postgres, dragonfly, garage-s3) sit on the **requesting** namespace and target a fixed service+port. HA-to-app is different: the source is always HA, but the target namespace and port vary per app (Immich 2283, Paperless 8000, etc.). Putting the port in the shared CCNP would require editing it for every integration — the opposite of opt-in.

Instead, the port lives in a per-app ingress CNP authored when the integration is wired up. Cilium's intersection of egress+ingress rules under default-deny means the shared CCNP supplies the "HA may reach this namespace" assertion, and the per-app CNP supplies the "on this port" assertion. Neither rule alone is sufficient; both must exist for traffic to flow. Every other pod in the `ai` namespace (e.g. open-webui) remains unreachable from HA because only Ollama has an ingress-from-home-assistant rule.

## Files changed

| File | Change |
|------|--------|
| `kubernetes/platform/config/network-policy/shared-resources/access-home-assistant.yaml` | New shared CCNP (L3-only egress from `home-assistant` to labeled namespaces) |
| `kubernetes/platform/config/network-policy/shared-resources/kustomization.yaml` | Registers new CCNP |
| `kubernetes/platform/config/network-policy/CLAUDE.md` | Documents new label with inverted-semantics note |
| `.claude/skills/network-policy/references/profiles.md` | Access label catalog + drop table entries |
| `kubernetes/clusters/live/config/ai-prereqs/namespace.yaml` | Adds `access.network-policy.homelab/home-assistant=true` to `ai` namespace |
| `kubernetes/clusters/live/config/ai-prereqs/network-policy.yaml` | Adds `ai-ollama-from-home-assistant` CNP (port 11434/TCP) |

## Test plan

- [x] `task k8s:validate` passes: 0 invalid, 0 errors across all manifests, no deprecated API versions detected (both commits)
- [ ] Verify HA → Ollama flows with `hubble observe --from-namespace home-assistant --to-namespace ai --since 2m` — expect FORWARDED on port 11434 after deployment
- [ ] Verify HA cannot reach open-webui or other `ai` pods (no ingress-from-home-assistant rule exists for them — expect DROPPED)
- [ ] Verify drops occur if either the namespace label or the per-app CNP is removed individually (Cilium requires both)

https://claude.ai/code/session_01A1UzhqEfNZuCUCwXiqHfGe