### PR TITLE
fix(tuppr,longhorn): let Talos own the drain and give rebuilds snapshot headroom

### DIFF
--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -29,10 +29,7 @@ defaultSettings:
   storageOverProvisioningPercentage: 500
   storageMinimalAvailablePercentage: 10
   autoCleanupSystemGeneratedSnapshot: true
-  # Peak snapshot count during a rebuild is the pinned base plus the system
-  # snapshots Longhorn creates before and after, which is exactly 3. At a limit
-  # of 3 there is no headroom and snapshot creation fails mid-rebuild.
-  snapshotMaxCount: 5
+  snapshotMaxCount: 250
   longGRPCTimeOut: 345600
   # Ensure snapshot checksums are computed immediately after every snapshot so
   # fast-rebuild (changed-blocks-only sync) is available at replica rebuild time.

--- a/kubernetes/platform/config/tuppr/talos-upgrade.yaml
+++ b/kubernetes/platform/config/tuppr/talos-upgrade.yaml
@@ -14,7 +14,6 @@ spec:
   policy:
     rebootMode: default
     timeout: 60m
-    waitForVolumeDetach: true
   healthChecks:
     - apiVersion: v1
       kind: Node


### PR DESCRIPTION
Two changes that together make Talos upgrades survivable on nodes with pinned workloads.

**Drop `policy.waitForVolumeDetach`.** Reading tuppr's source, this flag does two things and only one is documented: it makes tuppr own the drain (`tupprOwnsDrain` returns true on it alone), and it passes `--drain=false` to talosctl (`jobs.go:604`), disabling Talos's own drain. tuppr's drain doesn't retry — it iterates evictable pods once and the first eviction error aborts everything (`drain.go:120`), with a hardcoded 10m timeout that only bounds the context and does nothing against an immediate 429 from a PDB. The caller then uncordons every node in the batch including the failed one. On node2 that looped forever: jellyfin and ollama are pinned there by `nodeSelector` + `nvidia.com/gpu` and it's the only GPU node, so their four Longhorn volumes stay attached, Longhorn holds the instance-manager PDBs, the drain dies in under a second, rolls back, uncordons, and the evicted GPU pods land right back. What we give up is a 2-minute best-effort wait that logs and proceeds on timeout anyway; `--drain` landed in talosctl 1.13 and the tag defaults to each node's current version, so every node here is covered.

**Raise `snapshotMaxCount` 5 → 250.** A rebuild needs the pinned base plus the system snapshots Longhorn creates either side, and volumes already carry up to 8, so 5 still lets a rebuild fail with `snapshot count usage 3 is equal or larger than snapshotMaxCount 3` — exactly what stranded `pvc-98e98eb7`. The limit only blocks creation and never deletes, so raising it can't cause accumulation: `auto-cleanup-system-generated-snapshot` already reaps rebuild snapshots, and there's no recurring snapshot job or VolumeSnapshot in the cluster (165 snapshots / 57 volumes, avg 2.9). Existing volumes were patched to 250 out of band; this stops new ones being born with the old ceiling.

They're needed together: a rebuild that fails on the cap never recovers, and tuppr's Longhorn health check then blocks the upgrade indefinitely with `failedNodes` empty and no timeout that fires.

`task k8s:validate-all` passes.

**Merging this mid-run resets tuppr's progress** — it logs "Spec changed, resetting upgrade process" on any spec change. Worth landing while node2 is stuck anyway rather than partway through a later node. Also note `spec.maintenance` is still commented out from triggering this run and should be restored once the fleet is on v1.13.9.

https://claude.ai/code/session_01R7F4pzEqZ6eZt1ERDFDZNV
