### PR TITLE
fix(longhorn): run snapshot checksum cronjob every 4 hours instead of weekly

### DIFF
--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -42,7 +42,7 @@ defaultSettings:
   # 8.6Ti volume scanning at <1% per 2 min, ~0 MB/s net transfer). With the
   # checksum precomputed, Longhorn uses fast-rebuild = minutes instead of ~24h.
   snapshotDataIntegrityImmediateCheckAfterSnapshotCreation: true
-  snapshotDataIntegrityCronjob: "0 0 * * *"
+  snapshotDataIntegrityCronjob: "0 */4 * * *"
   engineReplicaTimeout: 30
   replicaFileSyncHttpClientTimeout: 120
 csi:

--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -42,6 +42,7 @@ defaultSettings:
   # 8.6Ti volume scanning at <1% per 2 min, ~0 MB/s net transfer). With the
   # checksum precomputed, Longhorn uses fast-rebuild = minutes instead of ~24h.
   snapshotDataIntegrityImmediateCheckAfterSnapshotCreation: true
+  snapshotDataIntegrityCronjob: "0 0 * * *"
   engineReplicaTimeout: 30
   replicaFileSyncHttpClientTimeout: 120
 csi:

--- a/kubernetes/platform/config/tuppr/talos-upgrade.yaml
+++ b/kubernetes/platform/config/tuppr/talos-upgrade.yaml
@@ -6,11 +6,11 @@ metadata:
 spec:
   talos:
     version: ${talos_version}
-#  maintenance:
-#    windows:
-#      - start: "0 2 * * 6"  # Every Saturday at 2:00 AM
-#        duration: 4h
-#        timezone: EST
+  # maintenance:
+  #   windows:
+  #     - start: "0 2 * * 6"  # Every Saturday at 2:00 AM
+  #       duration: 4h
+  #       timezone: EST
   policy:
     rebootMode: default
     timeout: 60m


### PR DESCRIPTION
`snapshotDataIntegrityImmediateCheckAfterSnapshotCreation` was set so fast-rebuild would always have checksums, but it does not survive snapshot cleanup — with `autoCleanupSystemGeneratedSnapshot` enabled, Longhorn coalesces system snapshots into their child and explicitly deletes the surviving checksum (`replica.linkDisk`: `"Cleaning up new disk checksum file .../volume-snap-cbafc256-....img.checksum before linking"`), so the tail of each snapshot chain stays unhashed until the cronjob next runs — up to a week at the 7-day default. This moves it to every 4 hours.

Observed on the node42 leg of the v1.13.9 Talos upgrade: `pvc-cd6ba345` (10Ti, ~9.96TB actual) correctly skipped its checksummed 9.75TB base snapshot, but had to transfer ~176GB of coalesced unhashed snapshots, taking ~37min. 173GB of that was a snapshot created 2026-08-22, one day after the 2026-08-21 cron run, so not due again until 2026-08-28.

The cost is low: `snapshot-data-integrity` runs in `fast-check` mode, which only hashes files that are unhashed or whose mtime changed, so a run skips everything already checksummed. Cluster-wide coverage is currently 10.13TB hashed vs 0.44TB unhashed — the work per run is the small recent tail, not the bulk.

This mitigates rather than fixes. The checksum discard on coalesce is upstream behaviour, so a rebuild starting immediately after a cleanup still finds up to one cron interval of writes unhashed. Eliminating it entirely would mean disabling `autoCleanupSystemGeneratedSnapshot`, which needs `snapshotMaxCount` raised first — at the current value of 5 there is little headroom, and the values file records that 3 already caused snapshot creation to fail mid-rebuild.

Also folds in an unrelated lint fix: the `maintenance:` block in `kubernetes/platform/config/tuppr/talos-upgrade.yaml` was commented out at column 1, and `yamllint --strict` promotes `comments-indentation` to an error, failing `validate-base` on every PR branched from main.

https://claude.ai/code/session_01R7F4pzEqZ6eZt1ERDFDZNV
