### PR TITLE
feat(k8s): deploy FreshRSS and Fusion RSS readers

### DIFF
--- a/kubernetes/clusters/live/apps/apps-resourceset.yaml
+++ b/kubernetes/clusters/live/apps/apps-resourceset.yaml
@@ -20,6 +20,12 @@ spec:
     - name: miniflux
       path: kubernetes/clusters/live/apps/miniflux
       dependsOn: [cloudnative-pg, secret-generator]
+    - name: freshrss
+      path: kubernetes/clusters/live/apps/freshrss
+      dependsOn: [cloudnative-pg, secret-generator]
+    - name: fusion
+      path: kubernetes/clusters/live/apps/fusion
+      dependsOn: [secret-generator]
   resourcesTemplate: |
     ---
     apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/kubernetes/clusters/live/apps/freshrss/canary.yaml
+++ b/kubernetes/clusters/live/apps/freshrss/canary.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/canaries.flanksource.com/canary_v1.json
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: http-check-freshrss
+  namespace: freshrss
+spec:
+  schedule: "@every 1m"
+  http:
+    - name: freshrss-gateway-health
+      url: https://freshrss.${internal_domain}/i/
+      responseCodes: [200, 302]
+      maxSSLExpiry: 7
+      thresholdMillis: 5000

--- a/kubernetes/clusters/live/apps/freshrss/freshrss-data-pvc.yaml
+++ b/kubernetes/clusters/live/apps/freshrss/freshrss-data-pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: freshrss-data
+  namespace: freshrss
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: fast
+  resources:
+    requests:
+      storage: 2Gi

--- a/kubernetes/clusters/live/apps/freshrss/freshrss-db-credentials.yaml
+++ b/kubernetes/clusters/live/apps/freshrss/freshrss-db-credentials.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: freshrss-db-credentials
+  namespace: freshrss
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: database/freshrss-role-password
+type: Opaque
+data: { }

--- a/kubernetes/clusters/live/apps/freshrss/freshrss-oidc-client-secret-replica.yaml
+++ b/kubernetes/clusters/live/apps/freshrss/freshrss-oidc-client-secret-replica.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: freshrss-oidc-client-secret
+  namespace: freshrss
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: authelia/freshrss-oidc-client-secret
+data: { }

--- a/kubernetes/clusters/live/apps/freshrss/freshrss-oidc-crypto-key.yaml
+++ b/kubernetes/clusters/live/apps/freshrss/freshrss-oidc-crypto-key.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: freshrss-oidc-crypto-key
+  namespace: freshrss
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: crypto-key
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+type: Opaque
+data: { }

--- a/kubernetes/clusters/live/apps/freshrss/freshrss-ollama-egress.yaml
+++ b/kubernetes/clusters/live/apps/freshrss/freshrss-ollama-egress.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: freshrss-ollama-egress
+  namespace: freshrss
+spec:
+  description: "Allow FreshRSS egress to Ollama API for AI Summary extension"
+  endpointSelector: { }
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP

