### PR TITLE
feat(k8s): deploy miniflux RSS reader

### DIFF
--- a/kubernetes/clusters/live/apps/apps-resourceset.yaml
+++ b/kubernetes/clusters/live/apps/apps-resourceset.yaml
@@ -17,6 +17,9 @@ spec:
     - name: paperless
       path: kubernetes/clusters/live/apps/paperless
       dependsOn: [cloudnative-pg, secret-generator]
+    - name: miniflux
+      path: kubernetes/clusters/live/apps/miniflux
+      dependsOn: [cloudnative-pg, secret-generator]
   resourcesTemplate: |
     ---
     apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/kubernetes/clusters/live/apps/miniflux/canary.yaml
+++ b/kubernetes/clusters/live/apps/miniflux/canary.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/canaries.flanksource.com/canary_v1.json
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: http-check-miniflux
+  namespace: miniflux
+spec:
+  schedule: "@every 1m"
+  http:
+    - name: miniflux-gateway-health
+      url: https://feeds.${internal_domain}/healthz
+      responseCodes: [200]
+      maxSSLExpiry: 7
+      thresholdMillis: 5000

--- a/kubernetes/clusters/live/apps/miniflux/grafana-dashboard.yaml
+++ b/kubernetes/clusters/live/apps/miniflux/grafana-dashboard.yaml
@@ -1,0 +1,444 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-miniflux
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "true"
+  annotations:
+    grafana_folder: "Applications"
+data:
+  miniflux.json: |-
+    {
+      "annotations": { "list": [] },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+          "id": 10,
+          "title": "Overview",
+          "type": "row"
+        },
+        {
+          "type": "stat",
+          "title": "Status",
+          "description": "Whether Prometheus can currently scrape Miniflux. Red for 5 minutes fires MinifluxDown.",
+          "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+          "id": 11,
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            { "expr": "up{job=\"miniflux\", namespace=\"miniflux\"}", "legendFormat": "", "refId": "A" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "mappings": [
+                { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "green", "value": 1 }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto"
+          }
+        },
+        {
+          "type": "stat",
+          "title": "Users",
+          "description": "Number of Miniflux user accounts, including the local admin and any OIDC-created users.",
+          "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+          "id": 12,
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            { "expr": "miniflux_users{namespace=\"miniflux\"}", "legendFormat": "", "refId": "A" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto"
+          }
+        },
+        {
+          "type": "stat",
+          "title": "Total Feeds",
+          "description": "Total number of subscribed feeds across all statuses (active, disabled, error).",
+          "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+          "id": 13,
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            { "expr": "sum(miniflux_feeds{namespace=\"miniflux\"})", "legendFormat": "", "refId": "A" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto"
+          }
+        },
+        {
+          "type": "stat",
+          "title": "Broken Feeds",
+          "description": "Feeds that have exceeded the parsing error limit and stopped refreshing. Above 5 for 30 minutes fires MinifluxBrokenFeedsHigh.",
+          "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+          "id": 14,
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            { "expr": "miniflux_broken_feeds{namespace=\"miniflux\"}", "legendFormat": "", "refId": "A" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 },
+                  { "color": "red", "value": 5 }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "textMode": "auto"
+          }
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+          "id": 20,
+          "title": "Feeds & Entries",
+          "type": "row"
+        },
+        {
+          "type": "timeseries",
+          "title": "Feeds by Status",
+          "description": "Number of feeds grouped by status (unread/active vs disabled). A growing 'error' population without a matching drop elsewhere indicates feeds silently failing.",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+          "id": 21,
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            { "expr": "sum(miniflux_feeds{namespace=\"miniflux\"}) by (status)", "legendFormat": "{{ status }}", "refId": "A" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "scheme",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "type": "timeseries",
+          "title": "Entries by Status",
+          "description": "Number of stored entries grouped by read status (unread, read, removed). Tracks reading backlog growth.",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+          "id": 22,
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            { "expr": "sum(miniflux_entries{namespace=\"miniflux\"}) by (status)", "legendFormat": "{{ status }}", "refId": "A" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "scheme",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+          "id": 30,
+          "title": "Background Workers",
+          "type": "row"
+        },
+        {
+          "type": "timeseries",
+          "title": "Feed Refresh Duration (p99)",
+          "description": "P99 processing time for background feed refreshes, split by outcome. Sustained increases indicate slow or unresponsive upstream feed servers.",
+          "gridPos": { "h": 8, "w": 8, "x": 0, "y": 15 },
+          "id": 31,
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(miniflux_background_feed_refresh_duration_bucket{namespace=\"miniflux\"}[5m])) by (le, status))",
+              "legendFormat": "{{ status }}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "scheme",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "type": "timeseries",
+          "title": "Feed Refresh Error Rate",
+          "description": "Share of background feed refreshes that failed over a 15m window. Above 10% for 15 minutes fires MinifluxHighFeedRefreshErrorRate.",
+          "gridPos": { "h": 8, "w": 8, "x": 8, "y": 15 },
+          "id": 32,
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "sum(rate(miniflux_background_feed_refresh_duration_count{status=\"error\", namespace=\"miniflux\"}[15m])) / sum(rate(miniflux_background_feed_refresh_duration_count{namespace=\"miniflux\"}[15m]))",
+              "legendFormat": "error rate",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "scheme",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "dashed" }
+              },
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "red", "value": 0.1 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "type": "timeseries",
+          "title": "Scraper Request Duration (p99)",
+          "description": "P99 duration of the web scraper used to fetch full article content for feeds configured to scrape original pages.",
+          "gridPos": { "h": 8, "w": 8, "x": 16, "y": 15 },
+          "id": 33,
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(miniflux_scraper_request_duration_bucket{namespace=\"miniflux\"}[5m])) by (le, status))",
+              "legendFormat": "{{ status }}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "scheme",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "collapsed": false,
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+          "id": 40,
+          "title": "Database",
+          "type": "row"
+        },
+        {
+          "type": "timeseries",
+          "title": "DB Connection Pool",
+          "description": "Miniflux's own Postgres connection pool usage against the shared platform CNPG pooler (open/in-use/idle).",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+          "id": 41,
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            { "expr": "miniflux_db_open_connections{namespace=\"miniflux\"}", "legendFormat": "open", "refId": "A" },
+            { "expr": "miniflux_db_connections_in_use{namespace=\"miniflux\"}", "legendFormat": "in_use", "refId": "B" },
+            { "expr": "miniflux_db_connections_idle{namespace=\"miniflux\"}", "legendFormat": "idle", "refId": "C" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "scheme",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        },
+        {
+          "type": "timeseries",
+          "title": "DB Connections Waited",
+          "description": "Rate of connection acquisitions that had to wait for a free connection from the pool. Sustained non-zero values indicate the pool is undersized for the workload.",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+          "id": 42,
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "targets": [
+            { "expr": "rate(miniflux_db_connections_wait_count{namespace=\"miniflux\"}[5m])", "legendFormat": "wait rate", "refId": "A" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "scheme",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "never",
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          }
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": ["miniflux", "rss"],
+      "templating": { "list": [] },
+      "time": { "from": "now-6h", "to": "now" },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Miniflux",
+      "uid": "miniflux",
+      "version": 1
+    }

--- a/kubernetes/clusters/live/apps/miniflux/helmrelease.yaml
+++ b/kubernetes/clusters/live/apps/miniflux/helmrelease.yaml
@@ -1,0 +1,176 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: miniflux
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cloudnative-pg
+    - name: secret-generator
+  chart:
+    spec:
+      chart: app-template
+      version: "${app_template_version}"
+      interval: 10m
+      sourceRef:
+        kind: HelmRepository
+        name: miniflux
+  install:
+    createNamespace: false
+    strategy:
+      name: RetryOnFailure
+    timeout: 10m
+  interval: 10m
+  maxHistory: 3
+  releaseName: miniflux
+  targetNamespace: miniflux
+  uninstall:
+    keepHistory: false
+  upgrade:
+    crds: CreateReplace
+    strategy:
+      name: RetryOnFailure
+    timeout: 10m
+  valuesFrom: []
+  values:
+    # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+    # https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+    controllers:
+      miniflux:
+        type: deployment
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile:
+              type: RuntimeDefault
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/miniflux/miniflux
+              tag: "${miniflux_version}"
+            env:
+              LISTEN_ADDR: "0.0.0.0:8080"
+              BASE_URL: "https://feeds.${internal_domain}"
+              RUN_MIGRATIONS: "1"
+              LOG_LEVEL: "info"
+              # Database — dedicated app user via secret-generator, shared platform CNPG cluster
+              MINIFLUX_DB_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: miniflux-db-credentials
+                    key: password
+              DATABASE_URL:
+                dependsOn: MINIFLUX_DB_PASSWORD
+                value: "user=miniflux password=$(MINIFLUX_DB_PASSWORD) dbname=miniflux host=platform-pooler-rw.database.svc.cluster.local port=5432 sslmode=disable"
+              # Bootstrap local admin — break-glass access if Authelia is unavailable.
+              CREATE_ADMIN: "1"
+              ADMIN_USERNAME:
+                valueFrom:
+                  secretKeyRef:
+                    name: miniflux-admin-credentials
+                    key: username
+              ADMIN_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: miniflux-admin-credentials
+                    key: password
+              # OIDC/SSO via Authelia
+              OAUTH2_PROVIDER: "oidc"
+              OAUTH2_CLIENT_ID: "miniflux"
+              OAUTH2_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: miniflux-oidc-client-secret
+                    key: client-secret
+              OAUTH2_OIDC_DISCOVERY_ENDPOINT: "https://auth.${external_domain}/.well-known/openid-configuration"
+              OAUTH2_OIDC_PROVIDER_NAME: "Authelia"
+              OAUTH2_REDIRECT_URL: "https://feeds.${internal_domain}/oauth2/oidc/callback"
+              OAUTH2_USER_CREATION: "1"
+              # Prometheus metrics — scraped by the ServiceMonitor below
+              METRICS_COLLECTOR: "1"
+              METRICS_ALLOWED_NETWORKS: "${cluster_pod_subnet}"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  failureThreshold: 30
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8080
+                  periodSeconds: 30
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: 8080
+                  periodSeconds: 10
+
+    service:
+      app:
+        controller: miniflux
+        ports:
+          http:
+            port: 8080
+
+    serviceMonitor:
+      app:
+        enabled: true
+        serviceName: miniflux
+        endpoints:
+          - port: http
+            scheme: http
+            path: /metrics
+            interval: 1m
+            scrapeTimeout: 10s
+
+    route:
+      internal:
+        enabled: true
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: "Miniflux"
+          gethomepage.dev/group: "Apps"
+          gethomepage.dev/icon: "miniflux.svg"
+          gethomepage.dev/pod-selector: "app.kubernetes.io/name=miniflux"
+        parentRefs:
+          - name: internal
+            namespace: istio-gateway
+        hostnames:
+          - "feeds.${internal_domain}"
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 8080

--- a/kubernetes/clusters/live/apps/miniflux/helmrepository.yaml
+++ b/kubernetes/clusters/live/apps/miniflux/helmrepository.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: miniflux
+  namespace: flux-system
+spec:
+  interval: 10m
+  type: oci
+  url: oci://ghcr.io/bjw-s-labs/helm

--- a/kubernetes/clusters/live/apps/miniflux/kustomization.yaml
+++ b/kubernetes/clusters/live/apps/miniflux/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - miniflux-db-credentials.yaml
+  - miniflux-oidc-client-secret-replica.yaml
+  - miniflux-admin-credentials.yaml
+  - canary.yaml
+  - prometheus-rules.yaml
+  - grafana-dashboard.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/kubernetes/clusters/live/apps/miniflux/miniflux-admin-credentials.yaml
+++ b/kubernetes/clusters/live/apps/miniflux/miniflux-admin-credentials.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: miniflux-admin-credentials
+  namespace: miniflux
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+type: Opaque
+stringData:
+  username: admin

--- a/kubernetes/clusters/live/apps/miniflux/miniflux-db-credentials.yaml
+++ b/kubernetes/clusters/live/apps/miniflux/miniflux-db-credentials.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: miniflux-db-credentials
+  namespace: miniflux
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: database/miniflux-role-password
+data: { }

--- a/kubernetes/clusters/live/apps/miniflux/miniflux-oidc-client-secret-replica.yaml
+++ b/kubernetes/clusters/live/apps/miniflux/miniflux-oidc-client-secret-replica.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: miniflux-oidc-client-secret
+  namespace: miniflux
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: authelia/miniflux-oidc-client-secret
+data: { }

--- a/kubernetes/clusters/live/apps/miniflux/namespace.yaml
+++ b/kubernetes/clusters/live/apps/miniflux/namespace.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: miniflux
+  labels:
+    istio.io/dataplane-mode: ambient
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+    network-policy.homelab/profile: internal-egress
+    access.network-policy.homelab/postgres: "true"

--- a/kubernetes/clusters/live/apps/miniflux/prometheus-rules.yaml
+++ b/kubernetes/clusters/live/apps/miniflux/prometheus-rules.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: miniflux-alerts
+  namespace: miniflux
+  labels:
+    app.kubernetes.io/name: miniflux
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: miniflux.rules
+      rules:
+        - alert: MinifluxDown
+          expr: |
+            up{job="miniflux", namespace="miniflux"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Miniflux is down"
+            description: "Prometheus has not been able to scrape the Miniflux pod for 5 minutes."
+        - alert: MinifluxHighFeedRefreshErrorRate
+          expr: |
+            (
+              sum(rate(miniflux_background_feed_refresh_duration_count{status="error", namespace="miniflux"}[15m]))
+              /
+              sum(rate(miniflux_background_feed_refresh_duration_count{namespace="miniflux"}[15m]))
+            ) > 0.1
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Miniflux background feed refresh error rate above 10%"
+            description: "{{ $value | humanizePercentage }} of background feed refreshes failed over the last 15 minutes."
+        - alert: MinifluxBrokenFeedsHigh
+          expr: |
+            miniflux_broken_feeds{namespace="miniflux"} > 5
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Miniflux has {{ $value | humanize }} broken feeds"
+            description: "More than 5 feeds have exceeded the parsing error limit and stopped refreshing for over 30 minutes. Review and fix or remove them in the Miniflux UI."

--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -431,6 +431,26 @@ configMap:
           grant_types:
             - authorization_code
           token_endpoint_auth_method: client_secret_basic
+        - client_id: miniflux
+          client_name: Miniflux
+          client_secret:
+            path: /secrets/miniflux-oidc-client-secret/client-secret
+          public: false
+          authorization_policy: two_factor
+          consent_mode: implicit
+          require_pkce: true
+          pkce_challenge_method: S256
+          redirect_uris:
+            - https://feeds.${internal_domain}/oauth2/oidc/callback
+          scopes:
+            - openid
+            - profile
+            - email
+          response_types:
+            - code
+          grant_types:
+            - authorization_code
+          token_endpoint_auth_method: client_secret_basic
 
   regulation:
     max_retries: 3
@@ -459,4 +479,5 @@ secret:
     sure-oidc-client-secret: { }
     home-assistant-oidc-client-secret: { }
     mealie-oidc-client-secret: { }
+    miniflux-oidc-client-secret: { }
     authelia-smtp-credentials: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - jellyseerr-oidc-client-secret.yaml
   - home-assistant-oidc-client-secret.yaml
   - mealie-oidc-client-secret.yaml
+  - miniflux-oidc-client-secret.yaml
   - authelia-secrets.yaml
   - authelia-smtp-credentials.yaml
   - authelia-smtp-egress.yaml

--- a/kubernetes/clusters/live/config/authelia-prereqs/miniflux-oidc-client-secret.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/miniflux-oidc-client-secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: miniflux-oidc-client-secret
+  namespace: authelia
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: client-secret
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "64"
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "miniflux"
+data: { }

--- a/kubernetes/clusters/live/config/database/cluster-roles-patch.yaml
+++ b/kubernetes/clusters/live/config/database/cluster-roles-patch.yaml
@@ -81,3 +81,8 @@ spec:
         login: true
         passwordSecret:
           name: mealie-role-password
+      - name: miniflux
+        ensure: present
+        login: true
+        passwordSecret:
+          name: miniflux-role-password

--- a/kubernetes/clusters/live/config/database/databases.yaml
+++ b/kubernetes/clusters/live/config/database/databases.yaml
@@ -238,3 +238,15 @@ spec:
   cluster:
     name: platform
   databaseReclaimPolicy: retain
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: miniflux-database
+  namespace: database
+spec:
+  name: miniflux
+  owner: miniflux
+  cluster:
+    name: platform
+  databaseReclaimPolicy: retain

--- a/kubernetes/clusters/live/config/database/role-secrets.yaml
+++ b/kubernetes/clusters/live/config/database/role-secrets.yaml
@@ -211,3 +211,17 @@ metadata:
 type: kubernetes.io/basic-auth
 stringData:
   username: mealie
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: miniflux-role-password
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "miniflux"
+type: kubernetes.io/basic-auth
+stringData:
+  username: miniflux

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -116,4 +116,4 @@ konflate_version=0.5.0
 
 # Miniflux
 # renovate: datasource=docker depName=ghcr.io/miniflux/miniflux versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-distroless$
-miniflux_version=2.3.1-distroless
+miniflux_version=2.3.3-distroless

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -113,3 +113,7 @@ talos_pxe_schematic_id=613e1592b2da41ae5e265e8789429f22e121aab91cb4deb6bc3c0b626
 # Konflate
 # renovate: datasource=docker depName=konflate packageName=ghcr.io/home-operations/charts/konflate
 konflate_version=0.5.0
+
+# Miniflux
+# renovate: datasource=docker depName=ghcr.io/miniflux/miniflux versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-distroless$
+miniflux_version=2.3.1-distroless


### PR DESCRIPTION
Deploys Miniflux (ghcr.io/miniflux/miniflux:2.3.1-distroless) as an internal-only app-template release on the `live` cluster, so the household has a self-hosted RSS reader instead of relying on a third-party service. It follows the paperless per-app-folder pattern: a dedicated CNPG database/role on the shared platform Postgres cluster, Authelia OIDC SSO (with a secret-generator-provisioned local admin kept as break-glass access if Authelia is down), Prometheus metrics/alerts (down, feed-refresh error rate, broken feeds) sourced from Miniflux's own exported metric names, a Grafana dashboard, an internal-gateway HTTPRoute + canary check, and the `internal-egress` network policy profile so it can reach arbitrary feed servers over 80/443.

Validated with `task k8s:validate`, `task k8s:validate-live`, `task renovate:validate`, and `yamllint --strict`, plus a standalone `helm template` render of the app-template values against chart 4.6.2 (this caught and fixed a ServiceMonitor label-selector mismatch that would have silently broken metrics scraping). I could not complete live functional verification (pod ready, OIDC login, Hubble/canary/scrape checks) — see PR comment / session report for details.