### PR TITLE
feat(k8s): deploy Ember RSS reader with Authelia forward-auth and Ollama summaries

### DIFF
--- a/kubernetes/clusters/live/apps/apps-resourceset.yaml
+++ b/kubernetes/clusters/live/apps/apps-resourceset.yaml
@@ -20,6 +20,9 @@ spec:
     - name: miniflux
       path: kubernetes/clusters/live/apps/miniflux
       dependsOn: [cloudnative-pg, secret-generator]
+    - name: ember
+      path: kubernetes/clusters/live/apps/ember
+      dependsOn: [secret-generator]
   resourcesTemplate: |
     ---
     apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/kubernetes/clusters/live/apps/ember/canary.yaml
+++ b/kubernetes/clusters/live/apps/ember/canary.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/canaries.flanksource.com/canary_v1.json
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: http-check-ember
+  namespace: ember
+spec:
+  schedule: "@every 1m"
+  http:
+    - name: ember-gateway-health
+      url: https://ember.${internal_domain}/healthz
+      responseCodes: [200, 302]
+      maxSSLExpiry: 7
+      thresholdMillis: 5000

--- a/kubernetes/clusters/live/apps/ember/ember-admin-credentials.yaml
+++ b/kubernetes/clusters/live/apps/ember/ember-admin-credentials.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ember-admin-credentials
+  namespace: ember
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+type: Opaque
+stringData:
+  username: admin

--- a/kubernetes/clusters/live/apps/ember/ember-auth-policy.yaml
+++ b/kubernetes/clusters/live/apps/ember/ember-auth-policy.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/security.istio.io/authorizationpolicy_v1.json
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: ember-auth
+  namespace: istio-gateway
+spec:
+  targetRefs:
+    - kind: Gateway
+      group: gateway.networking.k8s.io
+      name: internal
+  action: CUSTOM
+  provider:
+    name: authelia
+  rules:
+    - to:
+        - operation:
+            hosts:
+              - "ember.${internal_domain}"

--- a/kubernetes/clusters/live/apps/ember/ember-ollama-egress.yaml
+++ b/kubernetes/clusters/live/apps/ember/ember-ollama-egress.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: ember-ollama-egress
+  namespace: ember
+spec:
+  description: "Allow Ember egress to Ollama API for AI article summarization"
+  endpointSelector: { }
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP

--- a/kubernetes/clusters/live/apps/ember/ember-session-key.yaml
+++ b/kubernetes/clusters/live/apps/ember/ember-session-key.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ember-session-key
+  namespace: ember
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: session-key
+    secret-generator.v1.mittwald.de/length: "32"
+    secret-generator.v1.mittwald.de/encoding: base64
+data: { }

--- a/kubernetes/clusters/live/apps/ember/helmrelease.yaml
+++ b/kubernetes/clusters/live/apps/ember/helmrelease.yaml
@@ -1,0 +1,157 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ember
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: secret-generator
+  chart:
+    spec:
+      chart: app-template
+      version: "${app_template_version}"
+      interval: 10m
+      sourceRef:
+        kind: HelmRepository
+        name: ember
+  install:
+    createNamespace: false
+    strategy:
+      name: RetryOnFailure
+    timeout: 10m
+  interval: 10m
+  maxHistory: 3
+  releaseName: ember
+  targetNamespace: ember
+  uninstall:
+    keepHistory: false
+  upgrade:
+    crds: CreateReplace
+    strategy:
+      name: RetryOnFailure
+    timeout: 10m
+  valuesFrom: []
+  values:
+    # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+    # https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+    controllers:
+      ember:
+        type: deployment
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile:
+              type: RuntimeDefault
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/brandonhon/ember
+              tag: "${ember_version}"
+            env:
+              EMBER_ADDR: ":8080"
+              EMBER_DB_PATH: "/data/ember.db"
+              EMBER_PUBLIC_URL: "https://ember.${internal_domain}"
+              EMBER_SECURE_COOKIES: "1"
+              EMBER_TRUSTED_PROXIES: "${cluster_pod_subnet}"
+              EMBER_LOG_LEVEL: "info"
+              EMBER_SESSION_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: ember-session-key
+                    key: session-key
+              EMBER_ADMIN_USER:
+                valueFrom:
+                  secretKeyRef:
+                    name: ember-admin-credentials
+                    key: username
+              EMBER_ADMIN_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: ember-admin-credentials
+                    key: password
+              EMBER_OLLAMA_URL: "http://ollama.ai.svc.cluster.local:11434"
+              EMBER_OLLAMA_MODEL: "qwen2.5:0.5b"
+              EMBER_DISABLE_SUMMARIES: "0"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  failureThreshold: 30
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8080
+                  periodSeconds: 30
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: 8080
+                  periodSeconds: 10
+
+    service:
+      app:
+        controller: ember
+        ports:
+          http:
+            port: 8080
+
+    persistence:
+      data:
+        type: persistentVolumeClaim
+        storageClass: fast
+        accessMode: ReadWriteOnce
+        size: 2Gi
+        globalMounts:
+          - path: /data
+
+    route:
+      internal:
+        enabled: true
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: "Ember"
+          gethomepage.dev/group: "Apps"
+          gethomepage.dev/icon: "rss.svg"
+          gethomepage.dev/pod-selector: "app.kubernetes.io/name=ember"
+        parentRefs:
+          - name: internal
+            namespace: istio-gateway
+        hostnames:
+          - "ember.${internal_domain}"
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 8080

