### PR TITLE
fix(monitoring): stop Discord alert re-firing from group churn and label flap

### DIFF
--- a/kubernetes/platform/charts/kube-prometheus-stack.yaml
+++ b/kubernetes/platform/charts/kube-prometheus-stack.yaml
@@ -84,6 +84,32 @@ prometheus:
         networking/allow-ingress-internal: "true"
     externalLabels:
       prometheus_source: ${cluster_name}
+    additionalAlertRelabelConfigs:
+      - action: replace
+        source_labels: [job]
+        regex: tuppr-metrics-service
+        target_label: pod
+        replacement: ""
+      - action: replace
+        source_labels: [job]
+        regex: tuppr-metrics-service
+        target_label: instance
+        replacement: ""
+      - action: replace
+        source_labels: [alertname]
+        regex: KubeJobFailed
+        target_label: pod
+        replacement: ""
+      - action: replace
+        source_labels: [alertname]
+        regex: KubeJobFailed
+        target_label: instance
+        replacement: ""
+      - action: replace
+        source_labels: [alertname]
+        regex: KubeJobFailed
+        target_label: kubernetes_node
+        replacement: ""
     podMonitorSelectorNilUsesHelmValues: false
     probeSelectorNilUsesHelmValues: false
     ruleSelectorNilUsesHelmValues: false
@@ -212,12 +238,13 @@ additionalPrometheusRulesMap:
               runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodediskiosaturation
               summary: Disk IO queue is high.
             expr: |
-              (
+              max by (instance, device) (
                 rate(node_disk_io_time_weighted_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}[5m])
               * on(instance, device) group_left()
                 node_disk_info{model!="VIRTUAL-DISK"}
               ) > 10
             for: 30m
+            keep_firing_for: 30m
             labels:
               severity: warning
   oom-rules:

--- a/kubernetes/platform/config/monitoring/alertmanager-config.yaml
+++ b/kubernetes/platform/config/monitoring/alertmanager-config.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   route:
     groupBy: ["alertname", "job"]
-    groupInterval: 10m
+    groupInterval: 1h
     groupWait: 1m
     receiver: discord
     repeatInterval: 12h


### PR DESCRIPTION
Prometheus alerts re-notified via Discord roughly every 10 minutes despite `repeatInterval: 12h`, from three independent causes. Alertmanager re-sends a whole group whenever membership changes — gated by `groupInterval`, not `repeatInterval` — and `LonghornSnapshotUnhashed` churns constantly because its 6h `for` applies to continuously created/deleted Longhorn recurring snapshots, so `groupInterval` goes to 1h. Separately, alert identity is the full label fingerprint, so `TalosUpgradeStuck` and `KubeJobFailed` were torn down and recreated every time the exporting pod was replaced (three different tuppr pods across four "new" firings, while the TalosUpgrade CR never left HealthChecking); since neither rule is ours, the volatile labels are stripped via `alert_relabel_configs` rather than forking upstream — scoped by `job` for tuppr (all its alerts are CR-scoped) and by `alertname` for `KubeJobFailed` (kube-state-metrics sets `honorLabels`, so other alerts on that job carry a real subject pod). Finally `NodeDiskIOSaturation` had `for: 30m` gating entry but nothing gating exit, resolving on a single 5m sample dip — every observed resolution was at 10.07–11.94, still above the threshold of 10 — so it gains `keep_firing_for` plus aggregation to drop the node-exporter pod from its identity.

Verified against live Prometheus 3.14.0: the rewritten PromQL returns `{device, instance}` only, `helm template` renders the relabel secret and wires it to the Prometheus CR with no manual step, and `relabel.go:330-331` confirms an empty `replacement` deletes the label on match while non-matching alerts are left untouched. The Discord template is fully `if`-guarded, so absent labels simply omit the Context line.

https://claude.ai/code/session_01RS5BCqKU15ZvDW5qXa5rvo