### PR TITLE
fix(dragonfly): remove self-inflicted connection refusal, derive limits from node capacity

### DIFF
--- a/kubernetes/platform/config/dragonfly/dragonfly-instance.yaml
+++ b/kubernetes/platform/config/dragonfly/dragonfly-instance.yaml
@@ -29,13 +29,14 @@ spec:
   resources:
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 512Mi
     limits:
       memory: 2Gi
 
   args:
     - "--maxmemory"
-    - "768mb"
+    - "1gb"
+    - "--rss_oom_deny_ratio=1.5"
     - "--cache_mode"
     - "--proactor_threads"
     - "2"

--- a/kubernetes/platform/config/dragonfly/dragonfly-instance.yaml
+++ b/kubernetes/platform/config/dragonfly/dragonfly-instance.yaml
@@ -31,12 +31,12 @@ spec:
       cpu: 100m
       memory: 512Mi
     limits:
-      memory: 2Gi
+      memory: 8Gi
 
   args:
     - "--maxmemory"
-    - "1gb"
-    - "--rss_oom_deny_ratio=1.5"
+    - "768mb"
+    - "--rss_oom_deny_ratio=-1"
     - "--cache_mode"
     - "--proactor_threads"
     - "2"

--- a/kubernetes/platform/config/dragonfly/prometheus-rules.yaml
+++ b/kubernetes/platform/config/dragonfly/prometheus-rules.yaml
@@ -13,33 +13,108 @@ spec:
       rules:
         - alert: DragonflyHighMemoryUsage
           expr: |
-            (dragonfly_used_memory_bytes{namespace="cache"}
-            / dragonfly_maxmemory_bytes{namespace="cache"}) > 0.9
+            (dragonfly_memory_used_bytes{namespace="cache"}
+            / dragonfly_memory_max_bytes{namespace="cache"}) > 0.9
             and
-            (dragonfly_used_memory_bytes{namespace="cache"}
-            / dragonfly_maxmemory_bytes{namespace="cache"}) <= 0.95
+            (dragonfly_memory_used_bytes{namespace="cache"}
+            / dragonfly_memory_max_bytes{namespace="cache"}) <= 0.95
           for: 5m
           labels:
             severity: warning
           annotations:
-            summary: "Dragonfly memory usage > 90% on {{ $labels.pod }}"
+            summary: "Dragonfly dataset memory > 90% of maxmemory on {{ $labels.pod }}"
+            description: >-
+              Logical dataset size on {{ $labels.pod }} is above 90% of the
+              configured maxmemory. cache_mode eviction engages near this
+              threshold, so expect keys to start being evicted.
 
         - alert: DragonflyHighMemoryUsageCritical
           expr: |
-            (dragonfly_used_memory_bytes{namespace="cache"}
-            / dragonfly_maxmemory_bytes{namespace="cache"}) > 0.95
+            (dragonfly_memory_used_bytes{namespace="cache"}
+            / dragonfly_memory_max_bytes{namespace="cache"}) > 0.95
           for: 2m
           labels:
             severity: critical
           annotations:
-            summary: "Dragonfly memory usage > 95% on {{ $labels.pod }}"
+            summary: "Dragonfly dataset memory > 95% of maxmemory on {{ $labels.pod }}"
+            description: >-
+              Logical dataset size on {{ $labels.pod }} is above 95% of the
+              configured maxmemory. Sustained eviction is likely; consider
+              raising --maxmemory in dragonfly-instance.yaml.
+
+        - alert: DragonflyRssNearConnectionRefusal
+          expr: |
+            (dragonfly_used_memory_rss_bytes{namespace="cache"}
+            / (dragonfly_memory_max_bytes{namespace="cache"} * 1.5)) > 0.8
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Dragonfly RSS at {{ $value | humanizePercentage }} of the OOM-deny ceiling on {{ $labels.pod }}"
+            description: >-
+              Process RSS on {{ $labels.pod }} is approaching the
+              rss_oom_deny_ratio ceiling (maxmemory x 1.5, matching
+              --rss_oom_deny_ratio in dragonfly-instance.yaml). At 100%
+              Dragonfly refuses all new client connections on the non-admin
+              port. RSS can exceed the dataset size by orders of magnitude
+              through allocator fragmentation, so compare against
+              dragonfly_memory_used_bytes before raising maxmemory. Restarting
+              the pod clears fragmented RSS.
+
+        - alert: DragonflyRefusingConnections
+          expr: |
+            (dragonfly_used_memory_rss_bytes{namespace="cache"}
+            / (dragonfly_memory_max_bytes{namespace="cache"} * 1.5)) >= 1
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Dragonfly is refusing new connections on {{ $labels.pod }}"
+            description: >-
+              Process RSS on {{ $labels.pod }} has crossed the
+              rss_oom_deny_ratio ceiling (maxmemory x 1.5). Dragonfly has
+              stopped accepting new client connections; existing connections
+              survive but every client that reconnects gets an immediate EOF.
+              This affects all namespaces sharing this instance. This state
+              does not self-heal when the dataset is small, because cache_mode
+              eviction keys off dataset size rather than RSS. Restart the pod
+              to clear fragmented RSS.
 
         - alert: DragonflyReplicationBroken
