### PR TITLE
fix(valheim): migrate to community fork, pin 1.2.0

### DIFF
--- a/kubernetes/clusters/live/charts/valheim.yaml
+++ b/kubernetes/clusters/live/charts/valheim.yaml
@@ -18,8 +18,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/community-valheim-tools/valheim-server
-          # renovate: datasource=docker depName=ghcr.io/community-valheim-tools/valheim-server
-          tag: 1.2.0
+          tag: "${valheim_version}"
         env:
           # Server configuration
           SERVER_NAME: "Valheim Dedicated"

--- a/kubernetes/clusters/live/charts/valheim.yaml
+++ b/kubernetes/clusters/live/charts/valheim.yaml
@@ -17,9 +17,9 @@ controllers:
     containers:
       app:
         image:
-          repository: ghcr.io/lloesche/valheim-server
-          # renovate: datasource=docker depName=ghcr.io/lloesche/valheim-server
-          tag: latest
+          repository: ghcr.io/community-valheim-tools/valheim-server
+          # renovate: datasource=docker depName=ghcr.io/community-valheim-tools/valheim-server
+          tag: 1.2.0
         env:
           # Server configuration
           SERVER_NAME: "Valheim Dedicated"

--- a/kubernetes/clusters/live/versions.env
+++ b/kubernetes/clusters/live/versions.env
@@ -22,6 +22,8 @@ vectorchord_version=18.6
 lldap_version=v0.6.3
 # renovate: datasource=docker depName=satisfactory-server packageName=wolveix/satisfactory-server
 satisfactory_server_version=v1.9.10
+# renovate: datasource=docker depName=valheim-server packageName=ghcr.io/community-valheim-tools/valheim-server
+valheim_version=1.2.0
 # renovate: datasource=docker depName=ghcr.io/siderolabs/booter
 booter_version=v0.4.0
 # renovate: datasource=docker depName=qbittorrent packageName=ghcr.io/home-operations/qbittorrent


### PR DESCRIPTION
Valheim 1.0 moved world saves to a directory per world, and the old image chmod'd that directory to 0644 on every boot, stripping the search bit so the server could never write `_main.0.fwl2` — it aborted before binding UDP 2456/2457, leaving the LoadBalancer dead. `lloesche/valheim-server` is superseded by `community-valheim-tools`, whose #793 fixes the glob and ships in 1.2.0.

Pins `valheim_version` in the cluster `versions.env` and references it via Flux substitution, so a game release can't roll onto live unreviewed the way `latest` allowed.

https://claude.ai/code/session_01KcuVyAZ49zbf48Fe5n8VZG