### PR TITLE
fix(garage): raise cnpg-hass-backups quota from 20Gi to 40Gi

### DIFF
--- a/kubernetes/platform/config/garage/cnpg-hass-bucket.yaml
+++ b/kubernetes/platform/config/garage/cnpg-hass-bucket.yaml
@@ -7,4 +7,4 @@ spec:
   clusterRef:
     name: garage
   quotas:
-    maxSize: "20Gi"
+    maxSize: "40Gi"


### PR DESCRIPTION
## Summary

- The `cnpg-hass-backups` Garage S3 bucket on the live cluster hit its 20 GiB hard quota (21.45 GiB used / 99.9% full)
- CloudNativePG barman backups for `hass-database` have been failing for 17+ hours with `AccessDenied: Bucket size quota is reached`
- Barman only runs retention cleanup after a successful backup, creating a deadlock — the bucket cannot self-heal
- Raising the quota to 40 GiB allows the next backup to land, after which barman's retention policy will run and reclaim space

## Changed file

`kubernetes/platform/config/garage/cnpg-hass-bucket.yaml` — `quotas.maxSize` changed from `20Gi` to `40Gi`

## Test plan

- [ ] PR merges and Flux reconciles the `garage-config` Kustomization on live
- [ ] Garage operator applies the updated quota to the `cnpg-hass-backups` bucket
- [ ] Next barman scheduled backup completes successfully (check CNPG cluster events / barman logs)
- [ ] Barman retention cleanup runs and reduces used space below the new ceiling
- [ ] `AccessDenied` errors stop appearing in hass-database pod logs

https://claude.ai/code/session_0114gbN2avygXmch8Y5MkFfg