### PR TITLE
fix(authelia): add groups scope to mealie OIDC client

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -446,6 +446,7 @@ configMap:
             - openid
             - profile
             - email
+            - groups
           response_types:
             - code
           grant_types:


### PR DESCRIPTION
## Summary

- Mealie requests the `groups` scope via `OIDC_GROUPS_CLAIM: groups` env var
- Authelia's registered mealie client only allowed `openid`, `profile`, `email`
- This caused `invalid_scope` errors on login redirect

## Test plan

- [ ] Merge and wait for Authelia HelmRelease to reconcile
- [ ] Attempt OIDC login to `mealie.internal.tomnowak.work`
- [ ] Confirm redirect succeeds and user is authenticated

https://claude.ai/code/session_01ENE6QraW5NFXsnL7SH6YdV