### PR TITLE
fix(authelia): switch mealie token auth method to client_secret_basic

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -446,6 +446,7 @@ configMap:
             - openid
             - profile
             - email
+            - groups
           response_types:
             - code
           grant_types:

--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -451,7 +451,7 @@ configMap:
             - code
           grant_types:
             - authorization_code
-          token_endpoint_auth_method: client_secret_post
+          token_endpoint_auth_method: client_secret_basic
 
   regulation:
     max_retries: 3


### PR DESCRIPTION
## Summary

- Mealie's OIDC library uses `client_secret_basic` (Authorization header) for token exchange
- Authelia registered mealie with `client_secret_post` (POST body), causing all token requests to fail
- Logs showed: `The registered client with id 'mealie' is configured to only support 'token_endpoint_auth_method' method 'client_secret_post'`

## Test plan

- [ ] Merge and wait for Authelia HelmRelease to reconcile
- [ ] Attempt OIDC login to `mealie.internal.tomnowak.work`
- [ ] Confirm successful authentication

https://claude.ai/code/session_01ENE6QraW5NFXsnL7SH6YdV