### PR TITLE
feat(k8s): deploy Mealie recipe manager

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -451,6 +451,26 @@ configMap:
           access_token_signed_response_alg: none
           userinfo_signed_response_alg: none
           token_endpoint_auth_method: client_secret_post
+        - client_id: mealie
+          client_name: Mealie
+          client_secret:
+            path: /secrets/mealie-oidc-client-secret/client-secret
+          public: false
+          authorization_policy: recipes
+          consent_mode: implicit
+          require_pkce: true
+          pkce_challenge_method: S256
+          redirect_uris:
+            - https://mealie.${internal_domain}/login
+          scopes:
+            - openid
+            - profile
+            - email
+          response_types:
+            - code
+          grant_types:
+            - authorization_code
+          token_endpoint_auth_method: client_secret_post
 
   regulation:
     max_retries: 3
@@ -480,4 +500,5 @@ secret:
     papra-oidc-client-secret: { }
     sure-oidc-client-secret: { }
     home-assistant-oidc-client-secret: { }
+    mealie-oidc-client-secret: { }
     authelia-smtp-credentials: { }

--- a/kubernetes/clusters/live/charts/kustomization.yaml
+++ b/kubernetes/clusters/live/charts/kustomization.yaml
@@ -21,6 +21,7 @@ configMapGenerator:
       - houndarr.yaml
       - immich.yaml
       - it-tools.yaml
+      - mealie.yaml
       - konflate.yaml
       - jellyfin-exporter.yaml
       - jfa-go.yaml

--- a/kubernetes/clusters/live/charts/mealie.yaml
+++ b/kubernetes/clusters/live/charts/mealie.yaml
@@ -1,0 +1,113 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-4.6.2/charts/other/app-template/values.schema.json
+controllers:
+  main:
+    type: deployment
+    replicas: 1
+    annotations:
+      reloader.stakater.com/auto: "true"
+
+    pod:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+    containers:
+      app:
+        image:
+          repository: ghcr.io/mealie-recipes/mealie
+          tag: ${mealie_version}
+        env:
+          # Server configuration
+          API_PORT: "9000"
+          BASE_URL: "https://mealie.${internal_domain}"
+          TZ: UTC
+          ALLOW_SIGNUP: "false"
+          # Database — shared platform CNPG cluster
+          DB_ENGINE: postgres
+          POSTGRES_SERVER: platform-pooler-rw.database.svc.cluster.local
+          POSTGRES_PORT: "5432"
+          POSTGRES_DB: mealie
+          POSTGRES_USER: mealie
+          POSTGRES_PASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: mealie-db-credentials
+                key: password
+          # OIDC/SSO via Authelia
+          OIDC_AUTH_ENABLED: "true"
+          OIDC_SIGNUP_ENABLED: "true"
+          OIDC_REQUIRES_EMAIL_VERIFICATION: "false"
+          OIDC_CONFIGURATION_URL: "https://auth.${external_domain}/.well-known/openid-configuration"
+          OIDC_CLIENT_ID: mealie
+          OIDC_CLIENT_SECRET:
+            valueFrom:
+              secretKeyRef:
+                name: mealie-oidc-client-secret
+                key: client-secret
+          OIDC_USER_GROUP: recipes
+          OIDC_ADMIN_GROUP: admins
+          OIDC_AUTO_REDIRECT: "false"
+          OIDC_PROVIDER_NAME: Authelia
+          OIDC_REMEMBER_ME: "true"
+          OIDC_GROUPS_CLAIM: groups
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 256Mi
+          limits:
+            memory: 1Gi
+        probes:
+          startup:
+            enabled: true
+            spec:
+              initialDelaySeconds: 20
+              periodSeconds: 5
+              failureThreshold: 30
+          liveness:
+            enabled: true
+          readiness:
+            enabled: true
+
+service:
+  app:
+    controller: main
+    ports:
+      http:
+        port: 9000
+
+route:
+  internal:
+    enabled: true
+    annotations:
+      gethomepage.dev/enabled: "true"
+      gethomepage.dev/name: "Mealie"
+      gethomepage.dev/group: "Apps"
+      gethomepage.dev/icon: "mealie.svg"
+      gethomepage.dev/pod-selector: "app.kubernetes.io/name=mealie"
+    parentRefs:
+      - name: internal
+        namespace: istio-gateway
+    hostnames:
+      - "mealie.${internal_domain}"
+    rules:
+      - backendRefs:
+          - identifier: app
+            port: 9000
+
+persistence:
+  data:
+    type: persistentVolumeClaim
+    existingClaim: mealie-data
+    globalMounts:
+      - path: /app/data

--- a/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - jellyseerr-oidc-client-secret.yaml
   - papra-oidc-client-secret.yaml
   - home-assistant-oidc-client-secret.yaml
