### PR TITLE
fix(authelia): mount freshrss and fusion oidc client secrets

### DIFF
--- a/kubernetes/clusters/live/charts/authelia.yaml
+++ b/kubernetes/clusters/live/charts/authelia.yaml
@@ -526,4 +526,6 @@ secret:
     home-assistant-oidc-client-secret: { }
     mealie-oidc-client-secret: { }
     miniflux-oidc-client-secret: { }
+    freshrss-oidc-client-secret: { }
+    fusion-oidc-client-secret: { }
     authelia-smtp-credentials: { }


### PR DESCRIPTION
The OIDC clients added in #1646 reference their secrets by file path but were never registered in secret.additionalSecrets, which is what mounts them under /secrets/<name>/. Authelia's config template aborted on the missing file and crashlooped every new pod, so the clients never loaded and Fusion login returned invalid_client. Adds the two missing entries.

https://claude.ai/code/session_01NwjRmYRxYeeyX4kuz4uzwW