--- a/kubernetes/clusters/live/apps/freshrss/helmrelease.yaml
+++ b/kubernetes/clusters/live/apps/freshrss/helmrelease.yaml
@@ -1,0 +1,188 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: freshrss
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cloudnative-pg
+    - name: secret-generator
+  chart:
+    spec:
+      chart: app-template
+      version: "${app_template_version}"
+      interval: 10m
+      sourceRef:
+        kind: HelmRepository
+        name: freshrss
+  install:
+    createNamespace: false
+    strategy:
+      name: RetryOnFailure
+    timeout: 10m
+  interval: 10m
+  maxHistory: 3
+  releaseName: freshrss
+  targetNamespace: freshrss
+  uninstall:
+    keepHistory: false
+  upgrade:
+    crds: CreateReplace
+    strategy:
+      name: RetryOnFailure
+    timeout: 10m
+  valuesFrom: []
+  values:
+    # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+    # https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+    controllers:
+      freshrss:
+        type: deployment
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        pod:
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+
+        initContainers:
+          fetch-ai-summary-extension:
+            image:
+              repository: alpine
+              tag: "3.24.1"
+            command:
+              - sh
+              - -c
+              - |
+                set -e
+                mkdir -p /extensions/xExtension-AiSummary
+                wget -qO- "https://github.com/deimosfr/xExtension-AiSummary/archive/refs/tags/v${freshrss_ai_summary_extension_version}.tar.gz" \
+                  | tar -xz -C /extensions/xExtension-AiSummary --strip-components=1
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/freshrss/freshrss
+              tag: "${freshrss_version}"
+            env:
+              TZ: "America/Chicago"
+              CRON_MIN: "13,43"
+              FRESHRSS_DB_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: freshrss-db-credentials
+                    key: password
+              FRESHRSS_INSTALL:
+                dependsOn: FRESHRSS_DB_PASSWORD
+                value: |-
+                  --api-enabled
+                  --auth-type http_auth
+                  --base-url https://freshrss.${internal_domain}
+                  --db-base freshrss
+                  --db-host platform-pooler-rw.database.svc.cluster.local
+                  --db-password $(FRESHRSS_DB_PASSWORD)
+                  --db-type pgsql
+                  --db-user freshrss
+                  --default-user ionfury
+                  --language en
+              OIDC_ENABLED: "1"
+              OIDC_PROVIDER_METADATA_URL: "https://auth.${external_domain}/.well-known/openid-configuration"
+              OIDC_CLIENT_ID: "freshrss"
+              OIDC_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: freshrss-oidc-client-secret
+                    key: client-secret
+              OIDC_CLIENT_CRYPTO_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: freshrss-oidc-crypto-key
+                    key: crypto-key
+              OIDC_SCOPES: "openid profile"
+              OIDC_X_FORWARDED_HEADERS: "X-Forwarded-Proto"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop: ["ALL"]
+                add: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "SETUID", "SETGID", "NET_BIND_SERVICE"]
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+            probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ["php", "/var/www/FreshRSS/cli/health.php"]
+                  initialDelaySeconds: 15
+                  periodSeconds: 5
+                  failureThreshold: 60
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ["php", "/var/www/FreshRSS/cli/health.php"]
+                  periodSeconds: 30
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ["php", "/var/www/FreshRSS/cli/health.php"]
+                  periodSeconds: 10
+
+    service:
+      app:
+        controller: freshrss
+        ports:
+          http:
+            port: 80
+
+    route:
+      internal:
+        enabled: true
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: "FreshRSS"
+          gethomepage.dev/group: "Apps"
+          gethomepage.dev/icon: "freshrss.svg"
+          gethomepage.dev/pod-selector: "app.kubernetes.io/name=freshrss"
+        parentRefs:
+          - name: internal
+            namespace: istio-gateway
+        hostnames:
+          - "freshrss.${internal_domain}"
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 80
+
+    persistence:
+      data:
+        existingClaim: freshrss-data
+        advancedMounts:
+          freshrss:
+            app:
+              - path: /var/www/FreshRSS/data
+      extensions:
+        type: emptyDir
+        advancedMounts:
+          freshrss:
+            app:
+              - path: /var/www/FreshRSS/extensions
+            fetch-ai-summary-extension:
+              - path: /extensions

--- a/kubernetes/clusters/live/apps/freshrss/helmrelease.yaml
+++ b/kubernetes/clusters/live/apps/freshrss/helmrelease.yaml
@@ -91,7 +91,7 @@ spec:
                   --db-password $(FRESHRSS_DB_PASSWORD)
                   --db-type pgsql
                   --db-user freshrss
-                  --default-user ionfury
+                  --default-user thomasnowak
                   --language en
               OIDC_ENABLED: "1"
               OIDC_PROVIDER_METADATA_URL: "https://auth.${external_domain}/.well-known/openid-configuration"

--- a/kubernetes/clusters/live/apps/freshrss/helmrepository.yaml
+++ b/kubernetes/clusters/live/apps/freshrss/helmrepository.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: freshrss
+  namespace: flux-system
+spec:
+  interval: 10m
+  type: oci
+  url: oci://ghcr.io/bjw-s-labs/helm

