### PR TITLE
fix(jfa-go): pin latest tag to SHA digest instead of nonexistent v0.6.0

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -213,6 +213,14 @@
       ],
       "groupName": "tdarr"
     },
+    {
+      // hrfee/jfa-go publishes only floating tags (latest, unstable) — no semver.
+      // Restrict to digest-only updates to avoid phantom version lookup failures.
+      "matchDepNames": [
+        "hrfee/jfa-go"
+      ],
+      "updateTypes": ["digest"]
+    },
     // ============================================================
     // Version holds — upstream regressions (see .github/version-holds.yaml)
     // ============================================================

--- a/kubernetes/clusters/live/charts/jfa-go.yaml
+++ b/kubernetes/clusters/live/charts/jfa-go.yaml
@@ -16,7 +16,7 @@ controllers:
         image:
           repository: hrfee/jfa-go
           # renovate: datasource=docker depName=hrfee/jfa-go
-          tag: v0.6.0
+          tag: latest@sha256:701cfca823f9278b65f4cf7706b0c7f89b3be33e17ca077f11d89dc119e9f307
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false


### PR DESCRIPTION
## Summary

- `hrfee/jfa-go` does not publish semver Docker image tags — only `latest` and `unstable` exist on Docker Hub
- `v0.6.0` tag (pinned in #1555) does not exist, causing `ImagePullBackOff` on the live cluster (20 upgrade failures)
- Pin to `latest@sha256:701cfca823f9278b65f4cf7706b0c7f89b3be33e17ca077f11d89dc119e9f307` — immutable, pullable, and Renovate-trackable

## Test plan

- [ ] Verify Flux HelmRelease reconciles successfully after merge
- [ ] Verify pod in `media/jfa-go` transitions from `ImagePullBackOff` to `Running`
- [ ] Verify canary check passes for jfa-go
- [ ] Renovate can open digest-update PRs going forward (docker datasource understands `tag@sha256:digest` format)

https://claude.ai/code/session_0187EtVBDXte2zK6Hfd7J2d7