### PR TITLE
fix(mcp): use headersHelper for HASS token auth

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -10,9 +10,7 @@
     "homeassistant": {
       "type": "sse",
       "url": "https://hass.internal.tomnowak.work/mcp_server/sse",
-      "headers": {
-        "Authorization": "Bearer ${HASS_TOKEN}"
-      }
+      "headersHelper": "printf '{\"Authorization\":\"Bearer %s\"}' \"${HASS_TOKEN}\""
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,6 +6,13 @@
       "env": {
         "GRAFANA_URL": "http://localhost:3000"
       }
+    },
+    "homeassistant": {
+      "type": "sse",
+      "url": "https://hass.internal.tomnowak.work/mcp_server/sse",
+      "headers": {
+        "Authorization": "Bearer ${HASS_TOKEN}"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- `headers` values in `.mcp.json` are not shell-expanded — `${HASS_TOKEN}` was passing as a literal string
- Switches to `headersHelper` which runs a shell command at connect time and has access to env vars
- Token still sourced from `HASS_TOKEN` in `~/.claude/settings.json` (never committed)

## Root cause

Claude Code only expands `${VAR}` in `command`/`args` for stdio servers. For HTTP/SSE headers, values are passed verbatim. `headersHelper` is the correct mechanism for env-var-driven auth.

https://claude.ai/code/session_01Szgyt7qESwWpabcMz1so6o