+  - mealie-oidc-client-secret.yaml
   - authelia-secrets.yaml
   - authelia-smtp-credentials.yaml
   - authelia-smtp-egress.yaml

--- a/kubernetes/clusters/live/config/authelia-prereqs/mealie-oidc-client-secret.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/mealie-oidc-client-secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mealie-oidc-client-secret
+  namespace: authelia
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: client-secret
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "64"
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "mealie"
+data: { }

--- a/kubernetes/clusters/live/config/database/cluster-roles-patch.yaml
+++ b/kubernetes/clusters/live/config/database/cluster-roles-patch.yaml
@@ -81,3 +81,8 @@ spec:
         login: true
         passwordSecret:
           name: sure-role-password
+      - name: mealie
+        ensure: present
+        login: true
+        passwordSecret:
+          name: mealie-role-password

--- a/kubernetes/clusters/live/config/database/databases.yaml
+++ b/kubernetes/clusters/live/config/database/databases.yaml
@@ -238,3 +238,15 @@ spec:
   cluster:
     name: platform
   databaseReclaimPolicy: retain
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: mealie-database
+  namespace: database
+spec:
+  name: mealie
+  owner: mealie
+  cluster:
+    name: platform
+  databaseReclaimPolicy: retain

--- a/kubernetes/clusters/live/config/database/role-secrets.yaml
+++ b/kubernetes/clusters/live/config/database/role-secrets.yaml
@@ -211,3 +211,17 @@ metadata:
 type: kubernetes.io/basic-auth
 stringData:
   username: sure
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mealie-role-password
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "mealie"
+type: kubernetes.io/basic-auth
+stringData:
+  username: mealie

--- a/kubernetes/clusters/live/config/kustomization.yaml
+++ b/kubernetes/clusters/live/config/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - factorio
   - satisfactory
   - minecraft
+  - mealie
   - tandoor
   - sure
   - papra

--- a/kubernetes/clusters/live/config/mealie/kustomization.yaml
+++ b/kubernetes/clusters/live/config/mealie/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - mealie-data-pvc.yaml
+  - mealie-db-credentials.yaml
+  - mealie-oidc-client-secret-replica.yaml

--- a/kubernetes/clusters/live/config/mealie/mealie-data-pvc.yaml
+++ b/kubernetes/clusters/live/config/mealie/mealie-data-pvc.yaml
@@ -1,0 +1,14 @@
+---
+# Mealie app data — stores uploaded recipe images and attachments.
+# Recipes themselves are stored in PostgreSQL.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mealie-data
+  namespace: mealie
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/clusters/live/config/mealie/mealie-db-credentials.yaml
+++ b/kubernetes/clusters/live/config/mealie/mealie-db-credentials.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mealie-db-credentials
+  namespace: mealie
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: database/mealie-role-password
+type: Opaque
+data: { }

--- a/kubernetes/clusters/live/config/mealie/mealie-oidc-client-secret-replica.yaml
+++ b/kubernetes/clusters/live/config/mealie/mealie-oidc-client-secret-replica.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mealie-oidc-client-secret
+  namespace: mealie
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: authelia/mealie-oidc-client-secret
+data: { }

--- a/kubernetes/clusters/live/config/mealie/namespace.yaml
+++ b/kubernetes/clusters/live/config/mealie/namespace.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mealie
+  labels:
+    istio.io/dataplane-mode: ambient
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline
+    network-policy.homelab/profile: internal
+    access.network-policy.homelab/postgres: "true"

--- a/kubernetes/clusters/live/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/live/resourcesets/helm-charts.yaml
@@ -204,6 +204,13 @@ spec:
         version: "${app_template_version}"
         url: oci://ghcr.io/bjw-s-labs/helm
       dependsOn: [tdarr, nvidia-device-plugin]
+    - name: mealie
+      namespace: mealie
+      chart:
+        name: app-template
+        version: "${app_template_version}"
+        url: oci://ghcr.io/bjw-s-labs/helm
+      dependsOn: [cloudnative-pg, secret-generator]
     - name: tandoor
       namespace: tandoor
       chart:

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -11,7 +11,7 @@ immich_version=0.12.0
 # renovate: datasource=helm depName=authelia registryUrl=https://charts.authelia.com
 authelia_version=0.11.6
 # renovate: datasource=helm depName=open-webui registryUrl=https://helm.openwebui.com
-open_webui_version=15.2.1
+open_webui_version=16.0.0
 
 # Container image versions (Flux substitution into chart values)
 # renovate: datasource=docker depName=ghcr.io/immich-app/immich-machine-learning versioning=regex:^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-cuda$
