### PR TITLE
fix(monitoring): show pool utilization percent instead of free bytes

### DIFF
--- a/kubernetes/platform/config/monitoring/platform-home-dashboard.yaml
+++ b/kubernetes/platform/config/monitoring/platform-home-dashboard.yaml
@@ -624,25 +624,26 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "description": "Free space remaining inside provisioned volumes, grouped by StorageClass.",
+          "description": "Longhorn disk pool utilization. fast = SSD-backed disks, slow = HDD-backed disks.",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  { "color": "red", "value": null },
-                  { "color": "orange", "value": 53687091200 },
-                  { "color": "yellow", "value": 107374182400 },
-                  { "color": "green", "value": 214748364800 }
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 70 },
+                  { "color": "orange", "value": 85 },
+                  { "color": "red", "value": 95 }
                 ]
               },
-              "unit": "bytes",
-              "min": 0
+              "unit": "percent",
+              "min": 0,
+              "max": 100
             },
             "overrides": []
           },
-          "gridPos": { "h": 6, "w": 24, "x": 0, "y": 20 },
+          "gridPos": { "h": 4, "w": 24, "x": 0, "y": 20 },
           "id": 63,
           "options": {
             "displayMode": "gradient",
@@ -658,17 +659,17 @@ data:
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
-              "expr": "sum by (storageclass) (kubelet_volume_stats_available_bytes * on(namespace, persistentvolumeclaim) group_left(storageclass) kube_persistentvolumeclaim_info)",
-              "legendFormat": "{{storageclass}}",
+              "expr": "100 * longhorn:pool_usage_ratio:sum",
+              "legendFormat": "{{pool}}",
               "refId": "A"
             }
           ],
-          "title": "Available Space by StorageClass",
+          "title": "Longhorn Pool Utilization",
           "type": "bargauge"
         },
         {
           "collapsed": false,
-          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 26 },
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
           "id": 50,
           "title": "Database & Cache",
           "type": "row"
@@ -692,7 +693,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 4, "w": 8, "x": 0, "y": 27 },
+          "gridPos": { "h": 4, "w": 8, "x": 0, "y": 25 },
           "id": 51,
           "options": {
             "colorMode": "background",
@@ -734,7 +735,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 4, "w": 8, "x": 8, "y": 27 },
+          "gridPos": { "h": 4, "w": 8, "x": 8, "y": 25 },
           "id": 52,
           "options": {
             "minVizHeight": 75,
@@ -777,7 +778,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 4, "w": 8, "x": 16, "y": 27 },
+          "gridPos": { "h": 4, "w": 8, "x": 16, "y": 25 },
           "id": 53,
           "options": {
             "minVizHeight": 75,
@@ -801,7 +802,7 @@ data:
         },
         {
           "collapsed": false,
-          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 31 },
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 29 },
           "id": 60,
           "title": "Backup & Alerts",
           "type": "row"
@@ -824,7 +825,7 @@ data:
             },
             "overrides": []
           },
-          "gridPos": { "h": 6, "w": 8, "x": 0, "y": 32 },
+          "gridPos": { "h": 6, "w": 8, "x": 0, "y": 30 },
           "id": 61,
           "options": {
             "colorMode": "background",
@@ -893,7 +894,7 @@ data:
               }
             ]
           },
-          "gridPos": { "h": 6, "w": 16, "x": 8, "y": 32 },
+          "gridPos": { "h": 6, "w": 16, "x": 8, "y": 30 },
           "id": 62,
           "options": {
             "showHeader": true,


### PR DESCRIPTION
The panel from #1724 showed absolute free bytes per StorageClass, which isn't the question the home dashboard should answer — and absolute headroom colours misleadingly across classes of different size. Repoints it at `longhorn:pool_usage_ratio:sum` to show percent utilization of the fast and slow disk pools, using the same thresholds as the adjacent gauge, and drops the height to four rows now that it renders two bars.

Live values: fast 27%, slow 35%. This is also the first dashboard consumer of the pool recording rules, which previously only fed alerts.

https://claude.ai/code/session_011p5Brq4AA7inGrgq4womgr