### PR TITLE
fix(live): unbreak jfa-go and redlib HelmReleases

### DIFF
--- a/kubernetes/clusters/live/charts/jfa-go.yaml
+++ b/kubernetes/clusters/live/charts/jfa-go.yaml
@@ -16,7 +16,8 @@ controllers:
         image:
           repository: hrfee/jfa-go
           # renovate: datasource=docker depName=hrfee/jfa-go
-          tag: v0.6.0
+          # upstream publishes no semver tags on Docker Hub — only latest/unstable
+          tag: latest
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false

--- a/kubernetes/clusters/live/charts/redlib.yaml
+++ b/kubernetes/clusters/live/charts/redlib.yaml
@@ -5,11 +5,7 @@ controllers:
   redlib:
     type: deployment
     replicas: 2
-    strategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 1
-        maxUnavailable: 0
+    strategy: RollingUpdate
 
     pod:
       securityContext:


### PR DESCRIPTION
## Context

Follow-up to #1568. That PR was branched off a stale local `main` (68 commits behind) so it only landed the authelia papra-secret cleanup — the jfa-go and redlib breakages on real `main` were never touched. This PR fixes those two, branched off current `main`.

## Fixes

### jfa-go — ImagePullBackOff
`#1555` pinned the floating `latest` tag to `v0.6.0`, but `hrfee/jfa-go` publishes **no semver tags** on Docker Hub — only `latest` and `unstable`. The pinned tag doesn't exist, so the pod sits in `ImagePullBackOff` (`docker.io/hrfee/jfa-go:v0.6.0: not found`).

Reverted to `tag: latest` with a comment noting upstream has no pinnable semver tag.

### redlib — schema validation failure
`#1552` set `controllers.redlib.strategy` to a native Kubernetes Deployment strategy object. The bjw-s `app-template` schema expects `strategy` to be a **string** enum (`RollingUpdate`/`Recreate`/`OnDelete`), so every upgrade fails with `at '/controllers/redlib/strategy': got object, want string`.

Reverted to `strategy: RollingUpdate`. Note: the chart does not expose `maxSurge`/`maxUnavailable`, so the zero-downtime tuning intended by #1552 is not achievable via this field — default rolling-update behavior applies (with `replicas: 2`).

## authelia
Already fixed and merged via #1568 — no change here. Live self-heals once it reconciles to the current artifact.

https://claude.ai/code/session_01SRtd63kkiwC45BFSzwDN8W