@@ -27,11 +27,11 @@ booter_version=v0.4.0
 # renovate: datasource=docker depName=qbittorrent packageName=ghcr.io/home-operations/qbittorrent
 qbittorrent_version=5.2.3
 # renovate: datasource=docker depName=prowlarr packageName=ghcr.io/home-operations/prowlarr
-prowlarr_version=2.6.0.5494
+prowlarr_version=2.6.1.5509
 # renovate: datasource=docker depName=sonarr packageName=ghcr.io/home-operations/sonarr
-sonarr_version=4.0.19.2995
+sonarr_version=4.0.19.3001
 # renovate: datasource=docker depName=radarr packageName=ghcr.io/home-operations/radarr
-radarr_version=6.4.0.10540
+radarr_version=6.4.1.10545
 # renovate: datasource=docker depName=sonarr4k packageName=ghcr.io/home-operations/sonarr
 sonarr4k_version=4.0.17.2953
 # renovate: datasource=docker depName=radarr4k packageName=ghcr.io/home-operations/radarr
@@ -41,15 +41,17 @@ jellyfin_version=10.11.11
 # renovate: datasource=docker depName=jellyfin-exporter packageName=rebelcore/jellyfin-exporter
 jellyfin_exporter_version=v1.5.2
 # renovate: datasource=docker depName=tdarr packageName=ghcr.io/haveagitgat/tdarr
-tdarr_version=2.85.01
+tdarr_version=2.86.01
 # renovate: datasource=docker depName=tdarr-node packageName=ghcr.io/haveagitgat/tdarr_node
-tdarr_node_version=2.85.01
+tdarr_node_version=2.86.01
 # renovate: datasource=docker depName=seerr packageName=ghcr.io/seerr-team/seerr
 seerr_version=v3.4.1
 # renovate: datasource=docker depName=tandoor packageName=ghcr.io/tandoorrecipes/recipes versioning=loose
 tandoor_version=2.6.13
+# renovate: datasource=docker depName=mealie packageName=ghcr.io/mealie-recipes/mealie
+mealie_version=v3.22.0
 # renovate: datasource=docker depName=recyclarr packageName=ghcr.io/recyclarr/recyclarr
-recyclarr_version=8.7.0
+recyclarr_version=8.7.1
 # renovate: datasource=docker depName=bazarr packageName=ghcr.io/home-operations/bazarr
 bazarr_version=1.6.0
 # renovate: datasource=docker depName=yq packageName=mikefarah/yq
@@ -61,9 +63,9 @@ vaultwarden_version=1.37.1-alpine
 # renovate: datasource=docker depName=homepage packageName=ghcr.io/gethomepage/homepage
 homepage_version=v1.13.2
 # renovate: datasource=docker depName=ghcr.io/av1155/houndarr
-houndarr_version=v1.13.0
+houndarr_version=v1.13.2
 # renovate: datasource=docker depName=ollama packageName=ollama/ollama
-ollama_version=0.32.5
+ollama_version=0.32.10
 # renovate: datasource=docker depName=exportarr packageName=ghcr.io/onedr0p/exportarr
 exportarr_version=v2.3.0
 # renovate: datasource=docker depName=gluetun packageName=ghcr.io/qdm12/gluetun
@@ -71,9 +73,10 @@ gluetun_version=v3.40.4
 # renovate: datasource=docker depName=flaresolverr packageName=ghcr.io/flaresolverr/flaresolverr
 flaresolverr_version=v3.5.0
 # renovate: datasource=docker depName=sabnzbd packageName=ghcr.io/home-operations/sabnzbd
-sabnzbd_version=5.0.4
+sabnzbd_version=5.1.0
 # renovate: datasource=docker depName=it-tools packageName=ghcr.io/corentinth/it-tools versioning=loose
 it_tools_version=2024.10.22-7ca5933
+# renovate: datasource=docker depName=redlib packageName=quay.io/redlib/redlib versioning=loose
 redlib_version=sha-a4d36e9
 # Exporter versions
 # renovate: datasource=docker depName=qbittorrent-exporter packageName=ghcr.io/martabal/qbittorrent-exporter
@@ -83,25 +86,22 @@ mc_monitor_version=0.17.0
 
 # Minecraft versions
 # renovate: datasource=docker depName=minecraft-server packageName=itzg/minecraft-server
-minecraft_server_version=2026.7.2
+minecraft_server_version=2026.8.0
 # renovate: datasource=docker depName=mc-backup packageName=itzg/mc-backup
-minecraft_backup_version=2026.7.3
+minecraft_backup_version=2026.8.1
 # Minecraft game version (manual updates — no Renovate datasource)
 minecraft_game_version=1.21.4
 
 # renovate: datasource=docker depName=sure packageName=ghcr.io/we-promise/sure
 sure_version=0.7.3
 