-          expr: |
-            dragonfly_connected_replicas{namespace="cache"}
-            < (dragonfly_total_replicas{namespace="cache"} - 1)
+          expr: dragonfly_master_link_status{namespace="cache"} == 0
           for: 5m
           labels:
             severity: critical
           annotations:
-            summary: "Dragonfly replication broken for {{ $labels.pod }}"
+            summary: "Dragonfly replica {{ $labels.pod }} lost its master link"
+            description: >-
+              {{ $labels.pod }} reports master_link_status down. Writes to the
+              master are not reaching this replica, so a failover would lose
+              data.
+
+        - alert: DragonflyReplicationFlapping
+          expr: |
+            increase(dragonfly_replica_reconnect_count{namespace="cache"}[30m]) > 2
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Dragonfly replica {{ $labels.pod }} is reconnecting repeatedly"
+            description: >-
+              {{ $labels.pod }} has reconnected to its master more than twice
+              in 30 minutes. Repeated full resyncs drive allocator
+              fragmentation on the master, which can escalate into the
+              rss_oom_deny_ratio connection refusal.
+
+        - alert: DragonflyMetricsMissing
+          expr: absent(dragonfly_memory_max_bytes{namespace="cache"})
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Dragonfly metrics are not being scraped"
+            description: >-
+              dragonfly_memory_max_bytes has no series in the cache namespace.
+              Either the PodMonitor has stopped scraping or a Dragonfly upgrade
+              renamed the metric, which would silently disable every alert in
+              this group.

--- a/kubernetes/platform/config/dragonfly/prometheus-rules.yaml
+++ b/kubernetes/platform/config/dragonfly/prometheus-rules.yaml
@@ -42,43 +42,61 @@ spec:
               configured maxmemory. Sustained eviction is likely; consider
               raising --maxmemory in dragonfly-instance.yaml.
 
-        - alert: DragonflyRssNearConnectionRefusal
+        - alert: DragonflyMemoryNearContainerLimit
           expr: |
-            (dragonfly_used_memory_rss_bytes{namespace="cache"}
-            / (dragonfly_memory_max_bytes{namespace="cache"} * 1.5)) > 0.8
+            (container_memory_working_set_bytes{namespace="cache",container="dragonfly"}
+            / on(pod) kube_pod_container_resource_limits{namespace="cache",container="dragonfly",resource="memory"}) > 0.8
           for: 10m
           labels:
             severity: warning
           annotations:
-            summary: "Dragonfly RSS at {{ $value | humanizePercentage }} of the OOM-deny ceiling on {{ $labels.pod }}"
+            summary: "Dragonfly container memory at {{ $value | humanizePercentage }} of its limit on {{ $labels.pod }}"
             description: >-
-              Process RSS on {{ $labels.pod }} is approaching the
-              rss_oom_deny_ratio ceiling (maxmemory x 1.5, matching
-              --rss_oom_deny_ratio in dragonfly-instance.yaml). At 100%
-              Dragonfly refuses all new client connections on the non-admin
-              port. RSS can exceed the dataset size by orders of magnitude
-              through allocator fragmentation, so compare against
-              dragonfly_memory_used_bytes before raising maxmemory. Restarting
-              the pod clears fragmented RSS.
+              {{ $labels.pod }} is approaching its container memory limit and
+              will be OOMKilled if it continues. The limit is a runaway
+              containment threshold derived from node capacity, not from
+              working set, and sits several times above any legitimate
+              ceiling. Reaching it means the process is malfunctioning.
+              Compare
+              container_memory_working_set_bytes against
+              dragonfly_memory_used_bytes: if they diverge by orders of
+              magnitude the cause is allocator fragmentation rather than real
+              data, and a restart clears it.
 
