### PR TITLE
fix(velero): stagger backup schedules and raise CSI snapshot timeout

### DIFF
--- a/kubernetes/clusters/live/config/velero/schedule-default.yaml
+++ b/kubernetes/clusters/live/config/velero/schedule-default.yaml
@@ -12,6 +12,7 @@ spec:
     volumeSnapshotLocations:
       - csi
     snapshotMoveData: true
+    csiSnapshotTimeout: 15m0s
     ttl: 672h0m0s
     includedResources:
       - persistentvolumeclaims

--- a/kubernetes/platform/config/velero/schedule-platform.yaml
+++ b/kubernetes/platform/config/velero/schedule-platform.yaml
@@ -5,13 +5,14 @@ metadata:
   name: platform
   namespace: velero
 spec:
-  schedule: "0 2 * * 0"
+  schedule: "0 5 * * 0"
   useOwnerReferencesInBackup: false
   template:
     storageLocation: aws
     volumeSnapshotLocations:
       - csi
     snapshotMoveData: true
+    csiSnapshotTimeout: 15m0s
     ttl: 672h0m0s
     includedNamespaces:
       - garage


### PR DESCRIPTION
## Problem

`VeleroBackupStale` has been firing on `live` for `schedule="platform"` since 2026-08-18:

```
No successful backup for schedule platform in the last 7 days 4 hours (11d 23h 56m 30s).
```

The BackupStorageLocation was healthy the whole time and `VeleroBackupFailure` never fired, so this is not a credentials or connectivity problem.

## Root cause

`platform` (`kubernetes/platform/config/velero/schedule-platform.yaml`) and `default` (`kubernetes/clusters/live/config/velero/schedule-default.yaml`) were both set to `0 2 * * 0` — the same weekly slot. Because they live in different layers of the tree, the collision wasn't visible from either file.

Firing together produced ~15 simultaneous CSI/Longhorn data-mover operations. node-agent logs for the 02:01–02:11 window show sustained clone/attach contention across both schedules' PVCs:

```
AttachVolume.Attach failed ... "volume request cloning data but has not finished copying data"
AttachVolume.Attach failed ... "waiting for the volume to fully detach. current state: detaching"
```

Two garage DataUploads exceeded the 10m operation timeout and failed with `timeout on preparing data upload`:

```
platform-20260816020004-d8jlh   Failed   data-garage-2
platform-20260816020004-xmlfm   Failed   data-garage-0
```

That made `platform-20260816020004` `PartiallyFailed`. Velero only advances `velero_backup_last_successful_timestamp` on a `Completed` backup, so the staleness counter kept climbing past the alert's 7d4h threshold even though the backup had run.

The three preceding weekly runs (07/26, 08/02, 08/09) completed cleanly, and both Longhorn volumes are currently healthy with `restoreRequired=false` — this was transient contention, not a chronic storage fault.

## Changes

**Stagger the schedules.** `platform` moves to `0 5 * * 0`. The 03:00 slot is already occupied by the CNPG and immich daily backups and 04:00 by the Home Assistant database backup, so 05:00 is the nearest clean window. `default` stays at 02:00.

**Raise the timeout 50%.** `csiSnapshotTimeout: 15m0s` on both schedules, up from the 10m default. In Velero 1.18 this field populates `DataUpload.spec.operationTimeout`, which is what the data-mover prepare check measures against — verified directly on the failed DataUpload, which carried `operationTimeout: 10m0s`. This gives headroom for occasional Longhorn clone latency independently of the staggering.

## Verification

- `task k8s:validate-live` passes — 152/152 ResourceSet resources and 183 manifest resources valid, 0 invalid, no removed APIs against v1.36.4.
- `csiSnapshotTimeout` confirmed present in the live `schedules.velero.io` CRD schema (`type: string`, documented default 10 minutes).
- Investigation was read-only; no changes were made to any cluster.

## Convergence

Flux reconciles both Schedule resources. The next `platform` run lands Sunday at 05:00 and, on completion, advances `velero_backup_last_successful_timestamp` and clears the alert with no manual intervention.

## Follow-up not included here

node-agent runs with only `--features=EnableCSI` and no concurrency limits, so nothing caps simultaneous DataUploads per node. Tuning `nodeAgent` load concurrency would harden this platform-wide rather than just de-conflicting these two schedules — worth a separate change if contention recurs.

https://claude.ai/code/session_01R6QgPpUKb41QwkYZN2siFd
