### PR TITLE
feat(mcp): add Home Assistant MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,6 +6,13 @@
       "env": {
         "GRAFANA_URL": "http://localhost:3000"
       }
+    },
+    "homeassistant": {
+      "type": "sse",
+      "url": "https://hass.internal.tomnowak.work/mcp_server/sse",
+      "headers": {
+        "Authorization": "Bearer ${HASS_TOKEN}"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds the Home Assistant MCP server (`mcp_server` integration) to `.mcp.json` so Claude Code Desktop can control HA
- Uses SSE transport at `https://hass.internal.tomnowak.work/mcp_server/sse`
- Auth via `${HASS_TOKEN}` env var (Long-Lived Access Token — never committed)

## Prerequisites (manual steps before using)

1. **Enable HA integration**: Settings → Devices & Services → Add Integration → "Model Context Protocol Server"
2. **Generate token**: HA Profile → Long-Lived Access Tokens → Create token
3. **Export env var**: `export HASS_TOKEN=<your-token>` in your shell before launching Claude Code Desktop

## Test plan

- [ ] HA MCP Server integration enabled in live HASS
- [ ] `HASS_TOKEN` env var set
- [ ] Restart Claude Code Desktop — `homeassistant` should appear in MCP server list
- [ ] Verify Claude can list/control HA entities

https://claude.ai/code/session_01Szgyt7qESwWpabcMz1so6o