### PR TITLE
fix(longhorn): stop LonghornSnapshotUnhashed firing forever

### DIFF
--- a/kubernetes/clusters/live/charts/jellyfin.yaml
+++ b/kubernetes/clusters/live/charts/jellyfin.yaml
@@ -116,6 +116,8 @@ persistence:
     accessMode: ReadWriteOnce
     size: 200Gi
     storageClass: fast-ephemeral
+    labels:
+      velero.io/exclude-from-backup: "true"
     advancedMounts:
       jellyfin:
         app:

--- a/kubernetes/platform/config/monitoring/longhorn-snapshot-hash-alerts.yaml
+++ b/kubernetes/platform/config/monitoring/longhorn-snapshot-hash-alerts.yaml
@@ -26,6 +26,11 @@ spec:
         #   - LHS: user_created snapshots that exist (have actual_size_bytes)
         #   - RHS: user_created snapshots that have a populated checksum (checksum!="")
         #   - unless: set subtraction — alerts for any snapshot in LHS that has NO matching entry in RHS
+        #   - final unless: drops single-replica volumes, which can never satisfy this alert.
+        #     On-demand hashing (Volume.Spec.SnapshotHashingRequestedAt) requires at least two
+        #     replicas, so a snapshot on a one-replica volume stays un-hashed permanently and the
+        #     alert re-fires forever. Observed on jellyfin-transcodes, which Velero snapshots
+        #     weekly. Such volumes are also excluded from the tuppr Talos upgrade health check.
         - alert: LonghornSnapshotUnhashed
           expr: |
             count by (volume, snapshot) (
@@ -39,6 +44,9 @@ spec:
                 user_created="true",
                 checksum!=""
               }
+            )
+            unless on (volume) (
+              count by (volume) (longhorn_replica_info) < 2
             )
           for: 6h
           labels:


### PR DESCRIPTION
## Problem

`LonghornSnapshotUnhashed` has no guard for snapshots that **can never be hashed**, so it re-fires indefinitely on volumes that cannot satisfy it.

On-demand hashing (`Volume.Spec.SnapshotHashingRequestedAt`) requires **≥2 replicas**. `jellyfin-transcodes` runs one replica on `fast-ephemeral`, and Velero's weekly schedule (`0 2 * * 0`) snapshots it every Sunday at 02:00. That produces a `user_created` snapshot which is structurally impossible to checksum — the alert fires 6h later and stays lit until the snapshot rotates. Every week, forever.

This surfaced while clearing a 24-snapshot backlog after the media-library incident. Everything else hashed; this one cannot.

## Changes

**1. Exclude `jellyfin-transcodes` from Velero** — `kubernetes/clusters/live/charts/jellyfin.yaml`

It's transcode scratch. Both the backup and its checksum are worthless. Not taking the snapshot removes the cause rather than masking it, and matches the annotation `media-library`, `sabnzbd-downloads` and `qbittorrent-downloads` already carry.

**2. Guard the alert on replica count** — `kubernetes/platform/config/monitoring/longhorn-snapshot-hash-alerts.yaml`

```promql
unless on (volume) (
  count by (volume) (longhorn_replica_info) < 2
)
```

Fix 1 addresses today's instance; fix 2 stops any future single-replica volume reproducing it.

## Verification

Against live:

- Unguarded expression returns the `jellyfin-transcodes` snapshot
- Guarded expression returns **empty**
- `count by (volume) (longhorn_replica_info) == 1` returns exactly the three single-replica volumes
- `helm template` of app-template 4.6.2 confirms `labels` renders onto the PVC — it works but is **not** in the chart's documented persistence values, so worth a reviewer's eye
- `task k8s:validate` passes, no deprecated APIs

## Considered and rejected

A second guard for detached volumes. They can also fail to hash (no running engine — `recyclarr` hit this during the backlog clear), but unlike single-replica volumes they resolve on their own once reattached. An unhashed snapshot on a detached volume is a genuine risk at the next reboot, not a permanent false positive, so it should still alert.

## Related

Follows the media-library XFS corruption incident. Longhorn's Talos upgrade health check gates on attached volumes reaching `healthy` within 30m, which an unhashed base snapshot would blow through during a slow rebuild — next window is 2026-08-29 02:00.

https://claude.ai/code/session_01Q4vyrZRJrfUBbbs4kkZbMi