### PR TITLE
feat(flux): enable drift detection for all remaining HelmReleases

### DIFF
--- a/kubernetes/clusters/dev/resourcesets/helm-charts.yaml
+++ b/kubernetes/clusters/dev/resourcesets/helm-charts.yaml
@@ -72,6 +72,10 @@ spec:
         strategy:
           name: RetryOnFailure
         timeout: 10m
+      <<- if not (and (hasKey inputs "driftDetectionDisabled") inputs.driftDetectionDisabled) >>
+      driftDetection:
+        mode: enabled
+      <<- end >>
       valuesFrom:
         - kind: ConfigMap
           name: cluster-values

--- a/kubernetes/clusters/integration/helm-charts.yaml
+++ b/kubernetes/clusters/integration/helm-charts.yaml
@@ -65,6 +65,10 @@ spec:
         strategy:
           name: RetryOnFailure
         timeout: 10m
+      <<- if not (and (hasKey inputs "driftDetectionDisabled") inputs.driftDetectionDisabled) >>
+      driftDetection:
+        mode: enabled
+      <<- end >>
       valuesFrom:
         - kind: ConfigMap
           name: cluster-values

--- a/kubernetes/clusters/live/apps/miniflux/helmrelease.yaml
+++ b/kubernetes/clusters/live/apps/miniflux/helmrelease.yaml
@@ -32,6 +32,8 @@ spec:
     strategy:
       name: RetryOnFailure
     timeout: 10m
+  driftDetection:
+    mode: enabled
   valuesFrom: []
   values:
     # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json

--- a/kubernetes/clusters/live/apps/paperless/helmrelease.yaml
+++ b/kubernetes/clusters/live/apps/paperless/helmrelease.yaml
@@ -32,6 +32,8 @@ spec:
     strategy:
       name: RetryOnFailure
     timeout: 10m
+  driftDetection:
+    mode: enabled
   # Explicit empty list is required (not merely absent): the legacy ResourceSet's
   # flux-operator field manager still owns spec.valuesFrom on the live object, and
   # SSA only removes a field when the owning manager applies without it. Setting []

--- a/kubernetes/platform/helm-charts.yaml
+++ b/kubernetes/platform/helm-charts.yaml
@@ -329,6 +329,10 @@ spec:
         strategy:
           name: RetryOnFailure
         timeout: 10m
+      <<- if not (and (hasKey inputs "driftDetectionDisabled") inputs.driftDetectionDisabled) >>
+      driftDetection:
+        mode: enabled
+      <<- end >>
       valuesFrom:
         - kind: ConfigMap
           name: platform-values


### PR DESCRIPTION
#1430 made drift detection the default but only patched the app-tier ResourceSet template, leaving every other HelmRelease in the repo unprotected — the platform tier (36 releases including cilium, cert-manager, external-secrets, longhorn), the dev and integration cluster ResourceSets, and the standalone paperless/miniflux HelmReleases. That gap is why today's hubble-relay outage went uncorrected: Talos re-asserted a stale inline Cilium manifest onto live, reverting the hubble-relay Deployment to v1.19.4 into a crash loop, while Flux reported the cilium HelmRelease as Ready and a manual reconcile no-oped — without `spec.driftDetection`, helm-controller never compares the live object against the release manifest. This adds `driftDetection.mode: enabled` to all five remaining locations, reusing the existing `driftDetectionDisabled` input as a per-chart escape hatch in the templated tiers so it matches the app-tier template exactly.

`task k8s:validate-all` passes (exit 0). Verified by rendering the platform ResourceSet with `flux-operator build rset`: all 36 HelmReleases now carry the block.

Note this does not fix the Cilium drift at its source — the Talos inline manifest still ships v1.19.4 until the live talos stack is re-applied. It does mean Flux will now correct the Deployment within its 10m interval instead of leaving it broken indefinitely.

https://claude.ai/code/session_01R7F4pzEqZ6eZt1ERDFDZNV