--- a/kubernetes/clusters/live/apps/ember/helmrepository.yaml
+++ b/kubernetes/clusters/live/apps/ember/helmrepository.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ember
+  namespace: flux-system
+spec:
+  interval: 10m
+  type: oci
+  url: oci://ghcr.io/bjw-s-labs/helm

--- a/kubernetes/clusters/live/apps/ember/kustomization.yaml
+++ b/kubernetes/clusters/live/apps/ember/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - ember-admin-credentials.yaml
+  - ember-session-key.yaml
+  - ember-auth-policy.yaml
+  - ember-ollama-egress.yaml
+  - canary.yaml
+  - prometheus-rules.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/kubernetes/clusters/live/apps/ember/namespace.yaml
+++ b/kubernetes/clusters/live/apps/ember/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ember
+  labels:
+    istio.io/dataplane-mode: ambient
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+    network-policy.homelab/profile: internal-egress

--- a/kubernetes/clusters/live/apps/ember/prometheus-rules.yaml
+++ b/kubernetes/clusters/live/apps/ember/prometheus-rules.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: ember-alerts
+  namespace: ember
+  labels:
+    app.kubernetes.io/name: ember
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: ember.rules
+      rules:
+        - alert: EmberDown
+          expr: |
+            kube_deployment_status_replicas_available{namespace="ember", deployment="ember"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Ember is down"
+            description: "No available Ember replicas for 5 minutes."

--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -81,6 +81,11 @@ configMap:
 
   access_control:
     default_policy: two_factor
+    rules:
+      - domain: "ember.${internal_domain}"
+        policy: two_factor
+        subject:
+          - "group:ember"
 
   session:
     cookies:
@@ -461,6 +466,7 @@ configMap:
     endpoints:
       automatic_authz_implementations:
         - ForwardAuth
+        - ExtAuthz
 
 secret:
   existingSecret: "authelia-secrets"

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -117,3 +117,7 @@ konflate_version=0.6.1
 # Miniflux
 # renovate: datasource=docker depName=ghcr.io/miniflux/miniflux versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-distroless$
 miniflux_version=2.3.3-distroless
+
+# Ember
+# renovate: datasource=docker depName=ghcr.io/brandonhon/ember
+ember_version=0.9.6

--- a/kubernetes/platform/charts/istiod.yaml
+++ b/kubernetes/platform/charts/istiod.yaml
@@ -8,6 +8,32 @@ meshConfig:
   accessLogEncoding: JSON
   enablePrometheusMerge: true
   extensionProviders:
+    - name: authelia
+      envoyExtAuthzHttp:
+        service: authelia.authelia.svc.cluster.local
+        port: 80
+        pathPrefix: /api/authz/ext-authz/
+        headersToDownstreamOnDeny:
+          - content-type
+          - set-cookie
+          - location
+        headersToUpstreamOnAllow:
+          - remote-user
+          - remote-groups
+          - remote-name
+          - remote-email
+        headersToDownstreamOnAllow:
+          - set-cookie
+        includeRequestHeadersInCheck:
+          - accept
+          - cookie
+          - authorization
+          - proxy-authorization
+          - x-forwarded-proto
+          - x-forwarded-host
+          - x-forwarded-for
+        includeAdditionalHeadersInCheck:
+          x-forwarded-proto: "https"
     - name: oauth2-proxy
       envoyExtAuthzHttp:
         service: oauth2-proxy.oauth2-proxy.svc.cluster.local


### PR DESCRIPTION
Deploys Ember (ghcr.io/brandonhon/ember:0.9.6), a self-hosted RSS reader with Ollama-backed AI summarization, as a live-cluster app-template HelmRelease with SQLite persistence on the internal gateway. Ember has no OIDC support upstream, so rather than the usual Authelia OIDC-client pattern it is protected by a new Istio ext_authz forward-auth provider pointing at Authelia, gated by access_control group `ember`; AI summaries target the existing in-cluster Ollama service with a Cilium egress policy scoped to port 11434. No ServiceMonitor is included because Ember's `/metrics` requires an authenticated admin session cookie with no bypass, so a scrape would 401 permanently and publish a false-positive down series — availability alerting uses kube-state-metrics deployment replicas plus a canary-checker HTTP check instead.

https://claude.ai/code/session_01NwjRmYRxYeeyX4kuz4uzwW