### PR TITLE
fix(cnpg): add failoverDelay to CNPG clusters to reduce sensitivity to transient probe failures

### DIFF
--- a/kubernetes/clusters/live/config/home-assistant/hass-database-cluster.yaml
+++ b/kubernetes/clusters/live/config/home-assistant/hass-database-cluster.yaml
@@ -17,6 +17,12 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:${postgresql_image_version}
   instances: ${default_replica_count}
   primaryUpdateStrategy: unsupervised
+  # Wait 30s after the primary is detected unhealthy before triggering
+  # failover. Rides out transient cluster-wide disruptions (e.g. kubelet
+  # probe storms during control-plane instability) that are not genuine
+  # primary failures, avoiding unnecessary promotions and replica
+  # divergence. See incident 2026-08-18.
+  failoverDelay: 30
 
   postgresql:
     parameters:

--- a/kubernetes/clusters/live/config/home-assistant/hass-database-cluster.yaml
+++ b/kubernetes/clusters/live/config/home-assistant/hass-database-cluster.yaml
@@ -17,11 +17,7 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:${postgresql_image_version}
   instances: ${default_replica_count}
   primaryUpdateStrategy: unsupervised
-  # Wait 30s after the primary is detected unhealthy before triggering
-  # failover. Rides out transient cluster-wide disruptions (e.g. kubelet
-  # probe storms during control-plane instability) that are not genuine
-  # primary failures, avoiding unnecessary promotions and replica
-  # divergence. See incident 2026-08-18.
+  # Grace period before promoting, so transient probe failures do not fail over.
   failoverDelay: 30
 
   postgresql:

--- a/kubernetes/clusters/live/config/immich/immich-cluster.yaml
+++ b/kubernetes/clusters/live/config/immich/immich-cluster.yaml
@@ -17,6 +17,12 @@ spec:
   imageName: ghcr.io/tensorchord/cloudnative-vectorchord:${vectorchord_version:-17.7-1.0.0}
   instances: ${default_replica_count}
   primaryUpdateStrategy: unsupervised
+  # Wait 30s after the primary is detected unhealthy before triggering
+  # failover. Rides out transient cluster-wide disruptions (e.g. kubelet
+  # probe storms during control-plane instability) that are not genuine
+  # primary failures, avoiding unnecessary promotions and replica
+  # divergence. See incident 2026-08-18.
+  failoverDelay: 30
 
   postgresql:
     shared_preload_libraries:

--- a/kubernetes/clusters/live/config/immich/immich-cluster.yaml
+++ b/kubernetes/clusters/live/config/immich/immich-cluster.yaml
@@ -17,11 +17,7 @@ spec:
   imageName: ghcr.io/tensorchord/cloudnative-vectorchord:${vectorchord_version:-17.7-1.0.0}
   instances: ${default_replica_count}
   primaryUpdateStrategy: unsupervised
-  # Wait 30s after the primary is detected unhealthy before triggering
-  # failover. Rides out transient cluster-wide disruptions (e.g. kubelet
-  # probe storms during control-plane instability) that are not genuine
-  # primary failures, avoiding unnecessary promotions and replica
-  # divergence. See incident 2026-08-18.
+  # Grace period before promoting, so transient probe failures do not fail over.
   failoverDelay: 30
 
   postgresql:

--- a/kubernetes/platform/config/database/cluster.yaml
+++ b/kubernetes/platform/config/database/cluster.yaml
@@ -11,11 +11,7 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:${postgresql_image_version}
   instances: ${default_replica_count}
   primaryUpdateStrategy: unsupervised
-  # Wait 30s after the primary is detected unhealthy before triggering
-  # failover. Rides out transient cluster-wide disruptions (e.g. kubelet
-  # probe storms during control-plane instability) that are not genuine
-  # primary failures, avoiding unnecessary promotions and replica
-  # divergence. See incident 2026-08-18.
+  # Grace period before promoting, so transient probe failures do not fail over.
   failoverDelay: 30
 
   enableSuperuserAccess: true

--- a/kubernetes/platform/config/database/cluster.yaml
+++ b/kubernetes/platform/config/database/cluster.yaml
@@ -11,6 +11,12 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:${postgresql_image_version}
   instances: ${default_replica_count}
   primaryUpdateStrategy: unsupervised
+  # Wait 30s after the primary is detected unhealthy before triggering
+  # failover. Rides out transient cluster-wide disruptions (e.g. kubelet
+  # probe storms during control-plane instability) that are not genuine
+  # primary failures, avoiding unnecessary promotions and replica
+  # divergence. See incident 2026-08-18.
+  failoverDelay: 30
 
   enableSuperuserAccess: true
   superuserSecret:


### PR DESCRIPTION
## Incident summary

