### PR TITLE
fix(miniflux): pass OIDC issuer, not the well-known URL

### DIFF
--- a/kubernetes/clusters/live/apps/miniflux/helmrelease.yaml
+++ b/kubernetes/clusters/live/apps/miniflux/helmrelease.yaml
@@ -63,7 +63,6 @@ spec:
               BASE_URL: "https://feeds.${internal_domain}"
               RUN_MIGRATIONS: "1"
               LOG_LEVEL: "info"
-              # Database — dedicated app user via secret-generator, shared platform CNPG cluster
               MINIFLUX_DB_PASSWORD:
                 valueFrom:
                   secretKeyRef:
@@ -72,7 +71,6 @@ spec:
               DATABASE_URL:
                 dependsOn: MINIFLUX_DB_PASSWORD
                 value: "user=miniflux password=$(MINIFLUX_DB_PASSWORD) dbname=miniflux host=platform-pooler-rw.database.svc.cluster.local port=5432 sslmode=disable"
-              # Bootstrap local admin — break-glass access if Authelia is unavailable.
               CREATE_ADMIN: "1"
               ADMIN_USERNAME:
                 valueFrom:
@@ -84,7 +82,6 @@ spec:
                   secretKeyRef:
                     name: miniflux-admin-credentials
                     key: password
-              # OIDC/SSO via Authelia
               OAUTH2_PROVIDER: "oidc"
               OAUTH2_CLIENT_ID: "miniflux"
               OAUTH2_CLIENT_SECRET:
@@ -92,11 +89,10 @@ spec:
                   secretKeyRef:
                     name: miniflux-oidc-client-secret
                     key: client-secret
-              OAUTH2_OIDC_DISCOVERY_ENDPOINT: "https://auth.${external_domain}/.well-known/openid-configuration"
+              OAUTH2_OIDC_DISCOVERY_ENDPOINT: "https://auth.${external_domain}"
               OAUTH2_OIDC_PROVIDER_NAME: "Authelia"
               OAUTH2_REDIRECT_URL: "https://feeds.${internal_domain}/oauth2/oidc/callback"
               OAUTH2_USER_CREATION: "1"
-              # Prometheus metrics — scraped by the ServiceMonitor below
               METRICS_COLLECTOR: "1"
               METRICS_ALLOWED_NETWORKS: "${cluster_pod_subnet}"
             securityContext:


### PR DESCRIPTION
Miniflux passes `OAUTH2_OIDC_DISCOVERY_ENDPOINT` directly to go-oidc's `oidc.NewProvider`, which treats the value as the issuer and appends `/.well-known/openid-configuration` itself — so supplying the full well-known URL produced a doubled path that 404'd, provider init failed on startup, and the "Sign in with Authelia" button was dead. Authelia advertises issuer `https://auth.ionfury.tv`, so the variable now carries the bare issuer; verified the discovery document returns 200 with a matching `issuer` claim and advertises S256 plus client_secret_basic, matching the existing Authelia client block. Also drops explanatory comments from the values block per repo convention.

https://claude.ai/code/session_016Kquu8nf19d9C491b1ok64