### PR TITLE
feat(infra): add thread-ipv6 feature flag for OTBR RA acceptance

### DIFF
--- a/infrastructure/modules/config/main.tf
+++ b/infrastructure/modules/config/main.tf
@@ -80,10 +80,11 @@ locals {
   cluster_path     = "${var.accounts.github.repository_path}/${var.name}"
 
   # Feature detection
-  longhorn_enabled   = contains(var.features, "longhorn")
-  spegel_enabled     = contains(var.features, "spegel")
-  prometheus_enabled = contains(var.features, "prometheus")
-  gateway_enabled    = contains(var.features, "gateway-api")
+  longhorn_enabled    = contains(var.features, "longhorn")
+  spegel_enabled      = contains(var.features, "spegel")
+  prometheus_enabled  = contains(var.features, "prometheus")
+  gateway_enabled     = contains(var.features, "gateway-api")
+  thread_ipv6_enabled = contains(var.features, "thread-ipv6")
 
   # Filter machines belonging to this cluster
   cluster_machines = {
@@ -107,12 +108,23 @@ locals {
     name => try(machine.features.hugepages, null)
   }
 
+  # IPv6 RA acceptance for OTBR Route Information Option (Thread OMR prefix)
+  thread_ipv6_sysctls = {
+    "net.ipv6.conf.all.disable_ipv6"                   = "0"
+    "net.ipv6.conf.default.disable_ipv6"               = "0"
+    "net.ipv6.conf.all.accept_ra"                      = "2"
+    "net.ipv6.conf.default.accept_ra"                  = "2"
+    "net.ipv6.conf.all.accept_ra_rt_info_max_plen"     = "64"
+    "net.ipv6.conf.default.accept_ra_rt_info_max_plen" = "64"
+  }
+
   # 2M pages → sysctl (runtime, no reboot)
   machine_sysctls = {
     for name, hp in local.machine_hugepages :
-    name => hp != null && hp.size == "2M" ? {
-      "vm.nr_hugepages" = tostring(hp.count)
-    } : {}
+    name => merge(
+      hp != null && hp.size == "2M" ? { "vm.nr_hugepages" = tostring(hp.count) } : {},
+      local.thread_ipv6_enabled ? local.thread_ipv6_sysctls : {}
+    )
   }
 
   # 1G pages → kernel cmdline (boot-time, requires reboot)

--- a/infrastructure/modules/config/tests/feature_thread_ipv6.tftest.hcl
+++ b/infrastructure/modules/config/tests/feature_thread_ipv6.tftest.hcl
@@ -1,0 +1,210 @@
+# Thread IPv6 feature tests - validates IPv6 RA sysctls for OTBR Route Information
+# Option consumption (Thread OMR prefix), and coexistence with hugepages sysctls
+
+variables {
+  name = "test-cluster"
+
+  bgp = {
+    router_ip  = "192.168.10.1"
+    router_asn = 64512
+  }
+
+  networking = {
+    id                  = 1
+    internal_tld        = "internal.test.local"
+    external_tld        = "external.test.local"
+    node_subnet         = "192.168.10.0/24"
+    pod_subnet          = "172.18.0.0/16"
+    service_subnet      = "172.19.0.0/16"
+    vip                 = "192.168.10.20"
+    ip_pool_start       = "192.168.10.21"
+    internal_ingress_ip = "192.168.10.22"
+    external_ingress_ip = "192.168.10.23"
+    ip_pool_stop        = "192.168.10.29"
+    bgp_asn             = 64513
+    nameservers         = ["192.168.10.1"]
+    timeservers         = ["0.pool.ntp.org"]
+  }
+
+  versions = {
+    talos       = "v1.9.0"
+    kubernetes  = "1.32.0"
+    cilium      = "1.16.0"
+    gateway_api = "v1.2.0"
+    flux        = "v2.4.0"
+    prometheus  = "20.0.0"
+  }
+
+  local_paths = {
+    talos      = "~/.talos"
+    kubernetes = "~/.kube"
+  }
+
+  accounts = {
+    unifi = {
+      address       = "https://192.168.1.1"
+      site          = "default"
+      api_key_store = "/test/unifi"
+    }
+    github = {
+      org             = "testorg"
+      repository      = "testrepo"
+      repository_path = "clusters"
+      token_store     = "/test/github"
+    }
+    external_secrets = {
+      id_store     = "/test/es-id"
+      secret_store = "/test/es-secret"
+    }
+    healthchecksio = {
+      api_key_store = "/test/hc"
+    }
+  }
+
+  cilium_values_template = <<-EOT
+    cluster:
+      name: $${cluster_name}
+    ipv4NativeRoutingCIDR: $${cluster_pod_subnet}
+    hubble:
+      ui:
+        ingress:
+          hosts:
+            - hubble.$${internal_domain}
+  EOT
+
+  machines = {
+    node1 = {
+      cluster = "test-cluster"
+      type    = "controlplane"
+      install = { selector = "disk.model = *" }
+      bonds = [{
+        link_permanentAddr = ["aa:bb:cc:dd:ee:01"]
+        addresses          = ["192.168.10.101"]
+      }]
+    }
+  }
+}
+
+# Flag absent → no IPv6 sysctls emitted
+run "thread_ipv6_absent_no_sysctls" {
+  command = plan
+
+  variables {
+    features = []
+  }
+
+  assert {
+    condition = alltrue([
+      for name, m in output.machines :
+      length(m.sysctls) == 0
+    ])
+    error_message = "Nodes should have no sysctls when thread-ipv6 is not enabled"
+  }
+}
+
+# Flag present → all six sysctls emitted with correct string values
+run "thread_ipv6_enabled_emits_sysctls" {
+  command = plan
+
+  variables {
+    features = ["thread-ipv6"]
+  }
+
+  assert {
+    condition     = output.machines["node1"].sysctls["net.ipv6.conf.all.disable_ipv6"] == "0"
+    error_message = "thread-ipv6 should set net.ipv6.conf.all.disable_ipv6 = 0"
+  }
+
+  assert {
+    condition     = output.machines["node1"].sysctls["net.ipv6.conf.default.disable_ipv6"] == "0"
+    error_message = "thread-ipv6 should set net.ipv6.conf.default.disable_ipv6 = 0"
+  }
+
+  assert {
+    condition     = output.machines["node1"].sysctls["net.ipv6.conf.all.accept_ra"] == "2"
+    error_message = "thread-ipv6 should set net.ipv6.conf.all.accept_ra = 2"
+  }
+
+  assert {
+    condition     = output.machines["node1"].sysctls["net.ipv6.conf.default.accept_ra"] == "2"
+    error_message = "thread-ipv6 should set net.ipv6.conf.default.accept_ra = 2"
+  }
+
+  assert {
+    condition     = output.machines["node1"].sysctls["net.ipv6.conf.all.accept_ra_rt_info_max_plen"] == "64"
+    error_message = "thread-ipv6 should set net.ipv6.conf.all.accept_ra_rt_info_max_plen = 64"
+  }
+
+  assert {
+    condition     = output.machines["node1"].sysctls["net.ipv6.conf.default.accept_ra_rt_info_max_plen"] == "64"
+    error_message = "thread-ipv6 should set net.ipv6.conf.default.accept_ra_rt_info_max_plen = 64"
+  }
+
+  assert {
+    condition     = length(output.machines["node1"].sysctls) == 6
+    error_message = "thread-ipv6 should emit exactly six sysctls when no other sysctl feature is active"
+  }
+}
+
+# Flag present alongside 2M hugepages → seven entries total, vm.nr_hugepages preserved
+run "thread_ipv6_coexists_with_hugepages" {
+  command = plan
+
+  variables {
+    features = ["thread-ipv6"]
+    machines = {
+      hp-node = {
+        cluster = "test-cluster"
+        type    = "controlplane"
+        features = {
+          hugepages = { size = "2M", count = 512 }
+        }
+        install = { selector = "disk.model = *" }
+        bonds = [{
+          link_permanentAddr = ["aa:bb:cc:dd:ee:01"]
+          addresses          = ["192.168.10.101"]
+        }]
+      }
+    }
+  }
+
+  assert {
+    condition     = output.machines["hp-node"].sysctls["vm.nr_hugepages"] == "512"
+    error_message = "thread-ipv6 must not clobber vm.nr_hugepages"
+  }
+
+  assert {
+    condition     = output.machines["hp-node"].sysctls["net.ipv6.conf.all.accept_ra_rt_info_max_plen"] == "64"
+    error_message = "thread-ipv6 should still set accept_ra_rt_info_max_plen alongside hugepages"
+  }
+
+  assert {
+    condition     = length(output.machines["hp-node"].sysctls) == 7
+    error_message = "hugepages + thread-ipv6 should emit seven total sysctls"
+  }
+}
+
+# Flag present → rendered in Talos machine YAML
+run "thread_ipv6_in_talos_yaml" {
+  command = plan
+
+  variables {
+    features = ["thread-ipv6"]
+  }
+
+  assert {
+    condition = alltrue([
+      for m in output.talos.talos_machines :
+      strcontains(join("\n", m.configs), "sysctls:")
+    ])
+    error_message = "Talos config should contain sysctls: section"
+  }
+
+  assert {
+    condition = alltrue([
+      for m in output.talos.talos_machines :
+      strcontains(join("\n", m.configs), "net.ipv6.conf.all.accept_ra_rt_info_max_plen: \"64\"")
+    ])
+    error_message = "Talos config should contain accept_ra_rt_info_max_plen sysctl"
+  }
+}

--- a/infrastructure/modules/config/variables.tf
+++ b/infrastructure/modules/config/variables.tf
@@ -9,8 +9,8 @@ variable "features" {
   default     = ["gateway-api", "longhorn", "prometheus", "spegel"]
 
   validation {
-    condition     = alltrue([for feature in var.features : contains(["gateway-api", "longhorn", "prometheus", "spegel"], feature)])
-    error_message = "Each feature must be one of: gateway-api, longhorn, prometheus, spegel."
+    condition     = alltrue([for feature in var.features : contains(["gateway-api", "longhorn", "prometheus", "spegel", "thread-ipv6"], feature)])
+    error_message = "Each feature must be one of: gateway-api, longhorn, prometheus, spegel, thread-ipv6."
   }
 }
 

--- a/infrastructure/stacks/dev/terragrunt.stack.hcl
+++ b/infrastructure/stacks/dev/terragrunt.stack.hcl
@@ -1,6 +1,6 @@
 locals {
   name                 = "${basename(get_terragrunt_dir())}"
-  features             = ["gateway-api", "longhorn", "prometheus", "spegel"]
+  features             = ["gateway-api", "longhorn", "prometheus", "spegel", "thread-ipv6"]
   storage_provisioning = "minimal"
 }
 


### PR DESCRIPTION
Adds a cluster-scoped `thread-ipv6` feature flag that sets six IPv6 sysctls on every node in a cluster carrying it, and enables it on dev only. This is groundwork for running a SMLIGHT SLZB-06MU as an on-device Thread Border Router for Matter: Matter-over-Thread is IPv6-only, so the Matter controller must learn a route to the Thread OMR prefix, which OTBR advertises as a /64 Route Information Option in its Router Advertisements. `accept_ra=2` is required because forwarding hosts otherwise ignore RAs entirely, and `accept_ra_rt_info_max_plen=64` is required because it defaults to 0 and silently discards the RIO carrying that route. Sysctls are set on both `all` and `default` since nodes use bonded VLAN interfaces without predictable names. Implemented by extending the existing `machine_sysctls` local with a merge so hugepages and IPv6 sysctls coexist — dev's `node45` already carries `vm.nr_hugepages` and the plan confirms it is preserved. Talos v1.12.0 ships `CONFIG_IPV6_ROUTE_INFO=y`, so the sysctl exists. No apply has been run.

https://claude.ai/code/session_01CYpHtfycTZwxiD22ffGuCk