--- a/kubernetes/clusters/live/apps/freshrss/kustomization.yaml
+++ b/kubernetes/clusters/live/apps/freshrss/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - freshrss-data-pvc.yaml
+  - freshrss-db-credentials.yaml
+  - freshrss-oidc-client-secret-replica.yaml
+  - freshrss-oidc-crypto-key.yaml
+  - freshrss-ollama-egress.yaml
+  - canary.yaml
+  - prometheus-rules.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/kubernetes/clusters/live/apps/freshrss/namespace.yaml
+++ b/kubernetes/clusters/live/apps/freshrss/namespace.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: freshrss
+  labels:
+    istio.io/dataplane-mode: ambient
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline
+    network-policy.homelab/profile: internal-egress
+    access.network-policy.homelab/postgres: "true"

--- a/kubernetes/clusters/live/apps/freshrss/prometheus-rules.yaml
+++ b/kubernetes/clusters/live/apps/freshrss/prometheus-rules.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: freshrss-alerts
+  namespace: freshrss
+  labels:
+    app.kubernetes.io/name: freshrss
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: freshrss.rules
+      rules:
+        - alert: FreshRSSDeploymentReplicasUnavailable
+          expr: |
+            kube_deployment_status_replicas_available{namespace="freshrss", deployment="freshrss"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "FreshRSS has no available replicas"
+            description: "FreshRSS does not expose Prometheus metrics, so availability is inferred from the Deployment's available replica count via kube-state-metrics. No replicas have been available for 5 minutes."
+        - alert: FreshRSSPodCrashLooping
+          expr: |
+            increase(kube_pod_container_status_restarts_total{namespace="freshrss"}[15m]) > 3
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "FreshRSS pod {{ $labels.pod }} is crash looping"
+            description: "{{ $labels.pod }} has restarted {{ $value | humanize }} times in the last 15 minutes."

--- a/kubernetes/clusters/live/apps/fusion/canary.yaml
+++ b/kubernetes/clusters/live/apps/fusion/canary.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/canaries.flanksource.com/canary_v1.json
+apiVersion: canaries.flanksource.com/v1
+kind: Canary
+metadata:
+  name: http-check-fusion
+  namespace: fusion
+spec:
+  schedule: "@every 1m"
+  http:
+    - name: fusion-gateway-health
+      url: https://fusion.${internal_domain}/api/oidc/enabled
+      responseCodes: [200]
+      maxSSLExpiry: 7
+      thresholdMillis: 5000

--- a/kubernetes/clusters/live/apps/fusion/fusion-credentials.yaml
+++ b/kubernetes/clusters/live/apps/fusion/fusion-credentials.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fusion-credentials
+  namespace: fusion
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+type: Opaque
+data: { }

--- a/kubernetes/clusters/live/apps/fusion/fusion-data-pvc.yaml
+++ b/kubernetes/clusters/live/apps/fusion/fusion-data-pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fusion-data
+  namespace: fusion
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: fast
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/clusters/live/apps/fusion/fusion-oidc-client-secret-replica.yaml
+++ b/kubernetes/clusters/live/apps/fusion/fusion-oidc-client-secret-replica.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fusion-oidc-client-secret
+  namespace: fusion
+  annotations:
+    replicator.v1.mittwald.de/replicate-from: authelia/fusion-oidc-client-secret
+data: { }

--- a/kubernetes/clusters/live/apps/fusion/helmrelease.yaml
+++ b/kubernetes/clusters/live/apps/fusion/helmrelease.yaml
@@ -1,0 +1,140 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: fusion
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: secret-generator
+  chart:
+    spec:
+      chart: app-template
+      version: "${app_template_version}"
+      interval: 10m
+      sourceRef:
+        kind: HelmRepository
+        name: fusion
+  install:
+    createNamespace: false
+    strategy:
+      name: RetryOnFailure
+    timeout: 10m
+  interval: 10m
+  maxHistory: 3
+  releaseName: fusion
+  targetNamespace: fusion
+  uninstall:
+    keepHistory: false
+  upgrade:
+    crds: CreateReplace
+    strategy:
+      name: RetryOnFailure
+    timeout: 10m
+  valuesFrom: []
+  values:
+    # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/values.schema.json
+    # https://github.com/bjw-s-labs/helm-charts/tree/main/charts/other/app-template
+    controllers:
+      fusion:
+        type: deployment
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        pod:
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/0x2e/fusion
+              tag: "${fusion_version}"
+            env:
+              FUSION_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: fusion-credentials
+                    key: password
+              FUSION_OIDC_ISSUER: "https://auth.${external_domain}"
+              FUSION_OIDC_CLIENT_ID: "fusion"
+              FUSION_OIDC_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: fusion-oidc-client-secret
+                    key: client-secret
+              FUSION_OIDC_REDIRECT_URI: "https://fusion.${internal_domain}/api/oidc/callback"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/oidc/enabled
+                    port: 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  failureThreshold: 30
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/oidc/enabled
+                    port: 8080
+                  periodSeconds: 30
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/oidc/enabled
+                    port: 8080
+                  periodSeconds: 10
+
+    service:
+      app:
+        controller: fusion
+        ports:
+          http:
+            port: 8080
+
+    route:
+      internal:
+        enabled: true
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: "Fusion"
+          gethomepage.dev/group: "Apps"
+          gethomepage.dev/icon: "rss.svg"
+          gethomepage.dev/pod-selector: "app.kubernetes.io/name=fusion"
+        parentRefs:
+          - name: internal
+            namespace: istio-gateway
+        hostnames:
+          - "fusion.${internal_domain}"
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 8080
+
+    persistence:
+      data:
+        existingClaim: fusion-data
+        advancedMounts:
+          fusion:
+            app:
+              - path: /data

--- a/kubernetes/clusters/live/apps/fusion/helmrepository.yaml
+++ b/kubernetes/clusters/live/apps/fusion/helmrepository.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: fusion
+  namespace: flux-system
+spec:
+  interval: 10m
+  type: oci
+  url: oci://ghcr.io/bjw-s-labs/helm

--- a/kubernetes/clusters/live/apps/fusion/kustomization.yaml
+++ b/kubernetes/clusters/live/apps/fusion/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - fusion-data-pvc.yaml
+  - fusion-oidc-client-secret-replica.yaml
+  - fusion-credentials.yaml
+  - canary.yaml
+  - prometheus-rules.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/kubernetes/clusters/live/apps/fusion/namespace.yaml
+++ b/kubernetes/clusters/live/apps/fusion/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fusion
+  labels:
+    istio.io/dataplane-mode: ambient
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline
+    network-policy.homelab/profile: internal-egress

--- a/kubernetes/clusters/live/apps/fusion/prometheus-rules.yaml
+++ b/kubernetes/clusters/live/apps/fusion/prometheus-rules.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: fusion-alerts
+  namespace: fusion
+  labels:
+    app.kubernetes.io/name: fusion
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: fusion.rules
+      rules:
+        - alert: FusionDeploymentReplicasUnavailable
+          expr: |
+            kube_deployment_status_replicas_available{namespace="fusion", deployment="fusion"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Fusion has no available replicas"
+            description: "Fusion does not expose Prometheus metrics, so availability is inferred from the Deployment's available replica count via kube-state-metrics. No replicas have been available for 5 minutes."
+        - alert: FusionPodCrashLooping
+          expr: |
+            increase(kube_pod_container_status_restarts_total{namespace="fusion"}[15m]) > 3
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Fusion pod {{ $labels.pod }} is crash looping"
+            description: "{{ $labels.pod }} has restarted {{ $value | humanize }} times in the last 15 minutes."

--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -451,6 +451,46 @@ configMap:
           grant_types:
             - authorization_code
           token_endpoint_auth_method: client_secret_basic
+        - client_id: freshrss
+          client_name: FreshRSS
+          client_secret:
+            path: /secrets/freshrss-oidc-client-secret/client-secret
+          public: false
+          authorization_policy: two_factor
+          consent_mode: implicit
+          require_pkce: true
+          pkce_challenge_method: S256
+          redirect_uris:
+            - https://freshrss.${internal_domain}/i/oidc/
+          scopes:
+            - openid
+            - profile
+            - email
+          response_types:
+            - code
+          grant_types:
+            - authorization_code
+          token_endpoint_auth_method: client_secret_basic
+        - client_id: fusion
+          client_name: Fusion
+          client_secret:
+            path: /secrets/fusion-oidc-client-secret/client-secret
+          public: false
+          authorization_policy: two_factor
+          consent_mode: implicit
+          require_pkce: true
+          pkce_challenge_method: S256
+          redirect_uris:
+            - https://fusion.${internal_domain}/api/oidc/callback
+          scopes:
+            - openid
+            - profile
+            - email
+          response_types:
+            - code
+          grant_types:
+            - authorization_code
+          token_endpoint_auth_method: client_secret_post
 
   regulation:
     max_retries: 3

--- a/kubernetes/clusters/live/config/authelia-prereqs/freshrss-oidc-client-secret.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/freshrss-oidc-client-secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: freshrss-oidc-client-secret
+  namespace: authelia
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: client-secret
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "64"
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "freshrss"
+data: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/fusion-oidc-client-secret.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/fusion-oidc-client-secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fusion-oidc-client-secret
+  namespace: authelia
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: client-secret
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "64"
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "fusion"
+data: { }

--- a/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
+++ b/kubernetes/clusters/live/config/authelia-prereqs/kustomization.yaml
@@ -20,6 +20,8 @@ resources:
   - home-assistant-oidc-client-secret.yaml
   - mealie-oidc-client-secret.yaml
   - miniflux-oidc-client-secret.yaml
+  - freshrss-oidc-client-secret.yaml
+  - fusion-oidc-client-secret.yaml
   - authelia-secrets.yaml
   - authelia-smtp-credentials.yaml
   - authelia-smtp-egress.yaml

--- a/kubernetes/clusters/live/config/database/cluster-roles-patch.yaml
+++ b/kubernetes/clusters/live/config/database/cluster-roles-patch.yaml
@@ -86,3 +86,8 @@ spec:
         login: true
         passwordSecret:
           name: miniflux-role-password
+      - name: freshrss
+        ensure: present
+        login: true
+        passwordSecret:
+          name: freshrss-role-password

--- a/kubernetes/clusters/live/config/database/databases.yaml
+++ b/kubernetes/clusters/live/config/database/databases.yaml
@@ -250,3 +250,15 @@ spec:
   cluster:
     name: platform
   databaseReclaimPolicy: retain
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: freshrss-database
+  namespace: database
+spec:
+  name: freshrss
+  owner: freshrss
+  cluster:
+    name: platform
+  databaseReclaimPolicy: retain

--- a/kubernetes/clusters/live/config/database/role-secrets.yaml
+++ b/kubernetes/clusters/live/config/database/role-secrets.yaml
@@ -225,3 +225,17 @@ metadata:
 type: kubernetes.io/basic-auth
 stringData:
   username: miniflux
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: freshrss-role-password
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+    replicator.v1.mittwald.de/replication-allowed: "true"
+    replicator.v1.mittwald.de/replication-allowed-namespaces: "freshrss"
+type: kubernetes.io/basic-auth
+stringData:
+  username: freshrss

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -117,3 +117,16 @@ konflate_version=0.6.1
 # Miniflux
 # renovate: datasource=docker depName=ghcr.io/miniflux/miniflux versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-distroless$
 miniflux_version=2.3.3-distroless
+
+# FreshRSS — must stay on the default Debian variant (no -alpine suffix); OIDC via
+# mod_auth_openidc is only available in that image.
+# renovate: datasource=docker depName=ghcr.io/freshrss/freshrss versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
+freshrss_version=1.29.1
+
+# FreshRSS AI Summary extension (Ollama support)
+# renovate: datasource=github-tags depName=deimosfr/xExtension-AiSummary packageName=deimosfr/xExtension-AiSummary extractVersion=^v(?<version>.*)$
+freshrss_ai_summary_extension_version=1.1.0
+
+# Fusion
+# renovate: datasource=docker depName=ghcr.io/0x2e/fusion
+fusion_version=1.2.1


### PR DESCRIPTION
Deploys FreshRSS (Authelia OIDC via mod_auth_openidc, CNPG Postgres, Ollama article summaries through a pinned xExtension-AiSummary initContainer) and Fusion (OIDC only — it ships no AI by design) as replacements for Miniflux and Ember. Both register as native Authelia OIDC clients rather than using Istio ext_authz, since Istio permits only one CUSTOM authz provider per workload and the internal gateway already uses oauth2-proxy.

https://claude.ai/code/session_01NwjRmYRxYeeyX4kuz4uzwW