### PR TITLE
feat(monitoring): add available space by StorageClass to platform home

### DIFF
--- a/kubernetes/platform/config/monitoring/platform-home-dashboard.yaml
+++ b/kubernetes/platform/config/monitoring/platform-home-dashboard.yaml
@@ -623,8 +623,52 @@ data:
           "type": "stat"
         },
         {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "Free space remaining inside provisioned volumes, grouped by StorageClass.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "red", "value": null },
+                  { "color": "orange", "value": 53687091200 },
+                  { "color": "yellow", "value": 107374182400 },
+                  { "color": "green", "value": 214748364800 }
+                ]
+              },
+              "unit": "bytes",
+              "min": 0
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 6, "w": 24, "x": 0, "y": 20 },
+          "id": 63,
+          "options": {
+            "displayMode": "gradient",
+            "minVizHeight": 16,
+            "minVizWidth": 8,
+            "namePlacement": "left",
+            "orientation": "horizontal",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "sum by (storageclass) (kubelet_volume_stats_available_bytes * on(namespace, persistentvolumeclaim) group_left(storageclass) kube_persistentvolumeclaim_info)",
+              "legendFormat": "{{storageclass}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Available Space by StorageClass",
+          "type": "bargauge"
+        },
+        {
           "collapsed": false,
-          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 20 },
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 26 },
           "id": 50,
           "title": "Database & Cache",
           "type": "row"
@@ -648,7 +692,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 4, "w": 8, "x": 0, "y": 21 },
+          "gridPos": { "h": 4, "w": 8, "x": 0, "y": 27 },
           "id": 51,
           "options": {
             "colorMode": "background",
@@ -690,7 +734,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 4, "w": 8, "x": 8, "y": 21 },
+          "gridPos": { "h": 4, "w": 8, "x": 8, "y": 27 },
           "id": 52,
           "options": {
             "minVizHeight": 75,
@@ -733,7 +777,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 4, "w": 8, "x": 16, "y": 21 },
+          "gridPos": { "h": 4, "w": 8, "x": 16, "y": 27 },
           "id": 53,
           "options": {
             "minVizHeight": 75,
@@ -757,7 +801,7 @@ data:
         },
         {
           "collapsed": false,
-          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 25 },
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 31 },
           "id": 60,
           "title": "Backup & Alerts",
           "type": "row"
@@ -780,7 +824,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 6, "w": 8, "x": 0, "y": 26 },
+          "gridPos": { "h": 6, "w": 8, "x": 0, "y": 32 },
           "id": 61,
           "options": {
             "colorMode": "background",
@@ -849,7 +893,7 @@ data:
               }
             ]
           },
-          "gridPos": { "h": 6, "w": 16, "x": 8, "y": 26 },
+          "gridPos": { "h": 6, "w": 16, "x": 8, "y": 32 },
           "id": 62,
           "options": {
             "showHeader": true,


### PR DESCRIPTION
There was no view of free space by StorageClass — "Longhorn Pool Usage" is a single global ratio and "Top PVC Fill %" only shows the worst volume. Adds a bargauge to the Storage & Data row on Platform Home that joins `kubelet_volume_stats_available_bytes` against `kube_persistentvolumeclaim_info` to group free bytes by storageclass, shifting the panels below down six rows.

Query verified against live Prometheus: fast 624 GiB, fast-ephemeral 1083 GiB, slow-media 1578 GiB, slow 488 GiB, longhorn 10 GiB.

https://claude.ai/code/session_011p5Brq4AA7inGrgq4womgr