### PR TITLE
fix(longhorn): allow drain when the last replica is stopped

### DIFF
--- a/kubernetes/platform/charts/longhorn.yaml
+++ b/kubernetes/platform/charts/longhorn.yaml
@@ -21,6 +21,7 @@ defaultSettings:
   createDefaultDiskLabeledNodes: true
   storageReservedPercentageForDefaultDisk: 10
   nodeDownPodDeletionPolicy: delete-both-statefulset-and-deployment-pod
+  nodeDrainPolicy: allow-if-replica-is-stopped
   # Wait for a rebooted node to rejoin before replenishing its replicas. Talos
   # upgrades take a node offline longer than the 600s default, causing Longhorn
   # to full-rebuild multi-Ti replicas every upgrade. 1800s covers a single-node


### PR DESCRIPTION
Longhorn defaults `nodeDrainPolicy` to `block-if-contains-last-replica`, which holds the instance-manager PDB on any node carrying the only replica of a volume — making that node undrainable regardless of whether the volume is in use.

This blocked the v1.13.9 Talos upgrade on node2. After every consuming pod was evicted and all four GPU-pinned volumes had detached, Longhorn still refused to release two instance-managers:

```
removing node2 PDB is blocked: replica
  pvc-d7bd0018-2532-4402-a78f-0e8ccbc21131-r-e9f20833 has no pdb on another node
```

That's `media/jellyfin-transcodes` at `numberOfReplicas: 1`, so its only replica is on node2. talosctl retried the eviction for eight minutes against a condition that could never clear on its own.

`allow-if-replica-is-stopped` permits the drain when the last healthy replica is *stopped*, which it is once the volume detaches. The documented risk is data loss if the node is **removed** after draining — a reboot returns the same disk, so it doesn't apply. The alternative (giving every scratch volume a second replica) spends real capacity replicating data that's regenerated on demand.

node41 and node44 also host single-replica volumes (`media/sabnzbd-downloads`, `media/qbittorrent-downloads`), so the same block would have stopped their upgrades in turn.

Key name verified against the upstream chart values for v1.12.1. `yamllint --strict kubernetes/` passes. The live setting was patched out of band to unblock node2 — which worked, the node moved to `Rebooting` immediately after — and this makes it declarative.

https://claude.ai/code/session_01R7F4pzEqZ6eZt1ERDFDZNV