-# renovate: datasource=docker depName=papra packageName=ghcr.io/papra-hq/papra versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-rootless$
-papra_version=26.6.1-rootless
-
 # Home Assistant
 # renovate: datasource=docker depName=home-assistant packageName=ghcr.io/home-assistant/home-assistant
-home_assistant_version=2026.7.4
+home_assistant_version=2026.8.1
 # renovate: datasource=github-releases depName=hass-oidc-auth packageName=christiaangoossens/hass-oidc-auth
 hass_oidc_auth_version=v1.1.1
 # renovate: datasource=docker depName=code-server packageName=codercom/code-server
-code_server_version=4.131.0
+code_server_version=4.132.0
 
 # Palworld
 # renovate: datasource=docker depName=ghcr.io/thijsvanloef/palworld-server-docker
@@ -114,4 +114,4 @@ talos_pxe_schematic_id=613e1592b2da41ae5e265e8789429f22e121aab91cb4deb6bc3c0b626
 
 # Konflate
 # renovate: datasource=docker depName=konflate packageName=ghcr.io/home-operations/charts/konflate
-konflate_version=0.4.3
+konflate_version=0.5.0


### PR DESCRIPTION
## Summary

- Deploys Mealie v3.22.0 (`ghcr.io/mealie-recipes/mealie:v3.22.0`) to the live cluster using app-template
- Internal-only access via the `internal` gateway at `mealie.${internal_domain}`
- OIDC authentication via Authelia using the existing `recipes` authorization policy (restricts login to members of the `recipes` group)
- PostgreSQL on the shared CNPG platform cluster with auto-generated credentials managed by secret-generator and replicated by kubernetes-replicator
- Renovate annotation added to `versions.env` for automated image tag updates

## Changes

### New files
- `kubernetes/clusters/live/charts/mealie.yaml` — app-template values (image, env, service, route, persistence)
- `kubernetes/clusters/live/config/mealie/` — namespace (baseline security, internal network profile), PVC, DB credential replica, OIDC secret replica
- `kubernetes/clusters/live/config/authelia-prereqs/mealie-oidc-client-secret.yaml` — auto-generated OIDC client secret in `authelia` namespace, replicable to `mealie`

### Updated files
- `kubernetes/clusters/live/charts/authelia.yaml` — added `mealie` OIDC client + `mealie-oidc-client-secret` additionalSecret mount
- `kubernetes/clusters/live/charts/kustomization.yaml` — registered `mealie.yaml` in cluster-values ConfigMap
- `kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml` — registered `mealie-oidc-client-secret.yaml`
- `kubernetes/clusters/live/config/database/cluster-roles-patch.yaml` — added `mealie` managed role
- `kubernetes/clusters/live/config/database/databases.yaml` — added `mealie` Database CR
- `kubernetes/clusters/live/config/database/role-secrets.yaml` — added `mealie-role-password` secret
- `kubernetes/clusters/live/config/kustomization.yaml` — added `mealie` config directory
- `kubernetes/clusters/live/resourcesets/helm-charts.yaml` — added mealie HelmRelease input
- `kubernetes/clusters/live/versions.env` — added `mealie_version=v3.22.0` with Renovate annotation

## Design decisions

- **No Garage S3**: Tandoor uses Garage for media, but Mealie stores recipes in PostgreSQL and only uses `/app/data` for uploaded images/attachments. A 5Gi Longhorn PVC is provisioned instead — simpler and sufficient for recipe images.
- **`baseline` namespace security**: Mealie writes to `/app/data` at runtime; `readOnlyRootFilesystem: false` is required. The namespace uses `baseline` PodSecurity to allow this without the full `restricted` overhead.
- **`internal` network policy profile**: Internal gateway only, no external egress needed (no S3, no SMTP configured initially).
- **No `OIDC_AUTO_REDIRECT`**: Left as `false` so the login page remains reachable. Can be enabled once OIDC is validated.
- **OIDC `recipes` group**: Reuses the `recipes` authorization_policy already present in Authelia, which requires `two_factor` for the `recipes` group.

## Test plan

- [ ] Flux reconciles `cluster-resources` ResourceSet and creates the `mealie` HelmRelease
- [ ] Mealie pod reaches `Running/Ready` in the `mealie` namespace
- [ ] `mealie-db-credentials` secret is populated (replicated from `database/mealie-role-password`)
- [ ] `mealie-oidc-client-secret` secret is populated in both `authelia` and `mealie` namespaces
- [ ] `https://mealie.${internal_domain}` is reachable from the internal network
- [ ] OIDC login flow redirects to Authelia and back — members of `recipes` group can sign in
- [ ] Authelia pod restarts cleanly after config update (new OIDC client + secret mount)
- [ ] `mealie-data` PVC is bound

https://claude.ai/code/session_01Sz4dAo2cFabrdpvzmBpyCn