-        - alert: DragonflyRefusingConnections
+        - alert: DragonflyOOMKilled
           expr: |
-            (dragonfly_used_memory_rss_bytes{namespace="cache"}
-            / (dragonfly_memory_max_bytes{namespace="cache"} * 1.5)) >= 1
-          for: 2m
+            kube_pod_container_status_last_terminated_reason{namespace="cache",container="dragonfly",reason="OOMKilled"} == 1
+          for: 1m
           labels:
             severity: critical
           annotations:
-            summary: "Dragonfly is refusing new connections on {{ $labels.pod }}"
+            summary: "Dragonfly container was OOMKilled on {{ $labels.pod }}"
             description: >-
-              Process RSS on {{ $labels.pod }} has crossed the
-              rss_oom_deny_ratio ceiling (maxmemory x 1.5). Dragonfly has
-              stopped accepting new client connections; existing connections
-              survive but every client that reconnects gets an immediate EOF.
-              This affects all namespaces sharing this instance. This state
-              does not self-heal when the dataset is small, because cache_mode
-              eviction keys off dataset size rather than RSS. Restart the pod
-              to clear fragmented RSS.
+              {{ $labels.pod }} exceeded its container memory limit and was
+              killed, dropping every client connection on that pod. The limit
+              is a runaway containment threshold that legitimate operation
+              cannot reach, so treat this as an incident rather than as
+              routine recovery. Detection of the known fragmentation
+              pathology is handled by DragonflyMemoryFragmentation well
+              before this point.
+
+        - alert: DragonflyMemoryFragmentation
+          expr: |
+            (dragonfly_used_memory_rss_bytes{namespace="cache"}
+            / dragonfly_memory_used_bytes{namespace="cache"}) > 20
+            and
+            dragonfly_used_memory_rss_bytes{namespace="cache"} > 536870912
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Dragonfly RSS is {{ $value | humanize }}x its dataset size on {{ $labels.pod }}"
+            description: >-
+              Process RSS on {{ $labels.pod }} has grown far beyond the logical
+              dataset, which means allocator fragmentation rather than real
+              data. cache_mode eviction keys off dataset size and will not
+              reclaim this. Restarting the pod clears it. Repeated full resyncs
+              from replication flapping are a known driver.
 
         - alert: DragonflyReplicationBroken
           expr: dragonfly_master_link_status{namespace="cache"} == 0
@@ -103,8 +121,7 @@ spec:
             description: >-
               {{ $labels.pod }} has reconnected to its master more than twice
               in 30 minutes. Repeated full resyncs drive allocator
-              fragmentation on the master, which can escalate into the
-              rss_oom_deny_ratio connection refusal.
+              fragmentation on the master.
 
         - alert: DragonflyMetricsMissing
           expr: absent(dragonfly_memory_max_bytes{namespace="cache"})


### PR DESCRIPTION
Dragonfly's `rss_oom_deny_ratio` guard refused all client connections for 33 hours after allocator fragmentation pushed RSS past `maxmemory x 1.25`, with a ~9MiB dataset and the container at 53% of its limit — taking down `sure` and every other namespace on the shared cache. It failed closed and silent (process Running, probes passing, no restarts), and every alert in `dragonfly-alerts` referenced metric names this version doesn't expose, so nothing fired.

Disables the guard, since under Kubernetes it only converts a recoverable condition into a permanent wedge. Detection moves to a new `DragonflyMemoryFragmentation` alert on the RSS-to-dataset ratio (backtested: fires for 33.2h at peak 165x). With detection decoupled, the container limit is derived from node capacity as a pure runaway threshold (8Gi, ~25% of the 31GiB nodes) rather than from observed working set — limits don't reserve capacity, so a tight one only buys an outage.

**Note:** merging rolls the Dragonfly StatefulSet, briefly blipping the shared cache for `sure`, `ai`, `immich`, `authelia`, `paperless`.

https://claude.ai/code/session_01S8biLsqitoGumfRnJ8uFyP