### PR TITLE
chore(houndarr): scale deployment to 0

### DIFF
--- a/kubernetes/clusters/live/charts/houndarr.yaml
+++ b/kubernetes/clusters/live/charts/houndarr.yaml
@@ -4,7 +4,7 @@
 controllers:
   houndarr:
     type: deployment
-    replicas: 1
+    replicas: 0
 
     annotations:
       reloader.stakater.com/auto: "true"


### PR DESCRIPTION
Scales the houndarr deployment down to zero replicas. The PVC, service, and HTTPRoute are left in place so it can be scaled back up by reverting this one-line change.

https://claude.ai/code/session_01R7F4pzEqZ6eZt1ERDFDZNV