### PR TITLE
feat(tuppr): restore the Saturday maintenance window

### DIFF
--- a/kubernetes/platform/config/tuppr/talos-upgrade.yaml
+++ b/kubernetes/platform/config/tuppr/talos-upgrade.yaml
@@ -6,11 +6,11 @@ metadata:
 spec:
   talos:
     version: ${talos_version}
-  # maintenance:
-  #   windows:
-  #     - start: "0 2 * * 6"  # Every Saturday at 2:00 AM
-  #       duration: 4h
-  #       timezone: EST
+  maintenance:
+    windows:
+      - start: "0 2 * * 6"
+        duration: 4h
+        timezone: EST
   policy:
     rebootMode: default
     timeout: 60m


### PR DESCRIPTION
The window was commented out to trigger the v1.13.9 upgrade ahead of schedule, since tuppr has no mechanism to force a run outside one. That upgrade is done — all five nodes report v1.13.9 on kernel 6.18.44, `failedNodes` empty, phase `Completed`.

Left as-is, the next `talos_version` bump would drain and reboot the entire fleet the moment it merged. This restores Saturdays 02:00 EST for four hours, unchanged from the original schedule.

The inline comment decoding the cron is dropped per the repo convention of keeping rationale in commit messages rather than manifests — say the word if you'd rather keep it.

`policy.waitForVolumeDetach` is deliberately **not** restored; #1647 removed it so talosctl owns the drain, which is what unblocked node2.

`task k8s:validate-all` passes. Safe to merge now — the live CR reports `Progressing=False reason=Completed`, so tuppr's validating webhook will accept the spec update (it rejects changes while an upgrade is in flight, which is what blocked this file mid-run).

https://claude.ai/code/session_01R7F4pzEqZ6eZt1ERDFDZNV