On 2026-08-18 at 07:50:32–07:52:00 UTC, `live` experienced a ~28s cluster-wide,
control-plane-adjacent disruption: 251 `Unhealthy`/`Killing` events across 5
nodes, an etcd leader election, and a kube-apiserver p99 latency spike to
38.4s. During that window the `postgres` container on `platform-1` (then
primary of the shared `database/platform` CNPG cluster) failed its liveness
probe 3 consecutive times (`/healthz:8000`, `periodSeconds: 10`,
`failureThreshold: 3`) and was killed by kubelet.

CNPG had no configured `failoverDelay` (repo-wide default of the operator's
own default, `0`), so it promoted `platform-3` immediately, with zero grace
period. The result: a permanently diverged replica (`platform-2`) that has
required a manual re-clone ever since. CPU, memory, iowait, Longhorn volume
latency, and backup activity were all directly checked and ruled out — this
was a transient probe-storm, not a real primary failure. A 30s grace period
would have ridden out the entire storm without any failover at all.

## What this PR does

Sets `spec.failoverDelay: 30` on all three CNPG `Cluster` manifests in the
repo (shared `platform` cluster plus the two dedicated clusters that
observed the same replica-kill symptoms in the same incident: `immich-database`,
`hass-database`). Value chosen to comfortably exceed the ~28s observed storm
while still failing over quickly for a genuinely dead primary.

## Field semantics (verified against source, not memory)

Verified in `api/v1/cluster_types.go` on the `release-1.30` branch of
`cloudnative-pg/cloudnative-pg` — this repo's `cloudnative_pg_version` Helm
chart is `0.29.0`, whose `appVersion` is `1.30.0`:

- `failoverDelay` (`json:"failoverDelay,omitempty"`, `int32`,
  `+kubebuilder:default:=0`): *"The amount of time (in seconds) to wait
  before triggering a failover after the primary PostgreSQL instance in the
  cluster was detected to be unhealthy."* It is a top-level `Cluster.spec`
  field (same level as `primaryUpdateStrategy`), gates the delay **between
  unhealthy-detection and promotion**, and its unconfigured default is `0`
  — i.e. immediate failover, exactly the behavior that made this incident
  worse.

- `switchoverDelay` (`json:"switchoverDelay,omitempty"`, `int32`,
  `+kubebuilder:default:=3600`): governs how long a **planned switchover**
  (deliberate primary change, e.g. via `primaryUpdateStrategy: unsupervised`
  rolling updates) waits for the old primary to shut down gracefully. It is
  not related to unplanned failover, already defaults to a generous 3600s,
  and this incident was a failover (unplanned), not a switchover. Left
  unset — no reason from this incident to touch it.

## Scope

Searched the full repo for CNPG `Cluster` manifests. Three exist, all follow
an identical pattern (`postgresql.cnpg.io/v1` Cluster, top-level
`primaryUpdateStrategy: unsupervised`, no prior `failoverDelay`), and all
three are covered in this PR:

- `kubernetes/platform/config/database/cluster.yaml` — shared `platform` cluster (primary target, incident cluster)
- `kubernetes/clusters/live/config/immich/immich-cluster.yaml` — `immich-database`, dedicated cluster, replicas also killed in this incident
- `kubernetes/clusters/live/config/home-assistant/hass-database-cluster.yaml` — `hass-database`, dedicated cluster, replicas also killed in this incident

No other CNPG `Cluster` manifests exist in the repo (verified via `grep -rln
"kind: Cluster"` filtered to `postgresql.cnpg.io`). Files matching `kind:
Cluster` under `clusters/*/config/database/*-patch.yaml` are unrelated
JSON6902 patches (adding managed roles), not standalone Cluster definitions,
and were left untouched.

## What this does NOT fix

This change reduces how *often* CNPG triggers a failover — it does not
change what happens once a failover does occur. The replica-divergence
failure class itself (an old primary continuing to accept/produce WAL that
a promoted replica never received, leaving it unrecoverable without a
re-clone) is a property of CNPG's default async replication model, not of
failover timing. Preventing divergence structurally requires
synchronous/quorum replication, which is being discussed separately and is
deliberately out of scope here.

## Validation

- `task k8s:validate` — 0 Invalid, 0 Errors across all 152 platform-config
  resources and all 616 templated Helm resources (the one warning present,
  `bjw-s.github.io/helm-charts/index.yaml : 404`, is a pre-existing,
  unrelated stale HTTP Helm repo issue on an unrelated chart, unaffected by
  this change).
- No `renovate.json5`/`versions.env` changes were made, so `task
  renovate:validate` was not required.

## Test plan

- [x] `task k8s:validate` passes with 0 errors on all three modified manifests
- [ ] After merge, confirm via `kubectl --context live get cluster platform -n database -o jsonpath='{.spec.failoverDelay}'` (and same for `immich-database`, `hass-database`) that Flux/CNPG applied `30`
- [ ] No cluster mutation was performed as part of this PR — `live` and `integration` are read-only per repo policy; convergence happens automatically via the existing build → OCI artifact → live pipeline after merge

https://claude.ai/code/session_01Lm9YL15a4mvDwxqB7NDQmB