### PR TITLE
feat(media): rebind media-library to slow-media

### DIFF
--- a/kubernetes/clusters/live/config/media-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - media-library-pv.yaml
   - media-library-pvc.yaml
   - sabnzbd-downloads-pvc.yaml
   - qbittorrent-downloads-pvc.yaml

--- a/kubernetes/clusters/live/config/media-prereqs/media-library-pv.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/media-library-pv.yaml
@@ -1,0 +1,32 @@
+---
+# Static PV bound to the pre-existing Longhorn volume. The volume predates the
+# slow-media class and is rebound rather than reprovisioned, so no data moves.
+# volumeHandle is the Longhorn volume name and must not change.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: media-library
+spec:
+  capacity:
+    storage: 10Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: slow-media
+  volumeMode: Filesystem
+  claimRef:
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: media-library
+    namespace: media
+  csi:
+    driver: driver.longhorn.io
+    fsType: xfs
+    volumeHandle: pvc-cd6ba345-906b-4a8a-be87-bbc8328b3219
+    volumeAttributes:
+      fsType: xfs
+      numberOfReplicas: "3"
+      staleReplicaTimeout: "30"
+      dataLocality: disabled
+      diskSelector: slow
+      share: "true"

--- a/kubernetes/clusters/live/config/media-prereqs/media-library-pvc.yaml
+++ b/kubernetes/clusters/live/config/media-prereqs/media-library-pvc.yaml
@@ -9,7 +9,9 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: slow
+  storageClassName: slow-media
+  # Binds to the static PV above rather than provisioning a new volume.
+  volumeName: media-library
   resources:
     requests:
       storage: 10Ti


### PR DESCRIPTION
**Draft — merge only at step 7 of the migration runbook, after the existing PVC and PV are deleted.**

## Change

Moves the `media-library` PVC onto the `slow-media` class from #1611, via a static PV.

- `media-library-pv.yaml` (new) — static PV pointing at the existing Longhorn volume
- `media-library-pvc.yaml` — `storageClassName: slow` → `slow-media`, pinned with `volumeName`
- `kustomization.yaml` — adds the PV

## No data is copied

`volumeHandle: pvc-cd6ba345-906b-4a8a-be87-bbc8328b3219` is the existing Longhorn volume. This is a metadata rebind — the volume, its replicas and its snapshot chain are untouched.

Reprovisioning and copying was not an option regardless: 9.8Ti × 3 replicas onto disks that already hold the original does not fit.

## Why it can't be an in-place edit

`storageClassName` is immutable on both PVC and PV. The old pair has to be deleted and recreated, which is why this is sequenced rather than merged normally — if it merges while the old PVC still exists, Flux fails on the immutable field.

The live PV was patched to `persistentVolumeReclaimPolicy: Retain` during the recent incident. That is the only reason deleting it doesn't destroy 9.8Ti.

## What this does *not* do

`dataLocality` and `recurringJobSelector` are consumed at **provisioning** time and baked into the PV's `volumeAttributes`. A rebind does not re-provision, so the class does not retroactively apply. `spec.dataLocality: disabled` was set directly on the Longhorn `Volume` CR (runbook step 3) — that patch, not this PR, is what stopped the recurring 9.8Ti local rebuilds.

The attributes here describe the volume accurately and govern consistency with the class; they are not the mechanism.

## Notes

- `share: "true"` is required for RWX
- `claimRef` is pre-set so the PV binds only to this PVC and cannot be claimed by anything else
- `reclaimPolicy: Retain` carried over from the class

Prereq: #1611 (merged, `slow-media` present on live).

https://claude.ai/code/session_01Q4vyrZRJrfUBbbs4kkZbMi