### PR TITLE
fix(garage): upgrade operator to 0.7.8 for storage-tier reconnect

### DIFF
--- a/kubernetes/platform/charts/garage-operator.yaml
+++ b/kubernetes/platform/charts/garage-operator.yaml
@@ -1,4 +1,15 @@
 ---
+replicaCount: 2
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: garage-operator
+        app.kubernetes.io/instance: garage-operator
+        control-plane: controller-manager
+
 priorityClassName: platform
 resources:
   requests:

--- a/kubernetes/platform/versions.env
+++ b/kubernetes/platform/versions.env
@@ -51,7 +51,7 @@ istio_version=1.30.4
 # renovate: datasource=helm depName=cert-manager-istio-csr registryUrl=https://charts.jetstack.io
 istio_csr_version=v0.17.0
 # renovate: datasource=docker depName=garage-operator packageName=ghcr.io/rajsinghtech/charts/garage-operator
-garage_operator_version=0.6.3
+garage_operator_version=0.7.8
 # renovate: datasource=helm depName=cloudnative-pg registryUrl=https://cloudnative-pg.github.io/charts
 cloudnative_pg_version=0.29.0
 # renovate: datasource=docker depName=dragonfly-operator packageName=ghcr.io/dragonflydb/dragonfly-operator/helm/dragonfly-operator versioning=semver


### PR DESCRIPTION
Garage went down after the v2.4.0 image bump (#1716): the operator restarts all three single-replica storage StatefulSets at once, and with `bootstrap_peers = []` every node came back holding only the pre-restart pod IPs, so quorum was never re-formed. Operator 0.6.4 (rajsinghtech/garage-operator#204) fixes precisely this by issuing `ConnectClusterNodes` from the reconcile loop whenever a peer shows disconnected — we were pinned one patch below it, so the version lock caused the outage it was meant to prevent. Going to 0.7.8 also picks up later hardening of the same path, and adds a second operator replica because 0.7.8 introduces a cluster-wide PVC admission webhook that a single pod would turn into a chokepoint.

Diligence: all 26 live garage CRs validate against the 0.7.8 schemas, no CRD fields or served versions removed, conversion webhook unchanged, and neither v0.7.0 migration applies to us. Draft until it can be exercised on dev.