### PR TITLE
feat(longhorn): add slow-media storage class

### DIFF
--- a/kubernetes/platform/config/longhorn/kustomization.yaml
+++ b/kubernetes/platform/config/longhorn/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - routes/
   - storage-classes/fast-ephemeral.yaml
   - storage-classes/fast.yaml
+  - storage-classes/slow-media.yaml
   - storage-classes/slow.yaml

--- a/kubernetes/platform/config/longhorn/storage-classes/slow-media.yaml
+++ b/kubernetes/platform/config/longhorn/storage-classes/slow-media.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/storage.k8s.io/storageclass_v1.json
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: slow-media
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: ${storage_replica_count}
+  fsType: xfs
+  staleReplicaTimeout: "30"
+  # Multi-Ti volumes on this class are large enough that satisfying locality
+  # costs a full rebuild. With best-effort, Longhorn builds an extra local
+  # replica whenever the volume attaches to a node without one, which for
+  # media-library is ~9.8Ti copied over the network for no durability gain.
+  dataLocality: disabled
+  diskSelector: slow
+  # No recurringJobSelector. filesystem-trim reclaims nothing on volumes whose
+  # blocks are pinned by a base snapshot, and snapshot rotation on a multi-Ti
+  # volume merges the base on every pass.


### PR DESCRIPTION
## Change

New `slow-media` StorageClass for bulk media volumes.

| Parameter | `slow` | `slow-media` |
|---|---|---|
| `dataLocality` | `best-effort` | `disabled` |
| `recurringJobSelector` | snapshot-frequent + filesystem-trim-daily | *(none)* |
| `reclaimPolicy` | `Delete` | `Retain` |
| `numberOfReplicas` | `${storage_replica_count}` | `${storage_replica_count}` |
| `diskSelector` | `slow` | `slow` |
| `fsType` | `xfs` | `xfs` |

A new class rather than edits to `slow`, because StorageClass `parameters` are immutable — they cannot be changed in place, and `longhorn-storage` runs `force: false`, so an edit would fail reconciliation rather than delete-and-recreate.

## Why `dataLocality: disabled`

With `best-effort`, Longhorn builds an *additional* local replica whenever a volume attaches to a node that has none — beyond `numberOfReplicas`. For `media-library` that is ~9.8Ti copied over the network, recurring every time the share-manager moves nodes. One is running against node41 right now as a result.

On a 10Ti mostly-static library the read-locality benefit does not justify a multi-hour rebuild per attachment.

## Why no `recurringJobSelector`

- `filesystem-trim` reclaims nothing on a volume whose blocks are pinned by a base snapshot. On `media-library` the 9.75Ti base pins nearly everything and `remove-snapshots-during-filesystem-trim` is `false`, so trim could only free the ~70Gi head.
- Snapshot rotation on a multi-Ti volume merges the base on every pass — the treadmill #1533 removed `snapshot-frequent` to stop.

Note this is not a claim that trim caused the recent corruption; that remains unproven (see #1610). This class simply has no use for either job.

## Why `reclaimPolicy: Retain`

A PVC deletion should not be able to destroy a multi-Ti volume. `slow` uses `Delete`; the live `media-library` PV was manually patched to `Retain` during the recent incident for exactly this reason.

## Scope

Adds the class only. No existing volume changes.

Migrating `media-library` onto it is a **static rebind** — delete PVC+PV and recreate them against the same `volumeHandle`, zero data movement — and is sequenced separately in a runbook. Worth noting for reviewers: `dataLocality` and `recurringJobSelector` are consumed at *provisioning* time and are baked into the PV's `volumeAttributes`, so a rebind does not retroactively apply them. The existing volume's Longhorn `Volume` CR needs `spec.dataLocality` patched directly; the class governs future volumes.

https://claude.ai/code/session_01Q4vyrZRJrfUBbbs4kkZbMi